### PR TITLE
Fix metrics purge entry point arguments 

### DIFF
--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -26,6 +26,7 @@ spec:
             command: ["/bin/sh", "-c"]
             args:
               - |
+                node index.js \
                 purge \
                 --es=${ES_HOST} \
                 --ttl={{ .Values.metricsCollector.purge.ttl }}

--- a/charts/thoras/templates/collector/purge-forecast-hook.yaml
+++ b/charts/thoras/templates/collector/purge-forecast-hook.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-delete
 spec:
+  ttlSecondsAfterFinished: 0
   template:
     spec:
       serviceAccountName: thoras-operator


### PR DESCRIPTION
# Why are we making this change?

Metrics purge job pod fails on startup. 

# What's changing?

Fixed entry point arguments so that metrics purge job can start. 

