### PR TITLE
Add  v2 API service

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.thorasApiServerV2.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thoras-api-server-v2
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: thoras-api-server-v2
+  template:
+    metadata:
+      labels:
+        app: thoras-api-server-v2
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.thorasApiServerV2.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: thoras-collector
+      volumes:
+        - name: tls
+          secret:
+            secretName: thoras-api-server-cert
+      containers:
+      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        name: thoras-v2-api-server
+        env:
+          - name: "ES_HOST"
+            valueFrom:
+              secretKeyRef:
+                name: thoras-elastic-password
+                key: host
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookUrl
+          - name: SLACK_ERRORS_ENABLED
+            value: "{{ .Values.thorasApiServerV2.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+          - name: "LOGLEVEL"
+            value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
+        volumeMounts:
+          - name: tls
+            mountPath: /apps/packages/thoras-external-metrics-server/cert.pem
+            subPath: tls.crt
+            readOnly: true
+          - name: tls
+            mountPath: /apps/packages/thoras-external-metrics-server/key.pem
+            subPath: tls.key
+            readOnly: true
+        ports:
+        - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
+        resources:
+          limits:
+            cpu: {{ .Values.thorasApiServerV2.limits.cpu }}
+            memory: {{ .Values.thorasApiServerV2.limits.memory }}
+          requests:
+            cpu: {{ .Values.thorasApiServerV2.requests.cpu }}
+            memory: {{ .Values.thorasApiServerV2.requests.memory }}
+{{- end }}

--- a/charts/thoras/templates/api-server-v2/service.yaml
+++ b/charts/thoras/templates/api-server-v2/service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.thorasApiServerV2.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: thoras-api-server-v2
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: {{ .Values.thorasApiServerV2.port }}
+    protocol: TCP
+    targetPort: {{ .Values.thorasApiServerV2.containerPort }}
+  selector:
+    app: thoras-api-server-v2
+{{- end}}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -60,6 +60,16 @@ thorasApiServer:
   port: 443
   logLevel: "debug"
 
+thorasApiServerV2:
+  enabled: false
+  containerPort: 8443
+  podAnnotations: {}
+  requests:
+    cpu: 128m
+    memory: 100Mi
+  port: 443
+  logLevel: "info"
+
 thorasDashboard:
   enabled: true
   serviceAccount:


### PR DESCRIPTION
# Why are we making this change?

We have a new API service layer that needs to be added to the chart for it to be released.

# What's changing?

Adding a new, `thoras-api-server-v2` deployment and service. The service is default off unless the value `thorasServerV2.enabled == true`.