### PR TITLE
Bump chart and default Thoras version, 1.1.5

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "1.1.4"
+thorasVersion: "1.1.5"
 
 thorasOperator:
   limits:


### PR DESCRIPTION
# Why are we making this change?

We should have the latest chart default to the latest stable release


# What's changing?

Set the default version Thoras to `1.1.5`

