### PR TITLE
Enable API service layer

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.thorasApiServerV2.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -37,8 +36,9 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-v2-api-server
+        command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
         env:
-          - name: "ES_HOST"
+          - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:
                 name: thoras-elastic-password
@@ -69,4 +69,3 @@ spec:
           requests:
             cpu: {{ .Values.thorasApiServerV2.requests.cpu }}
             memory: {{ .Values.thorasApiServerV2.requests.memory }}
-{{- end }}

--- a/charts/thoras/templates/api-server-v2/service.yaml
+++ b/charts/thoras/templates/api-server-v2/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.thorasApiServerV2.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -12,4 +11,3 @@ spec:
     targetPort: {{ .Values.thorasApiServerV2.containerPort }}
   selector:
     app: thoras-api-server-v2
-{{- end}}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -58,15 +58,14 @@ thorasApiServer:
   logLevel: "debug"
 
 thorasApiServerV2:
-  enabled: false
-  containerPort: 8443
+  containerPort: 8080
   podAnnotations: {}
   limits:
     memory: 2000Mi
   requests:
     cpu: 128m
     memory: 100Mi
-  port: 443
+  port: 80
   logLevel: "info"
 
 thorasDashboard:


### PR DESCRIPTION
# Why are we making this change?

The API service layer is ready for deploying every where, not just where enabled.

# What's changing?

The API service layer is an internal service used by various components to store and retrieve data from Kubernetes and our internal storage. Initially, none of these components are using the service layer, but we'll soon be moving various components to the new service until all components are going through the layer.
