### PR TITLE
Default to thoras 1.1.3

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.3.0

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "1.1.2"
+thorasVersion: "1.1.3"
 
 thorasOperator:
   limits:


### PR DESCRIPTION
# Why are we making this change?

Using the latest version of the Thoras chart should default to installing the latest version of Thoras (`1.1.3`)


# What's changing?

Default to Thoras version `1.1.3`