### PR TITLE
Default to Thoras version 2.0.10

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0
+version: 3.2.1

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 2.0.8](https://img.shields.io/badge/AppVersion-2.0.8-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![AppVersion: 2.0.10](https://img.shields.io/badge/AppVersion-2.0.10-informational?style=flat-square)
 
 # Install
 Using [Helm](https://helm.sh), you can easily install and test Throas in a Kubernetes cluster by running the following:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,6 +1,6 @@
 ---
 
-thorasVersion: "2.0.8"
+thorasVersion: "2.0.10"
 
 imageCredentials:
   registry: "us-east4-docker.pkg.dev/thoras-registry/platform"


### PR DESCRIPTION
# Why are we making this change?

We've released a new version of the Thoras Platform (`2.0.10`) and we want to ensure the latest helm chart defaults to using it

# What's changing?

Default Thoras Platform version to 2.0.10
