### PR TITLE
add thoras-monitor deployment

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -21,9 +21,9 @@ helm repo update
 ```
 # values.yaml
 imageCredentials:
-  registry: docker.thoras.ai
-  username: thoras
-  password: <your license key>
+  registry: "us-east4-docker.pkg.dev/thoras-registry/platform"
+  username: "_json_key_base64"
+  password: "<thoras license key>"
 
 metricsCollector:
   persistence:
@@ -38,13 +38,14 @@ Now let’s install Thoras with Helm! We recommend installing Thoras into the th
 helm install
   my-thoras-release \
   thoras/thoras \
-  -n thoras --create-namespace \
+  -n thoras \
+  --create-namespace \
   -f ./values.yaml
 ```
 
 # Values
 
-#### Global
+## Global
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | thorasVersion | String | 1.1.5 | Thoras app version |
@@ -52,12 +53,12 @@ helm install
 | imageCredentials.username | String | _json_key_base64 | Container registry username |
 | imageCredentials.password | String | "" | Container registry auth string |
 
-### Thoras Forecast
+## Thoras Forecast
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | thorasForecast.imageTag | String | .thorasVersion | Image tag for Thoras Forecast job |
 
-#### Thoras Operator
+## Thoras Operator
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | thorasOperator.limits.cpu | String | 1000m | Thoras Operator CPU limit |
@@ -65,7 +66,7 @@ helm install
 | thorasOperator.requests.cpu | String | 1000m | Thoras Operator CPU request |
 | thorasOperator.requests.memory | String | 1000Mi | Thoras Operator memory request |
 
-#### Thoras Metrics Collector
+## Thoras Metrics Collector
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | metricsCollector.persistence.enabled | Bool | false | Enables persistence for Thoras metrics collector |
@@ -79,7 +80,7 @@ helm install
 | metricsCollector.purge.schedule | String | 00 00 * * * | Cron expression for metrics purge job |
 | metricsCollector.init.imageTag | String | latest | Image tag for metrics collector init container |
 
-#### Thoras API Server
+## Thoras API Server
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | thorasApiServer.containerPort | Number | 8443 | Thoras API port |
@@ -89,7 +90,7 @@ helm install
 | thorasApiServer.requests.cpu | String | 1000Mi | Thoras API CPU request |
 | thorasApiServer.requests.memory | String | 1000Mi | Thoras API memory request |
 
-#### Thoras Dashboard
+## Thoras Dashboard
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | thorasDashboard.enabled | Bool | true | Enables the Thoras Dashboard |
@@ -103,3 +104,16 @@ helm install
 | thorasDashboard.limits.memory | String | 1000Mi | Thoras Dashboard memory limit |
 | thorasDashboard.requests.cpu | String | 1000Mi | Thoras Dashboard CPU request |
 | thorasDashboard.requests.memory | String | 1000Mi | Thoras Dashboard memory request |
+
+## Thoras Monitor
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| thorasMonitor.enabled | Bool | false | Enable Thoras monitoring |
+| thorasMonitor.monitorCadenceSeconds | String | 15 | Health check frequency in seconds |
+| thorasMonitor.maxJobLifeSeconds | String | 600 | Maximum job length before notification |
+| thorasMonitor.underProvisionThreshold | String | 0.1 | How underprovisioned forecasts can be before alerting |
+| thorasMonitor.overProvisionThreshold | String | 10 | How overprovisioned forecasts can be before alerting |
+| thorasMonitor.slackWorkspaceID | String | "" | Target slack workspace for alert notifications |
+| thorasMonitor.slackChannelID | String | "" | Target slack channel for alert notifications |
+| thorasMonitor.slackWebhookID | String | "" | Webhook destination for notifications |
+

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.thorasMonitor.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thoras-monitor
+  namespace: thoras
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: thoras-monitor
+  template:
+    metadata:
+      labels:
+        app: thoras-monitor
+    spec:
+      serviceAccountName: thoras-operator
+      containers:
+      - image: {{ .Values.imageCredentials.registry }}/thoras-monitor:{{ default .Values.thorasVersion .Values.thorasMonitor.imageTag }}
+        imagePullPolicy: Always
+        name: thoras-monitor
+        env:
+          - name: "ES_HOST"
+            valueFrom:
+              secretKeyRef:
+                name: thoras-elastic-password
+                key: host
+          - name: "WEBHOOK_ID"
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookID
+          - name: MONITOR_CADENCE
+            value:  "{{ .Values.thorasMonitor.monitorCadenceSeconds }}"
+          - name: MAX_JOB_LIFE
+            value: "{{ .Values.thorasMonitor.maxJobLifeSeconds }}"
+          - name: UNDERPROVISION_THRESHOLD
+            value: "{{ .Values.thorasMonitor.underProvisionThreshold }}"
+          - name: OVERPROVISION_THRESHOLD
+            value: "{{ .Values.thorasMonitor.overProvisionThreshold }}"
+          - name: SLACK_WORKSPACE_ID
+            value: {{ .Values.thorasMonitor.slackWorkspaceID }}
+          - name: SLACK_CHANNEL_ID
+            value: {{ .Values.thorasMonitor.slackChannelID }}
+{{- end }}

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -4,7 +4,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: thoras-monitor
-  namespace: thoras
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: 1
   selector:
@@ -14,6 +19,10 @@ spec:
     metadata:
       labels:
         app: thoras-monitor
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: thoras-operator
       containers:

--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.thorasMonitor.enabled }}
+---
+apiVersion: v1
+data:
+  webhookID: {{ .Values.thorasMonitor.slackWebhookID | b64enc }}
+kind: Secret
+metadata:
+  name: thoras-slack
+{{- end }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -60,4 +60,14 @@ thorasDashboard:
     memory: 100Mi
   port: 80
 
+thorasMonitor:
+  enabled: false
+  monitorCadenceSeconds: "15"
+  maxJobLifeSeconds: "600"
+  underProvisionThreshold: "0.1"
+  overProvisionThreshold: "10"
+  slackWorkspaceID: ""
+  slackChannelID: ""
+  slackWebhookID: ""
+
 thorasForecast: {}


### PR DESCRIPTION
# Why are we making this change?

We are adding a new service that monitors and alerts users of various potential issues both in their infrastructure and on the thoras platform (e.g. a deployment going down).

# What's changing?

Added new deployment and corresponding values for `thoras-monitor`.

