### PR TITLE
Always create slack secret

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.2
+version: 4.0.3

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 4.0.3](https://img.shields.io/badge/Version-4.0.3-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 # Install
 Using [Helm](https://helm.sh), you can easily install and test Thoras in a Kubernetes cluster by running the following:

--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.thorasMonitor.enabled }}
 ---
 apiVersion: v1
 data:
@@ -6,4 +5,3 @@ data:
 kind: Secret
 metadata:
   name: thoras-slack
-{{- end }}


### PR DESCRIPTION
# Why are we making this change?

[We expect](https://github.com/thoras-ai/helm-charts/blob/dev/charts/thoras/templates/operator/deployment.yaml#L50) the `thoras-slack` secret to be present, so create it no matter what -- even if the content is empty

# What's changing?

Removed conditions for if we create a Slack secret (always create it)