### PR TITLE
Provide ability to autocreate StorageClass for Thoras EFS volume

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -76,6 +76,7 @@ helm install \
 | --- | --- | --- | --- |
 | metricsCollector.persistence.enabled | Bool | false | Enables persistence for Thoras metrics collector |
 | metricsCollector.persistence.volumeName | String | "" | PV name for PVC. Keep blank if using dynamic provisioning |
+| metricsCollector.persistence.createEFSStorageClass.fileSystemId | String | "" | Create dynamic PV provisioner for EFS by specifying EFS id  |
 | metricsCollector.persistence.storageClassName | String | "" | Storage class for PVC |
 | metricsCollector.collector.name | String | thoras-collector | Thoras collector container name |
 | metricsCollector.podAnnotations | Object | {} | Pod Annotations for Thoras metrics collector  |

--- a/charts/thoras/templates/collector/storageclass.yaml
+++ b/charts/thoras/templates/collector/storageclass.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.metricsCollector.persistence.enabled .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .Values.metricsCollector.persistence.storageClassName }}
+provisioner: efs.csi.aws.com
+parameters:
+  fileSystemId: {{ .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId }}
+  provisioningMode: efs-ap
+  directoryPerms: "700"
+  gidRangeStart: "1000"
+  gidRangeEnd: "2000"
+  basePath: "/dynamic_provisioning"
+  subPathPattern: "${.PVC.namespace}/${.PVC.name}"
+  ensureUniqueDirectory: "true"
+  reuseAccessPoint: "false"
+{{- end }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -27,7 +27,9 @@ metricsCollector:
   persistence:
     enabled: false
     volumeName: ""
-    storageClassName: ""
+    storageClassName: "efs-sc-thoras"
+    createEFSStorageClass:
+      fileSystemId: ""
   podAnnotations: {}
   collector:
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?

Users shouldn't have to set up an EFS `StorageClass` object in their cluster if they want to use EFS for Thoras in addition to the easiest install experience possible


# What's changing?

* Create the ability for users to automatically create a dedicated thoras `StorageClass` that's bound to the Thoras EFS volume
* Update docs
* Set a default `storageClassName` since users who want this automated probably don't want to have to think about its name
