### PR TITLE
Update scale.thoras.ai rule

### DIFF
--- a/charts/thoras/templates/api-server/webhooks.yaml
+++ b/charts/thoras/templates/api-server/webhooks.yaml
@@ -28,7 +28,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: "pods.thoras.ai"
+  name: "thoras.ai"
 webhooks:
 - name: "pods.thoras.ai"
   rules:
@@ -49,10 +49,10 @@ webhooks:
     - v1
 - name: "scale.thoras.ai"
   rules:
-  - apiGroups:   ["thoras.ai"]
-    apiVersions: ["v1"]
+  - apiGroups:   ["*"]
+    apiVersions: ["*"]
     operations:  ["UPDATE"]
-    resources:   ["aiscaletargets/scale"]
+    resources:   ["*/scale"]
     scope:       "Namespaced"
   clientConfig:
     service:

--- a/charts/thoras/templates/api-server/webhooks.yaml
+++ b/charts/thoras/templates/api-server/webhooks.yaml
@@ -28,7 +28,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: "thoras.ai"
+  name: "pods.thoras.ai"
 webhooks:
 - name: "pods.thoras.ai"
   rules:

--- a/charts/thoras/templates/api-server/webhooks.yaml
+++ b/charts/thoras/templates/api-server/webhooks.yaml
@@ -52,7 +52,7 @@ webhooks:
   - apiGroups:   ["*"]
     apiVersions: ["*"]
     operations:  ["UPDATE"]
-    resources:   ["*/scale"]
+    resources:   ["deployments/scale"]
     scope:       "Namespaced"
   clientConfig:
     service:


### PR DESCRIPTION
# Why are we making this change?

App changes require updating the MutatingWebhookConfiguration for `scale.thoras.ai`

# What's changing?

scale.thoras.ai MutatingWebhookConfiguration rule from `aiscaletargets/scale` to `*/scale`

