### PR TITLE
HA improvements

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: thoras-api-server

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: metrics-collector

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "1.1.3"
+thorasVersion: "1.1.4"
 
 thorasOperator:
   limits:


### PR DESCRIPTION
# Why are we making this change?

The pursuit of high availability is always happening. We're always looking for ways to optimize resilience and lower the chances of issues


# What's changing?

* Give the api server 3 replicas instead of 1
* On deployment updates, ensure the metrics collector gets terminated before spinning up a new pod

