### PR TITLE
Added chart version env var to operator

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -36,6 +36,8 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
+          - name: THORAS_VERSION
+            value: {{ .Chart.Version | replace "+" "_" }}
         args:
           - start
         resources:


### PR DESCRIPTION
# Why?

It'd be useful for the application to know the helm  version so we can make decisions based off of that, if needed (such as for backwards compatibility)

# What's changing?

Assign the helm chart version as the value to a new env var in the operator component called `THORAS_VERSION`