### PR TITLE
Use imageTag to override deployment images 

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           secret:
             secretName: thoras-api-server-cert
       containers:
-      - image: {{ .Values.imageCredentials.registry }}/thoras-external-metrics-server:{{ default .Values.thorasVersion .Values.thorasApiServer.image }}
+      - image: {{ .Values.imageCredentials.registry }}/thoras-external-metrics-server:{{ default .Values.thorasVersion .Values.thorasApiServer.imageTag }}
         imagePullPolicy: Always
         name: thoras-api-server
         env:

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: thoras-collector
           restartPolicy: OnFailure
           containers:
-          - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.image }}
+          - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
             imagePullPolicy: Always
             name: metrics-collector
             env:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             name: elastic-search-data
       {{- end }}
       containers:
-      - image: {{ .Values.metricsCollector.search.image }}
+      - image: {{ .Values.metricsCollector.search.imageTag }}
         imagePullPolicy: Always
         name: {{ .Values.metricsCollector.search.name }}
         ports:
@@ -64,7 +64,7 @@ spec:
           runAsUser: 1000
           runAsGroup: 0
         {{- end }}
-      - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.image }}
+      - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
         imagePullPolicy: Always
         name: {{ .Values.metricsCollector.collector.name }}
         command: ["/bin/sh", "-c"]

--- a/charts/thoras/templates/collector/purge-forecast-hook.yaml
+++ b/charts/thoras/templates/collector/purge-forecast-hook.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: thoras-operator
       restartPolicy: OnFailure
       containers:
-      - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.image }}
+      - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
         imagePullPolicy: Always
         name: metrics-collector
         args:

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -46,6 +46,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: "MODEL_IMAGE"
+            value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
         resources:
           limits:
             cpu: {{ .Values.thorasDashboard.limits.cpu }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       serviceAccountName: {{ .Values.thorasDashboard.serviceAccount.name }}
       containers:
-      - image: {{ .Values.imageCredentials.registry }}/thoras-dashboard:{{ default .Values.thorasVersion .Values.thorasDashboard.image }}
+      - image: {{ .Values.imageCredentials.registry }}/thoras-dashboard:{{ default .Values.thorasVersion .Values.thorasDashboard.imageTag }}
         imagePullPolicy: Always
         name: thoras-dashboard
         ports:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       serviceAccountName: thoras-operator
       containers:
-      - image: {{ .Values.imageCredentials.registry }}/thoras-operator:{{ default .Values.thorasVersion .Values.thorasOperator.image }}
+      - image: {{ .Values.imageCredentials.registry }}/thoras-operator:{{ default .Values.thorasVersion .Values.thorasOperator.imageTag }}
         imagePullPolicy: Always
         name: thoras-operator
         env:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -36,6 +36,8 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
+          - name: "MODEL_IMAGE"
+            value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
         args:
           - start
         resources:


### PR DESCRIPTION
# Why

* Currently there's no way for users to specify what specific forecast version should be run. We need to give them that control
* `image` is less accurate of a value name than `imageTag` so we'll want to level up our naming accuracy

# What's changing?

* Provide new environment variable called `MODEL_IMAGE` that enables the user to specify the desired forecast image tag
* Rename instances of `image` to the more accurately named `imageTag`