### PR TITLE
Add resource annotations

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -74,6 +74,7 @@ helm install \
 | metricsCollector.persistence.volumeName | String | "" | PV name for PVC. Keep blank if using dynamic provisioning |
 | metricsCollector.persistence.storageClassName | String | "" | Storage class for PVC |
 | metricsCollector.collector.name | String | thoras-collector | Thoras collector container name |
+| metricsCollector.podAnnotations | Object | {} | Pod Annotations for Thoras metrics collector  |
 | metricsCollector.search.imageTag | String | 8.12.1 | Elasticsearch image tag |
 | metricsCollector.search.name | String | elasticsearch | Elasticsearch container name |
 | metricsCollector.search.containerPort | Number | 9200 | Elasticsearch port |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -118,6 +118,7 @@ helm install \
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | thorasMonitor.enabled | Bool | false | Enable Thoras monitoring |
+| thorasMonitor.podAnnotations | Object | {} | Pod Annotations for Thoras monitor |
 | thorasMonitor.monitorCadenceSeconds | String | 15 | Health check frequency in seconds |
 | thorasMonitor.maxJobLifeSeconds | String | 600 | Maximum job length before notification |
 | thorasMonitor.underProvisionThreshold | String | 0.1 | How underprovisioned forecasts can be before alerting |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -35,7 +35,7 @@ metricsCollector:
 Now let’s install Thoras with Helm! We recommend installing Thoras into the thoras namespace:
 
 ```
-helm install
+helm install \
   my-thoras-release \
   thoras/thoras \
   -n thoras \
@@ -104,6 +104,11 @@ helm install
 | thorasDashboard.limits.memory | String | 1000Mi | Thoras Dashboard memory limit |
 | thorasDashboard.requests.cpu | String | 1000Mi | Thoras Dashboard CPU request |
 | thorasDashboard.requests.memory | String | 1000Mi | Thoras Dashboard memory request |
+| thorasDashboard.service.type | String | ClusterIP | Type of Service to use |
+| thorasDashboard.service.annotations | object | {} | Service annotations |
+| thorasDashboard.service.clusterIP | string | nil | Service cluserIP when type is ClusterIP |
+| thorasDashboard.service.loadBalancerIP | string | nil | Service loadBalancerIP when type is LoadBalancer |
+| thorasDashboard.service.loadBalancerSourceRanges | list | nil | Service loadBalancerSourceRanges when type is LoadBalancer |
 
 ## Thoras Monitor
 | Key | Type | Default | Description |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -105,10 +105,11 @@ helm install \
 | thorasDashboard.requests.cpu | String | 1000Mi | Thoras Dashboard CPU request |
 | thorasDashboard.requests.memory | String | 1000Mi | Thoras Dashboard memory request |
 | thorasDashboard.service.type | String | ClusterIP | Type of Service to use |
-| thorasDashboard.service.annotations | object | {} | Service annotations |
-| thorasDashboard.service.clusterIP | string | nil | Service cluserIP when type is ClusterIP |
-| thorasDashboard.service.loadBalancerIP | string | nil | Service loadBalancerIP when type is LoadBalancer |
-| thorasDashboard.service.loadBalancerSourceRanges | list | nil | Service loadBalancerSourceRanges when type is LoadBalancer |
+| thorasDashboard.service.annotations | Object | {} | Service annotations |
+| thorasDashboard.service.clusterIP | String | nil | Service cluserIP when type is ClusterIP |
+| thorasDashboard.service.loadBalancerIP | String | nil | Service loadBalancerIP when type is LoadBalancer |
+| thorasDashboard.service.loadBalancerSourceRanges | List | nil | Service loadBalancerSourceRanges when type is LoadBalancer |
+| thorasDashboard.service.externalIPs | List | nil | Service externalIPs |
 
 ## Thoras Monitor
 | Key | Type | Default | Description |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -85,6 +85,7 @@ helm install \
 ## Thoras API Server
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
+| thorasApiServer.podAnnotations | Object | {} | Pod Annotations for Thoras Thoras API |
 | thorasApiServer.containerPort | Number | 8443 | Thoras API port |
 | thorasApiServer.port | Number | 443 | Thoras API service port |
 | thorasApiServer.limits.cpu | String | 1000m | Thoras API CPU limit |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -61,6 +61,7 @@ helm install \
 ## Thoras Operator
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
+| thorasOperator.podAnnotations | Object | {} | Pod Annotations for Thoras Operator |
 | thorasOperator.limits.cpu | String | 1000m | Thoras Operator CPU limit |
 | thorasOperator.limits.memory | String | 1000Mi | Thoras Operator memory limit |
 | thorasOperator.requests.cpu | String | 1000m | Thoras Operator CPU request |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -109,7 +109,7 @@ helm install \
 | thorasDashboard.requests.memory | String | 1000Mi | Thoras Dashboard memory request |
 | thorasDashboard.service.type | String | ClusterIP | Type of Service to use |
 | thorasDashboard.service.annotations | Object | {} | Service annotations |
-| thorasDashboard.service.clusterIP | String | nil | Service cluserIP when type is ClusterIP |
+| thorasDashboard.service.clusterIP | String | nil | Service clusterIP when type is ClusterIP |
 | thorasDashboard.service.loadBalancerIP | String | nil | Service loadBalancerIP when type is LoadBalancer |
 | thorasDashboard.service.loadBalancerSourceRanges | List | nil | Service loadBalancerSourceRanges when type is LoadBalancer |
 | thorasDashboard.service.externalIPs | List | nil | Service externalIPs |

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -18,6 +18,14 @@ spec:
     metadata:
       labels:
         app: thoras-api-server
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.thorasApiServer.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: thoras-collector
       volumes:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.metricsCollector.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: thoras-collector
       {{- if .Values.metricsCollector.persistence.enabled }}

--- a/charts/thoras/templates/dashboard/service.yaml
+++ b/charts/thoras/templates/dashboard/service.yaml
@@ -13,7 +13,7 @@ spec:
   type: ClusterIP
   {{- if .Values.thorasDashboard.service.clusterIP }}
   clusterIP: {{ .Values.thorasDashboard.service.clusterIP }}
-  {{end}}
+  {{- end }}
 {{- else if eq .Values.thorasDashboard.service.type "LoadBalancer" }}
   type: {{ .Values.thorasDashboard.service.type }}
   {{- if .Values.thorasDashboard.service.loadBalancerIP }}

--- a/charts/thoras/templates/dashboard/service.yaml
+++ b/charts/thoras/templates/dashboard/service.yaml
@@ -4,7 +4,32 @@ kind: Service
 metadata:
   name: thoras-dashboard
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.thorasDashboard.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
 spec:
+{{- if (or (eq .Values.thorasDashboard.service.type "ClusterIP") (empty .Values.thorasDashboard.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.thorasDashboard.service.clusterIP }}
+  clusterIP: {{ .Values.thorasDashboard.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.thorasDashboard.service.type "LoadBalancer" }}
+  type: {{ .Values.thorasDashboard.service.type }}
+  {{- if .Values.thorasDashboard.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.thorasDashboard.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.thorasDashboard.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.thorasDashboard.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.thorasDashboard.service.type }}
+{{- end }}
+{{- if .Values.thorasDashboard.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.thorasDashboard.service.externalIPs | indent 4 }}
+{{- end }}
   ports:
   - port: {{ .Values.thorasDashboard.port }}
     protocol: TCP

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.thorasMonitor.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: thoras-operator
       containers:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.thorasOperator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       name: thoras-operator
     spec:
       serviceAccountName: thoras-operator

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -9,6 +9,7 @@ imageCredentials:
 imagePullPolicy: "IfNotPresent"
 
 thorasOperator:
+  podAnnotations: {}
   limits:
     cpu: 1000m
     memory: 1000Mi

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -37,6 +37,7 @@ metricsCollector:
 
 thorasApiServer:
   containerPort: 8443
+  podAnnotations: {}
   limits:
     cpu: 1000m
     memory: 1000Mi

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -22,6 +22,7 @@ metricsCollector:
     enabled: false
     volumeName: ""
     storageClassName: ""
+  podAnnotations: {}
   collector:
     name: thoras-collector
   search:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -59,6 +59,9 @@ thorasDashboard:
     cpu: 100m
     memory: 100Mi
   port: 80
+  service:
+    type: ClusterIP
+    annotations: {}
 
 thorasMonitor:
   enabled: false

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -68,6 +68,7 @@ thorasDashboard:
 
 thorasMonitor:
   enabled: false
+  podAnnotations: {}
   monitorCadenceSeconds: "15"
   maxJobLifeSeconds: "600"
   underProvisionThreshold: "0.1"


### PR DESCRIPTION
# Why are we making this change?

Thoras is introducing these enhancements to provide clients with greater control over their Kubernetes infrastructure. Specifically:

- **Pod Annotations:** Clients will now have the ability to update pod annotations, facilitating smoother integration with third-party software.
- **Dashboard Service Configuration:** Clients will gain more flexibility in configuring the Thoras dashboard service, including options for internal load balancing.

# What's changing?

The following updates have been made:

- **Pod Annotations:** Introduced the .podAnnotations key across all deployment values.
- **Dashboard Service:** Added new configuration options for the Thoras dashboard service: 

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| thorasDashboard.service.type | String | ClusterIP | Type of Service to use |
| thorasDashboard.service.annotations | Object | {} | Service annotations |
| thorasDashboard.service.clusterIP | String | nil | Service clusterIP when type is ClusterIP |
| thorasDashboard.service.loadBalancerIP | String | nil | Service loadBalancerIP when type is LoadBalancer |
| thorasDashboard.service.loadBalancerSourceRanges | List | nil | Service loadBalancerSourceRanges when type is LoadBalancer |
| thorasDashboard.service.externalIPs | List | nil | Service externalIPs |

Below is an example values.yaml configuration that enables internal load balancing within Amazon EKS:

```
# values.yaml
...
thorasDashboard:
  service:
    type: LoadBalancer
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
```

