### PR TITLE
Bump default thorasVersion to 3.0.1

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "3.0.0"
+thorasVersion: "3.0.1"
 
 imageCredentials:
   registry: "us-east4-docker.pkg.dev/thoras-registry/platform"


### PR DESCRIPTION
# Why are we making this change?

We want the latest helm chart to use the latest stable Thoras version


# What's changing?

Defaulting Thoras version to latest stable, 3.0.1