### PR TITLE
Added FORECAST_IMAGE_PULL_POLICY env var to operator and dashboard

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -63,6 +63,8 @@ spec:
             value: "http://thoras-api-server-v2"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
+          - name: FORECAST_IMAGE_PULL_POLICY
+            value: "{{ .Values.imagePullPolicy }}"
         resources:
           limits:
             memory: {{ .Values.thorasDashboard.limits.memory }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -57,6 +57,8 @@ spec:
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
+          - name: FORECAST_IMAGE_PULL_POLICY
+            value: "{{ .Values.imagePullPolicy }}"
         args:
           - start
         resources:


### PR DESCRIPTION
# Why are we making this change?

To ensure consistency and maintainability across the platform, it is recommended to standardize the image pull policy for all components, including forecast cron jobs. Currently, the pull policy for these jobs differs from the rest of the platform, potentially leading to inconsistencies and operational difficulties.

# What's changing?

We are introducing a new environment variable, `FORECAST_IMAGE_PULL_POLICY`, within both the operator and dashboard containers. This variable is set to the helm value `imagePullPolicy`. No change is required for any current values files. This variable will be utilized when configuring the `imagePullPolicy` setting for the forecast cron job.

This change will ensure that the image pull policy for forecast cron jobs aligns with the platform's best practices, promoting consistency, reliability, and security. 
