### PR TITLE
Convert the slackWebhookUrl into a secret

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -73,7 +73,6 @@ helm install \
 | thorasOperator.limits.memory | String | 1000Mi | Thoras Operator memory limit |
 | thorasOperator.requests.cpu | String | 1000m | Thoras Operator CPU request |
 | thorasOperator.requests.memory | String | 1000Mi | Thoras Operator memory request |
-| thorasOperator.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
 | thorasOperator.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasOperator.logLevel | String | Nil | Logging level |
 
@@ -92,7 +91,6 @@ helm install \
 | metricsCollector.search.containerPort | Number | 9200 | Elasticsearch port |
 | metricsCollector.purge.ttl | String | 30d | How long to keep metrics data in Elasticsearch |
 | metricsCollector.purge.schedule | String | 00 00 * * * | Cron expression for metrics purge job |
-| metricsCollector.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
 | metricsCollector.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | metricsCollector.purge.logLevel | String | Nil | Logging level |
 | metricsCollector.init.imageTag | String | latest | Image tag for metrics collector init container |
@@ -107,7 +105,6 @@ helm install \
 | thorasApiServer.limits.memory | String | 1000Mi | Thoras API memory limit |
 | thorasApiServer.requests.cpu | String | 1000Mi | Thoras API CPU request |
 | thorasApiServer.requests.memory | String | 1000Mi | Thoras API memory request |
-| thorasApiServer.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
 | thorasApiServer.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasApiServer.logLevel | String | Nil | Logging level |
 
@@ -131,7 +128,6 @@ helm install \
 | thorasDashboard.service.loadBalancerIP | String | nil | Service loadBalancerIP when type is LoadBalancer |
 | thorasDashboard.service.loadBalancerSourceRanges | List | nil | Service loadBalancerSourceRanges when type is LoadBalancer |
 | thorasDashboard.service.externalIPs | List | nil | Service externalIPs |
-| thorasDashboard.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
 | thorasDashboard.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasDashboard.logLevel | String | Nil | Logging level |
 
@@ -140,7 +136,6 @@ helm install \
 | --- | --- | --- | --- |
 | thorasMonitor.enabled | Bool | false | Enable Thoras monitoring |
 | thorasMonitor.podAnnotations | Object | {} | Pod Annotations for Thoras monitor |
-| thorasMonitor.slackWebhookUrl | String | "" | Slack Webhook URL destination for notifications |
 | thorasMonitor.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasMonitor.config | String | "" | Thoras Monitor configuration yaml |
 | thorasMonitor.logLevel | String | Nil | Logging level |

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -43,7 +43,10 @@ spec:
                 name: thoras-elastic-password
                 key: host
           - name: SLACK_WEBHOOK_URL
-            value: {{ .Values.thorasApiServer.slackWebhookUrl | default .Values.slackWebhookUrl }}
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: {{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -48,7 +48,7 @@ spec:
                 name: thoras-slack
                 key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
+            value: "{{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasApiServer.logLevel }}
         volumeMounts:

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -24,7 +24,10 @@ spec:
                     name: thoras-elastic-password
                     key: host
               - name: SLACK_WEBHOOK_URL
-                value: {{ .Values.metricsCollector.slackWebhookUrl | default .Values.slackWebhookUrl }}
+                valueFrom:
+                  secretKeyRef:
+                    name: thoras-slack
+                    key: webhookUrl
               - name: SLACK_ERRORS_ENABLED
                 value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
               - name: "LOGLEVEL"

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
                     name: thoras-slack
                     key: webhookUrl
               - name: SLACK_ERRORS_ENABLED
-                value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
+                value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
               - name: "LOGLEVEL"
                 value: {{ default .Values.logLevel .Values.metricsCollector.purge.logLevel }}
             command: ["/bin/sh", "-c"]

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -110,6 +110,6 @@ spec:
                 name: thoras-slack
                 key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
+            value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           runAsGroup: 0
         {{- end }}
       - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
-        imagePullPolicy: Always
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: {{ .Values.metricsCollector.collector.name }}
         command: ["/bin/sh", "-c"]
         args:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -105,7 +105,10 @@ spec:
                 name: thoras-elastic-password
                 key: host
           - name: SLACK_WEBHOOK_URL
-            value: {{ .Values.metricsCollector.slackWebhookUrl | default .Values.slackWebhookUrl }}
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: {{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 name: thoras-slack
                 key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
+            value: "{{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
         resources:

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -49,7 +49,10 @@ spec:
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
           - name: SLACK_WEBHOOK_URL
-            value: {{ .Values.thorasDashboard.slackWebhookUrl | default .Values.slackWebhookUrl }}
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: {{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           name: thoras-monitor-config
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-monitor:{{ default .Values.thorasVersion .Values.thorasMonitor.imageTag }}
-        imagePullPolicy: Always
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-monitor
         volumeMounts:
           - name: config

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -70,13 +70,11 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
-          - name: "WEBHOOK_ID"
+          - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
                 name: thoras-slack
-                key: webhookID
-          - name: SLACK_WEBHOOK_URL
-            value: {{ .Values.thorasMonitor.slackWebhookUrl | default .Values.slackWebhookUrl }}
+                key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: {{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -76,7 +76,7 @@ spec:
                 name: thoras-slack
                 key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
+            value: "{{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
 {{- end }}

--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -2,7 +2,7 @@
 ---
 apiVersion: v1
 data:
-  webhookID: {{ .Values.thorasMonitor.slackWebhookID | b64enc }}
+  webhookUrl: {{ .Values.thorasMonitor.slackWebhookUrl | b64enc }}
 kind: Secret
 metadata:
   name: thoras-slack

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -50,7 +50,7 @@ spec:
                 name: thoras-slack
                 key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
-            value: {{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
+            value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
         args:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -45,7 +45,10 @@ spec:
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
           - name: SLACK_WEBHOOK_URL
-            value: {{ .Values.thorasOperator.slackWebhookUrl | default .Values.slackWebhookUrl }}
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: {{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}
           - name: "LOGLEVEL"


### PR DESCRIPTION
# Why are we making this change?

When converting over to the webhook URL in #49, I didn't make it a secret

# What's changing?

I think this captures the effort in turning the `slackWebhookUrl` into a secret.

