### PR TITLE
Provide more verbose logging for the API server

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.6
+version: 3.2.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 3.1.6](https://img.shields.io/badge/Version-3.1.6-informational?style=flat-square) ![AppVersion: 2.0.8](https://img.shields.io/badge/AppVersion-2.0.8-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 2.0.8](https://img.shields.io/badge/AppVersion-2.0.8-informational?style=flat-square)
 
 # Install
 Using [Helm](https://helm.sh), you can easily install and test Throas in a Kubernetes cluster by running the following:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -56,6 +56,7 @@ thorasApiServer:
     cpu: 100m
     memory: 100Mi
   port: 443
+  logLevel: "debug"
 
 thorasDashboard:
   enabled: true


### PR DESCRIPTION
# Why are we making this change?

Customers may find more verbose logs for the API server useful. We can always adjust down the road if this is too verbose for a default

# What's changing?

* Increasing verbosity of the API server logs
* Bump version to 3.2.0
