### PR TITLE
Parameterize collector init image

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             name: elastic-search-data
       {{- end }}
       containers:
-      - image: {{ .Values.metricsCollector.search.image }}
+      - image: thoras.docker.ai/elasticsearch:{{ .Values.metricsCollector.search.imageTag }}
         imagePullPolicy: Always
         name: {{ .Values.metricsCollector.search.name }}
         ports:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             claimName:  elastic-search-data
       initContainers:
       - name: fix-dir-ownership
-        image: alpine:latest
+        image: docker.thoras.ai/alpine:{{ .Values.metricsCollector.init.imageTag }}
         command: ["/bin/sh", "-c"]
         args:
           - |

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             claimName:  elastic-search-data
       initContainers:
       - name: fix-dir-ownership
-        image: docker.thoras.ai/alpine:{{ .Values.metricsCollector.init.imageTag }}
+        image: {{ .Values.imageCredentials.registry }}/alpine:{{ .Values.metricsCollector.init.imageTag }}
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -39,7 +39,7 @@ spec:
             name: elastic-search-data
       {{- end }}
       containers:
-      - image: docker.thoras.ai/elasticsearch:{{ .Values.metricsCollector.search.imageTag }}
+      - image: {{ .Values.imageCredentials.registry }}/elasticsearch:{{ .Values.metricsCollector.search.imageTag }}
         imagePullPolicy: Always
         name: {{ .Values.metricsCollector.search.name }}
         ports:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             name: elastic-search-data
       {{- end }}
       containers:
-      - image: thoras.docker.ai/elasticsearch:{{ .Values.metricsCollector.search.imageTag }}
+      - image: docker.thoras.ai/elasticsearch:{{ .Values.metricsCollector.search.imageTag }}
         imagePullPolicy: Always
         name: {{ .Values.metricsCollector.search.name }}
         ports:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -23,6 +23,8 @@ metricsCollector:
   purge:
     ttl: 30d
     schedule: "00 00 * * *"
+  init:
+    imageTag: "latest"
 
 thorasApiServer:
   containerPort: 8443

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -17,7 +17,7 @@ metricsCollector:
   collector:
     name: thoras-collector
   search:
-    image: elasticsearch:8.12.1
+    imageTag: "8.12.1"
     name: elasticsearch
     containerPort: 9200
   purge:


### PR DESCRIPTION
# Why are we making this change?

It's important to give users the ability to change their collector init image tag


# What's changing?

* Parameterize collector init image tag
* Use Thoras image registry