### PR TITLE
Allow specifying forecast cpu requests

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.0
+version: 4.2.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 # Install
 Using [Helm](https://helm.sh), you can easily install and test Thoras in a Kubernetes cluster by running the following:

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -46,6 +46,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.thorasForecast.requestCpu }}
+          - name: "FORECAST_RESOURCE_REQUESTS_CPU"
+            value: {{ .Values.thorasForecast.requestCpu | quote }}
+          {{- end }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
           - name: SLACK_WEBHOOK_URL

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -42,6 +42,10 @@ spec:
                 key: host
           - name: "THORAS_VERSION"
             value: {{ .Chart.Version | replace "+" "_" }}
+          {{- if .Values.thorasForecast.requestCpu }}
+          - name: "FORECAST_RESOURCE_REQUESTS_CPU"
+            value: {{ .Values.thorasForecast.requestCpu | quote }}
+          {{- end }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
           - name: SLACK_WEBHOOK_URL

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -93,4 +93,5 @@ thorasMonitor:
   podAnnotations: {}
   config: |
 
-thorasForecast: {}
+thorasForecast:
+  requestCpu:


### PR DESCRIPTION
# Why are we making this change?

Users may want to configure CPU requests for forecasts for various reasons

One consideration here is if a user sets a non-trivial cpu request it's always possible the forecast has to wait for autoscaler to spin up a new node which could add ~45-120 seconds to the time the forecast is allowed to start 

# What's changing?

Add conditional env var on the operator deployment that causes cpu request to be set on the forecast cron, if defined

We decided not to include limits or memory requests in this change to keep it simple and focused on current use-case