### PR TITLE
Release Chart 2.6.0!

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.6.0

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             claimName:  elastic-search-data
       initContainers:
       - name: fix-dir-ownership
-        image: alpine:latest
+        image: {{ .Values.imageCredentials.registry }}/alpine:{{ .Values.metricsCollector.init.imageTag }}
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -39,7 +39,7 @@ spec:
             name: elastic-search-data
       {{- end }}
       containers:
-      - image: {{ .Values.metricsCollector.search.image }}
+      - image: {{ .Values.imageCredentials.registry }}/elasticsearch:{{ .Values.metricsCollector.search.imageTag }}
         imagePullPolicy: Always
         name: {{ .Values.metricsCollector.search.name }}
         ports:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -17,12 +17,14 @@ metricsCollector:
   collector:
     name: thoras-collector
   search:
-    image: elasticsearch:8.12.1
+    imageTag: "8.12.1"
     name: elasticsearch
     containerPort: 9200
   purge:
     ttl: 30d
     schedule: "00 00 * * *"
+  init:
+    imageTag: "latest"
 
 thorasApiServer:
   containerPort: 8443


### PR DESCRIPTION
# Why are we making this change?

Releasing chart `2.6.0`

