### PR TITLE
Fix direct volume name assignment

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.3
+version: 4.0.4

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.0.3](https://img.shields.io/badge/Version-4.0.3-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 4.0.4](https://img.shields.io/badge/Version-4.0.4-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 # Install
 Using [Helm](https://helm.sh), you can easily install and test Thoras in a Kubernetes cluster by running the following:

--- a/charts/thoras/templates/collector/pvc.yaml
+++ b/charts/thoras/templates/collector/pvc.yaml
@@ -14,7 +14,9 @@ spec:
   {{- if .Values.metricsCollector.persistence.volumeName }}
   volumeName: {{ .Values.metricsCollector.persistence.volumeName }}
   {{- end }}
+  {{- if (not .Values.metricsCollector.persistence.volumeName) }}
   storageClassName: {{ .Values.metricsCollector.persistence.storageClassName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
# Why are we making this change?

If users provision a PV out-of-band from the Thoras installation, they should be able to reference that PV and be done with it.

The issue is that in that case, we'll still set the `storageClassName` field which is no longer applicable and could cause undesired behavior

# What's changing?

Make the helm chart not set `storageClassName` field on the PVC when `volumeName` is set by the user
