### PR TITLE
Added containers list to vertical spec

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -54,32 +54,41 @@ spec:
                   properties:
                     mode:
                       type: string
-                    cpu:
-                      type: object
-                      properties:
-                        lowerbound:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                        upperbound:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          x-kubernetes-int-or-string: true
-                    memory:
-                      type: object
-                      properties:
-                        lowerbound:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          x-kubernetes-int-or-string: true
-                        upperbound:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          x-kubernetes-int-or-string: true
+                    containers:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          cpu:
+                            type: object
+                            properties:
+                              lowerbound:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              upperbound:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          memory:
+                            type: object
+                            properties:
+                              lowerbound:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              upperbound:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                        required:
+                          - name
                 model:
                   type: object
                   required:


### PR DESCRIPTION
# Why are we making this change?

This enhancement introduces the ability to target specific containers within deployments for vertical scaling, enabling fine-grained control over resource allocation and optimization. 

# What's changing?

The `AIScaleTarget` Custom Resource Definition (CRD) has been updated to include a `containers` list within the `vertical` spec. This list allows users to specify individual containers for vertical scaling by their name. Memory upper and lower bounds remain optional. 

**Example `AIScaleTarget` CRD:**

```yaml
apiVersion: thoras.ai/v1
kind: AIScaleTarget
metadata:
  name: test-vertical
  namespace: test-mutate
spec:
  scaleTargetRef:
    kind: Deployment
    name: test-vertical
  model:
    mode: balanced
  vertical:
    mode: autonomous
    containers:
      - name: nginx
        memory: 
          lowerbound: 250Mi
          upperbound: 4Gi
```

**Backwards Compatibility:**

Existing `AIScaleTarget` resources will not be affected by this change. However, vertical scaling will be disabled for these resources until the `vertical` spec is updated to include the `containers` list.

**Benefits:**

* Enhanced control over resource allocation within deployments.
* Increased flexibility and fine-tuning capabilities for vertical scaling.
* Improved resource utilization and optimization. 
