### PR TITLE
Default thoras version to latest stable release

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "1.1.1"
+thorasVersion: "1.1.2"
 
 thorasOperator:
   limits:


### PR DESCRIPTION
# Why are we making this change?

We want the latest helm chart to default using the latest Thoras release (`1.1.2`)

# What's changing?

Set `thorasVersion` to `1.1.2`
