### PR TITLE
Drop CPU limits; bump memory to 2Gi

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -69,8 +69,7 @@ helm install \
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | thorasOperator.podAnnotations | Object | {} | Pod Annotations for Thoras Operator |
-| thorasOperator.limits.cpu | String | 1000m | Thoras Operator CPU limit |
-| thorasOperator.limits.memory | String | 1000Mi | Thoras Operator memory limit |
+| thorasOperator.limits.memory | String | 2000Mi | Thoras Operator memory limit |
 | thorasOperator.requests.cpu | String | 1000m | Thoras Operator CPU request |
 | thorasOperator.requests.memory | String | 1000Mi | Thoras Operator memory request |
 | thorasOperator.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
@@ -101,8 +100,7 @@ helm install \
 | thorasApiServer.podAnnotations | Object | {} | Pod Annotations for Thoras Thoras API |
 | thorasApiServer.containerPort | Number | 8443 | Thoras API port |
 | thorasApiServer.port | Number | 443 | Thoras API service port |
-| thorasApiServer.limits.cpu | String | 1000m | Thoras API CPU limit |
-| thorasApiServer.limits.memory | String | 1000Mi | Thoras API memory limit |
+| thorasApiServer.limits.memory | String | 2000Mi | Thoras API memory limit |
 | thorasApiServer.requests.cpu | String | 1000Mi | Thoras API CPU request |
 | thorasApiServer.requests.memory | String | 1000Mi | Thoras API memory request |
 | thorasApiServer.slackErrorsEnabled | Boolean | false | Determines if error-level logs are sent to `slackWebHookUrl` |
@@ -118,8 +116,7 @@ helm install \
 | thorasDashboard.podAnnotations | Object | {} | Pod Annotations for Thoras Dashboard |
 | thorasDashboard.containerPort | Number | 3000 | Thoras Dashboard port |
 | thorasDashboard.port | Number | 3000 | Thoras Dashboard service port |
-| thorasDashboard.limits.cpu | String | 1000m | Thoras Dashboard CPU limit |
-| thorasDashboard.limits.memory | String | 1000Mi | Thoras Dashboard memory limit |
+| thorasDashboard.limits.memory | String | 2000Mi | Thoras Dashboard memory limit |
 | thorasDashboard.requests.cpu | String | 1000Mi | Thoras Dashboard CPU request |
 | thorasDashboard.requests.memory | String | 1000Mi | Thoras Dashboard memory request |
 | thorasDashboard.service.type | String | ClusterIP | Type of Service to use |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -65,7 +65,6 @@ spec:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
         resources:
           limits:
-            cpu: {{ .Values.thorasApiServerV2.limits.cpu }}
             memory: {{ .Values.thorasApiServerV2.limits.memory }}
           requests:
             cpu: {{ .Values.thorasApiServerV2.requests.cpu }}

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -64,7 +64,6 @@ spec:
         - containerPort: {{ .Values.thorasApiServer.containerPort }}
         resources:
           limits:
-            cpu: {{ .Values.thorasApiServer.limits.cpu }}
             memory: {{ .Values.thorasApiServer.limits.memory }}
           requests:
             cpu: {{ .Values.thorasApiServer.requests.cpu }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -59,7 +59,6 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
         resources:
           limits:
-            cpu: {{ .Values.thorasDashboard.limits.cpu }}
             memory: {{ .Values.thorasDashboard.limits.memory }}
           requests:
             cpu: {{ .Values.thorasDashboard.requests.cpu }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -57,7 +57,6 @@ spec:
           - start
         resources:
           limits:
-            cpu: {{ .Values.thorasOperator.limits.cpu }}
             memory: {{ .Values.thorasOperator.limits.memory }}
           requests:
             cpu: {{ .Values.thorasOperator.requests.cpu }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -22,8 +22,7 @@ slackErrorsEnabled: false
 thorasOperator:
   podAnnotations: {}
   limits:
-    cpu: 1000m
-    memory: 1000Mi
+    memory: 2000Mi
   requests:
     cpu: 100m
     memory: 100Mi
@@ -52,8 +51,7 @@ thorasApiServer:
   containerPort: 8443
   podAnnotations: {}
   limits:
-    cpu: 1000m
-    memory: 1000Mi
+    memory: 2000Mi
   requests:
     cpu: 100m
     memory: 100Mi
@@ -64,6 +62,8 @@ thorasApiServerV2:
   enabled: false
   containerPort: 8443
   podAnnotations: {}
+  limits:
+    memory: 2000Mi
   requests:
     cpu: 128m
     memory: 100Mi
@@ -80,8 +80,7 @@ thorasDashboard:
   podAnnotations: {}
   containerPort: 3000
   limits:
-    cpu: 1000m
-    memory: 1000Mi
+    memory: 2000Mi
   requests:
     cpu: 100m
     memory: 100Mi


### PR DESCRIPTION
# Why are we making this change?

We don't need to set CPU limits and increasing the memory limit will reduce future OOMs

# What's changing?

- Removing `limits.cpu` in all cases
- Bumping `limits.memory` to 2000Mi in all cases