### PR TITLE
Add forecast_buffer_percentage field

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -105,6 +105,8 @@ spec:
                         - type: integer
                         - type: string
                       x-kubernetes-int-or-string: true
+                    forecast_buffer_percentage:
+                      x-kubernetes-int-or-string: true
             status:
               type: object
               properties:


### PR DESCRIPTION
# Why are we making this change?

Users should have a way to define a "safety buffer" that gets added to their usage forecasts so that they can have increased confidence that there won't be disruption.

# What's changing?

Add `spec.mode.forecast_buffer_percentage` field to the `AIScaleTarget` CRD. Can be an integer or string
