### PR TITLE
Add API_BASE_URL to dashboard

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -55,6 +55,8 @@ spec:
                 key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+          - name: API_BASE_URL
+            value: "https://thoras-api-server-v2"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
         resources:


### PR DESCRIPTION
# Why are we making this change?

The dashboard service needs to start talking to the V2 api server by environment variable

# What's changing?

Adding an `API_BASE_URL` environment variable to the dashboard service that references the the API v2 service.