### PR TITLE
Allow int or str for forecast_blocks

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -241,7 +241,10 @@ spec:
                       pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
                       default: '*/15 * * * *'
                     forecast_blocks:
-                      type: string
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
             status:
               type: object
               properties:


### PR DESCRIPTION
# Why are we making this change?

We want to be able to iterate on how CRD properties are used , which might involve changing a type. But we want to do that in a backwards compatible way, which this change ensures for `forecast_blocks`

# What's changing?

Allow `forecast_blocks` to be a string or an int

