### PR TITLE
Turn off TLS for api-v2 server

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-v2-api-server
-        command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}, "--certificate-file", "/app/cert.pem", "--key-file", "/app/key.pem"]
+        command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
         env:
           - name: "ELASTICSEARCH_URL"
             valueFrom:

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: API_BASE_URL
-            value: "https://thoras-api-server-v2"
+            value: "http://thoras-api-server-v2"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
         resources:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -58,14 +58,14 @@ thorasApiServer:
   logLevel: "debug"
 
 thorasApiServerV2:
-  containerPort: 8443
+  containerPort: 8080
   podAnnotations: {}
   limits:
     memory: 2000Mi
   requests:
     cpu: 128m
     memory: 100Mi
-  port: 443
+  port: 80
   logLevel: "info"
 
 thorasDashboard:


### PR DESCRIPTION
# Why are we making this change?

I recently switched the dashboard to use the new api service layer, but there are TLS errors that break the fetching of data for the graphs on the dashboard. This PR switches off the TLS settings until I can figure out what the issue is. I'm not sure if it's an issue with the dashboard talking to the API service layer or something else.

Example error: 
```
thoras-api-server-v2-75bb7795c4-skzw8 thoras-v2-api-server 2024/10/18 15:22:19 http: TLS handshake error from 10.128.33.155:56608: EOF
```

# What's changing?

Turning off TLS for the API service layer. I filed https://github.com/thoras-ai/helm-charts/issues/69 to turn TLS back on