### PR TITLE
Default thoras version to latest stable (1.1.1)

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.4
+version: 2.2.0

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "1.1.0"
+thorasVersion: "1.1.1"
 
 thorasOperator:
   limits:


### PR DESCRIPTION
# Why are we making this change?

We've published a new version of the Thoras platform (`1.1.1`). We want to make sure we publish a new helm chart that defaults to using it

# What's changing?

Default to the newest stable version of Thoras: `1.1.1`

