### PR TITLE
Fix metrics backend image name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+# Why are we making this change?
+
+
+# What's changing?
+

--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             name: elastic-search-data
       {{- end }}
       containers:
-      - image: {{ .Values.metricsCollector.search.imageTag }}
+      - image: {{ .Values.metricsCollector.search.image }}
         imagePullPolicy: Always
         name: {{ .Values.metricsCollector.search.name }}
         ports:


### PR DESCRIPTION
# Why ?

We unintentionally changed the convention for how we reference our backend metrics collection pod. Its convention is to use `.image` which is a full <image>/<tag> combo, unlike Thoras components which usage `.imageTag` to specify only the tag.

# What's changing?

* Use the correct value for specifying backend metrics container image
* Also add a PR template while we're here
* Bump to 2.1.3