### PR TITLE
Add SLACK_WEBHOOK_URL and SLACK_ERRORS_ENABLED to helm charts

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.1
+version: 4.0.1

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -7,7 +7,7 @@ This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 ![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![AppVersion: 2.0.10](https://img.shields.io/badge/AppVersion-2.0.10-informational?style=flat-square)
 
 # Install
-Using [Helm](https://helm.sh), you can easily install and test Throas in a Kubernetes cluster by running the following:
+Using [Helm](https://helm.sh), you can easily install and test Thoras in a Kubernetes cluster by running the following:
 
 #### Add Helm repo
 First, add the repo if you haven't already done so:
@@ -57,6 +57,8 @@ helm install \
 | resourceQuota.cronjobs | Number | 200 | Maximum number of cronjobs allowed |
 | resourceQuota.jobs | Number | 200 | Maximum number of jobs allowed |
 | logLevel | String | info | Default log level |
+| slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications. |
+| slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 
 ## Thoras Forecast
 | Key | Type | Default | Description |
@@ -71,6 +73,8 @@ helm install \
 | thorasOperator.limits.memory | String | 1000Mi | Thoras Operator memory limit |
 | thorasOperator.requests.cpu | String | 1000m | Thoras Operator CPU request |
 | thorasOperator.requests.memory | String | 1000Mi | Thoras Operator memory request |
+| thorasOperator.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
+| thorasOperator.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasOperator.logLevel | String | Nil | Logging level |
 
 ## Thoras Metrics Collector
@@ -88,6 +92,8 @@ helm install \
 | metricsCollector.search.containerPort | Number | 9200 | Elasticsearch port |
 | metricsCollector.purge.ttl | String | 30d | How long to keep metrics data in Elasticsearch |
 | metricsCollector.purge.schedule | String | 00 00 * * * | Cron expression for metrics purge job |
+| metricsCollector.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
+| metricsCollector.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | metricsCollector.purge.logLevel | String | Nil | Logging level |
 | metricsCollector.init.imageTag | String | latest | Image tag for metrics collector init container |
 
@@ -101,6 +107,8 @@ helm install \
 | thorasApiServer.limits.memory | String | 1000Mi | Thoras API memory limit |
 | thorasApiServer.requests.cpu | String | 1000Mi | Thoras API CPU request |
 | thorasApiServer.requests.memory | String | 1000Mi | Thoras API memory request |
+| thorasApiServer.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
+| thorasApiServer.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasApiServer.logLevel | String | Nil | Logging level |
 
 ## Thoras Dashboard
@@ -123,6 +131,8 @@ helm install \
 | thorasDashboard.service.loadBalancerIP | String | nil | Service loadBalancerIP when type is LoadBalancer |
 | thorasDashboard.service.loadBalancerSourceRanges | List | nil | Service loadBalancerSourceRanges when type is LoadBalancer |
 | thorasDashboard.service.externalIPs | List | nil | Service externalIPs |
+| thorasDashboard.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
+| thorasDashboard.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasDashboard.logLevel | String | Nil | Logging level |
 
 ## Thoras Monitor
@@ -130,9 +140,8 @@ helm install \
 | --- | --- | --- | --- |
 | thorasMonitor.enabled | Bool | false | Enable Thoras monitoring |
 | thorasMonitor.podAnnotations | Object | {} | Pod Annotations for Thoras monitor |
-| thorasMonitor.slackWorkspaceID | String | "" | Target slack workspace for alert notifications |
-| thorasMonitor.slackChannelID | String | "" | Target slack channel for alert notifications |
-| thorasMonitor.slackWebhookID | String | "" | Webhook destination for notifications |
+| thorasMonitor.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
+| thorasMonitor.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasMonitor.config | String | "" | Thoras Monitor configuration yaml |
 | thorasMonitor.logLevel | String | Nil | Logging level |
 

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![AppVersion: 2.0.10](https://img.shields.io/badge/AppVersion-2.0.10-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: 2.0.10](https://img.shields.io/badge/AppVersion-2.0.10-informational?style=flat-square)
 
 # Install
 Using [Helm](https://helm.sh), you can easily install and test Thoras in a Kubernetes cluster by running the following:

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           - name: SLACK_WEBHOOK_URL
             value: {{ .Values.thorasApiServer.slackWebhookUrl | default .Values.slackWebhookUrl }}
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
+            value: {{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasApiServer.logLevel }}
         volumeMounts:

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -42,6 +42,10 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
+          - name: SLACK_WEBHOOK_URL
+            value: {{ .Values.thorasApiServer.slackWebhookUrl | default .Values.slackWebhookUrl }}
+          - name: SLACK_ERRORS_ENABLED
+            value: {{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasApiServer.logLevel }}
         volumeMounts:

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -23,6 +23,10 @@ spec:
                   secretKeyRef:
                     name: thoras-elastic-password
                     key: host
+              - name: SLACK_WEBHOOK_URL
+                value: {{ .Values.metricsCollector.slackWebhookUrl | default .Values.slackWebhookUrl }}
+              - name: SLACK_ERRORS_ENABLED
+                value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
               - name: "LOGLEVEL"
                 value: {{ default .Values.logLevel .Values.metricsCollector.purge.logLevel }}
             command: ["/bin/sh", "-c"]

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
               - name: SLACK_WEBHOOK_URL
                 value: {{ .Values.metricsCollector.slackWebhookUrl | default .Values.slackWebhookUrl }}
               - name: SLACK_ERRORS_ENABLED
-                value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
+                value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
               - name: "LOGLEVEL"
                 value: {{ default .Values.logLevel .Values.metricsCollector.purge.logLevel }}
             command: ["/bin/sh", "-c"]

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -104,5 +104,9 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
+          - name: SLACK_WEBHOOK_URL
+            value: {{ .Values.metricsCollector.slackWebhookUrl | default .Values.slackWebhookUrl }}
+          - name: SLACK_ERRORS_ENABLED
+            value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -107,6 +107,6 @@ spec:
           - name: SLACK_WEBHOOK_URL
             value: {{ .Values.metricsCollector.slackWebhookUrl | default .Values.slackWebhookUrl }}
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
+            value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           - name: SLACK_WEBHOOK_URL
             value: {{ .Values.thorasDashboard.slackWebhookUrl | default .Values.slackWebhookUrl }}
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
+            value: {{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
         resources:

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -48,6 +48,10 @@ spec:
                 fieldPath: metadata.namespace
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
+          - name: SLACK_WEBHOOK_URL
+            value: {{ .Values.thorasDashboard.slackWebhookUrl | default .Values.slackWebhookUrl }}
+          - name: SLACK_ERRORS_ENABLED
+            value: {{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
         resources:

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           - name: SLACK_WEBHOOK_URL
             value: {{ .Values.thorasMonitor.slackWebhookUrl | default .Values.slackWebhookUrl }}
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
+            value: {{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
 {{- end }}

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -75,10 +75,10 @@ spec:
               secretKeyRef:
                 name: thoras-slack
                 key: webhookID
-          - name: SLACK_WORKSPACE_ID
-            value: {{ .Values.thorasMonitor.slackWorkspaceID }}
-          - name: SLACK_CHANNEL_ID
-            value: {{ .Values.thorasMonitor.slackChannelID }}
+          - name: SLACK_WEBHOOK_URL
+            value: {{ .Values.thorasMonitor.slackWebhookUrl | default .Values.slackWebhookUrl }}
+          - name: SLACK_ERRORS_ENABLED
+            value: {{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
 {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             value: {{ .Chart.Version | replace "+" "_" }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
+          - name: SLACK_WEBHOOK_URL
+            value: {{ .Values.thorasOperator.slackWebhookUrl | default .Values.slackWebhookUrl }}
+          - name: SLACK_ERRORS_ENABLED
+            value: {{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
         args:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           - name: SLACK_WEBHOOK_URL
             value: {{ .Values.thorasOperator.slackWebhookUrl | default .Values.slackWebhookUrl }}
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled | default false }}
+            value: {{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
         args:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -16,6 +16,8 @@ resourceQuota:
 imagePullPolicy: "IfNotPresent"
 
 logLevel: info
+slackWebhookUrl: ""
+slackErrorsEnabled: false
 
 thorasOperator:
   podAnnotations: {}
@@ -82,9 +84,6 @@ thorasDashboard:
 thorasMonitor:
   enabled: false
   podAnnotations: {}
-  slackWorkspaceID: ""
-  slackChannelID: ""
-  slackWebhookID: ""
   config: |
 
 thorasForecast: {}


### PR DESCRIPTION
# Why are we making this change?

To turn on sending `error`-level logs to slack, we need to expose the environment variables.

Needed for https://github.com/thoras-ai/platform/pull/73

# What's changing?

This PR adds global and service-level configurations for `SLACK_WEBHOOK_URL` and `SLACK_ERRORS_ENABLED`. In the case of `thorasMonitor`, the webhook URL makes the passing of workspace, channel and hook IDs obsolete.