### PR TITLE
New registry and image pull policy

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 3.0.0

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             secretName: thoras-api-server-cert
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-external-metrics-server:{{ default .Values.thorasVersion .Values.thorasApiServer.imageTag }}
-        imagePullPolicy: Always
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-api-server
         env:
           - name: "ES_HOST"

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -15,8 +15,8 @@ spec:
           restartPolicy: OnFailure
           containers:
           - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
-            imagePullPolicy: Always
             name: metrics-collector
+            imagePullPolicy: "{{ .Values.imagePullPolicy }}"
             env:
               - name: "ES_HOST"
                 valueFrom:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -40,8 +40,8 @@ spec:
       {{- end }}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/elasticsearch:{{ .Values.metricsCollector.search.imageTag }}
-        imagePullPolicy: Always
         name: {{ .Values.metricsCollector.search.name }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         ports:
         - containerPort: {{ .Values.metricsCollector.search.containerPort }}
         env:

--- a/charts/thoras/templates/collector/purge-forecast-hook.yaml
+++ b/charts/thoras/templates/collector/purge-forecast-hook.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
-        imagePullPolicy: Always
         name: metrics-collector
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         args:
           - purgeCronjobs

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -30,8 +30,8 @@ spec:
       serviceAccountName: {{ .Values.thorasDashboard.serviceAccount.name }}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-dashboard:{{ default .Values.thorasVersion .Values.thorasDashboard.imageTag }}
-        imagePullPolicy: Always
         name: thoras-dashboard
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         ports:
         - containerPort: {{ .Values.thorasDashboard.containerPort }}
         env:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -28,8 +28,8 @@ spec:
       serviceAccountName: thoras-operator
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-operator:{{ default .Values.thorasVersion .Values.thorasOperator.imageTag }}
-        imagePullPolicy: Always
         name: thoras-operator
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         env:
           - name: "ES_HOST"
             valueFrom:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,6 +1,13 @@
 ---
 thorasVersion: "1.1.5"
 
+imageCredentials:
+  registry: "us-east4-docker.pkg.dev/thoras-registry/platform"
+  username: "_json_key_base64"
+  password: ""
+
+imagePullPolicy: "IfNotPresent"
+
 thorasOperator:
   limits:
     cpu: 1000m


### PR DESCRIPTION
# Why are we making this change?

1. We've migrated to a new container image registry so we need to update the default. We consider this a breaking change, so we're bumping to `3.0.0`

2. Historically we've set `imagePullPolicy` to `Always` since we've had several use-cases for using the `:latest` image tag. We don't have that use-case anymore so let's allow users to cache their images on nodes which is the default Kubernetes behavior


# What's changing?

* Set new defaults for image registry and have them use the new registry name and username
* Make `imagePullPolicy` configurable and default to `IfNotPresent`
