### PR TITLE
Added optional Resource Quota

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -53,9 +53,9 @@ helm install \
 | imageCredentials.username | String | _json_key_base64 | Container registry username |
 | imageCredentials.password | String | "" | Container registry auth string |
 | resourceQuota.enabled | Bool | false | Enables resource quotas within Thoras |
-| resourceQuota.pods | Number | 200 | Pod total limit |
-| resourceQuota.cronjobs | Number | 200 | Cronjob total limit |
-| resourceQuota.jobs | Number | 200 | Job total limit |
+| resourceQuota.pods | Number | 200 | Maximum number of pods allowed|
+| resourceQuota.cronjobs | Number | 200 | Maximum number of cronjobs allowed |
+| resourceQuota.jobs | Number | 200 | Maximum number of jobs allowed |
 
 ## Thoras Forecast
 | Key | Type | Default | Description |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -52,6 +52,10 @@ helm install \
 | imageCredentials.registry | String | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name |
 | imageCredentials.username | String | _json_key_base64 | Container registry username |
 | imageCredentials.password | String | "" | Container registry auth string |
+| resourceQuota.enabled | Bool | false | Enables resource quotas within Thoras |
+| resourceQuota.pods | Number | 200 | Pod total limit |
+| resourceQuota.cronjobs | Number | 200 | Cronjob total limit |
+| resourceQuota.jobs | Number | 200 | Job total limit |
 
 ## Thoras Forecast
 | Key | Type | Default | Description |

--- a/charts/thoras/templates/resource-quota.yaml
+++ b/charts/thoras/templates/resource-quota.yaml
@@ -1,0 +1,19 @@
+
+{{- if .Values.resourceQuota.enabled }}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: thoras
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  hard:
+    pods: {{ .Values.resourceQuota.pods }}
+    count/cronjobs.batch: {{ .Values.resourceQuota.cronjobs }}
+    count/jobs.batch: {{ .Values.resourceQuota.jobs }}
+{{- end }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -6,6 +6,12 @@ imageCredentials:
   username: "_json_key_base64"
   password: ""
 
+resourceQuota:
+  enabled: false
+  pods: 200
+  cronjobs: 200
+  jobs: 200
+
 imagePullPolicy: "IfNotPresent"
 
 thorasOperator:


### PR DESCRIPTION
# Why are we making this change?

This change is being implemented to mitigate the risk of Thoras potentially consuming all available resources in a cluster in the event of a cascading cronjob failure. 

# What's changing?

An optional resource quota has been introduced to help manage resource consumption within Thoras. The following configuration options are now available:

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| resourceQuota.enabled | Bool | false | Enables resource quotas within Thoras |
| resourceQuota.pods | Number | 200 | Maximum number of pods allowed|
| resourceQuota.cronjobs | Number | 200 | Maximum number of cronjobs allowed |
| resourceQuota.jobs | Number | 200 | Maximum number of jobs allowed |

