### PR TITLE
Use latest Thoras version, 2.0.0

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.0.1

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "1.1.5"
+thorasVersion: "2.0.0"
 
 imageCredentials:
   registry: "us-east4-docker.pkg.dev/thoras-registry/platform"


### PR DESCRIPTION
# Why are we making this change?

We always want the latest chart to use the latest version of Thoras. Let's make sure we're defaulting to install the latest Thoras platform version, `2.0.0`

# What's changing?

Make `.Values.thorasVersion` default to `2.0.0`