### PR TITLE
Wait for ES readiness before monitor start

### DIFF
--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -33,6 +33,27 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/thoras-monitor:{{ default .Values.thorasVersion .Values.thorasMonitor.imageTag }}
         imagePullPolicy: Always
         name: thoras-monitor
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Don't start app until ES is available
+            retries=0
+            max_retries=48
+            until [ $retries -eq $max_retries ]; do
+              if curl -s --connect-timeout 5 --fail -XGET ${ES_HOST}; then
+                echo "elasticsearch ready"
+                break
+              else
+                echo "elasticsearch not ready"
+                retries=$((retries+1))
+                sleep 5
+              fi
+            done
+            if [ $retries -eq $max_retries ]; then
+                echo "fatal: giving up on elasticsearch availability"
+                exit 1
+            fi
+            node index.js
         env:
           - name: "ES_HOST"
             valueFrom:


### PR DESCRIPTION
# Why are we making this change?

In certain scenarios we may need to wait for ES to come up / initialize. Let's try waiting first before giving up!

One callout: this is the second time we do this (first is for the collector). If we end up needing it a third time, we should consider throwing this script into the container image

# What's changing?

Give ES a chance to come up before bailing