### PR TITLE
One SlackURL var to rule them all!

### DIFF
--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -2,7 +2,7 @@
 ---
 apiVersion: v1
 data:
-  webhookUrl: {{ .Values.thorasMonitor.slackWebhookUrl | b64enc }}
+  webhookUrl: {{ .Values.slackWebhookUrl | b64enc }}
 kind: Secret
 metadata:
   name: thoras-slack


### PR DESCRIPTION
# Why are we making this change?

Since we have one URL at the top level, we need to reference that var!

# What's changing?

Update monitor template to reference top level Slack webhook URL var
