### PR TITLE
Add TLS support to API service layer

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-v2-api-server
-        command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
+        command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}, "--certificate-file", "/app/cert.pem", "--key-file", "/app/key.pem"]
         env:
           - name: "ELASTICSEARCH_URL"
             valueFrom:
@@ -54,11 +54,11 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
         volumeMounts:
           - name: tls
-            mountPath: /apps/packages/thoras-external-metrics-server/cert.pem
+            mountPath: /app/cert.pem
             subPath: tls.crt
             readOnly: true
           - name: tls
-            mountPath: /apps/packages/thoras-external-metrics-server/key.pem
+            mountPath: /app/key.pem
             subPath: tls.key
             readOnly: true
         ports:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -58,14 +58,14 @@ thorasApiServer:
   logLevel: "debug"
 
 thorasApiServerV2:
-  containerPort: 8080
+  containerPort: 8443
   podAnnotations: {}
   limits:
     memory: 2000Mi
   requests:
     cpu: 128m
     memory: 100Mi
-  port: 80
+  port: 443
   logLevel: "info"
 
 thorasDashboard:


### PR DESCRIPTION
# Why are we making this change?

To add TLS support to the API service layer, we need to pass the certificate and key file.

# What's changing?

Updating the API service layer command to include the TLS certificate and key files and updating the ports to be on 443.
