### PR TITLE
Bump default app version to latest stable

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.3
+version: 2.1.4

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "1.0.0"
+thorasVersion: "1.1.0"
 
 thorasOperator:
   limits:


### PR DESCRIPTION
# Why are we making this change?

Generally speaking the latest helm chart version should default to using the latest app version. This change is ensuring that's true


# What's changing?

Set the default Thoras version to be the latest stable version of Thoras