### PR TITLE
Add Reasoning API component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   helm-unit-tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine if we're bumping the version
+        shell: bash
+        id: version_bump
+        run: |
+          if git diff origin/main -- charts/*/Chart.yaml | grep -E '^version:'; then
+            echo "is_bump=true" >> $GITHUB_ENV
+          else
+            echo "is_bump=false" >> $GITHUB_ENV
+          fi
+
       - name: Configure Git
+        if: steps.version_bump.outputs.is_bump == 'true'
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
+        if: steps.version_bump.outputs.is_bump == 'true'
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -1,0 +1,60 @@
+{{ if $.Values.thorasReasoningApi.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thoras-reasoning-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: thoras-reasoning-api
+  template:
+    metadata:
+      labels:
+        app: thoras-reasoning-api
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.thorasReasoningApi.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: thoras-collector
+      containers:
+      - image: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasReasoningApi.imageTag }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        name: thoras-reasoning-api
+        command: ["/usr/local/bin/reasoning_api"]
+        env:
+          - name: "ELASTICSEARCH_URL"
+            valueFrom:
+              secretKeyRef:
+                name: thoras-elastic-password
+                key: host
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookUrl
+          - name: SLACK_ERRORS_ENABLED
+            value: "{{ .Values.thorasReasoningApi.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+          - name: "LOGLEVEL"
+            value: {{ default .Values.logLevel .Values.thorasReasoningApi.logLevel }}
+        ports:
+        - containerPort: {{ .Values.thorasReasoningApi.containerPort }}
+        resources:
+          limits:
+            memory: {{ .Values.thorasReasoningApi.limits.memory }}
+          requests:
+            cpu: {{ .Values.thorasReasoningApi.requests.cpu }}
+            memory: {{ .Values.thorasReasoningApi.requests.memory }}
+{{ end }}

--- a/charts/thoras/templates/reasoning-api/service.yaml
+++ b/charts/thoras/templates/reasoning-api/service.yaml
@@ -1,0 +1,15 @@
+{{ if $.Values.thorasReasoningApi.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: thoras-reasoning-api
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: {{ .Values.thorasReasoningApi.port }}
+    protocol: TCP
+    targetPort: {{ .Values.thorasReasoningApi.containerPort }}
+  selector:
+    app: thoras-reasoning-api
+{{ end }}

--- a/charts/thoras/tests/component_not_enabled_test.yaml
+++ b/charts/thoras/tests/component_not_enabled_test.yaml
@@ -1,0 +1,19 @@
+suite: Deployments
+templates:
+  - reasoning-api/deployment.yaml
+set:
+  thorasVersion: 1.0.0-alpha
+tests:
+
+  - it: Renders Deployment when enabled
+    asserts:
+      - isKind:
+          of: Deployment
+    set:
+      thorasReasoningApi:
+        enabled: true
+
+  - it: Doesn't render Deployment when not enabled
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/thoras/tests/deployments_test.yaml
+++ b/charts/thoras/tests/deployments_test.yaml
@@ -6,8 +6,11 @@ templates:
   - dashboard/deployment.yaml
   # - monitor/deployment.yaml
   - operator/deployment.yaml
+  - reasoning-api/deployment.yaml
 set:
   thorasVersion: 1.0.0-alpha
+  thorasReasoningApi:
+    enabled: true
 tests:
   - it: Deployment name and image registry should be correct
     asserts:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -98,3 +98,14 @@ thorasForecast:
 
 thorasAgent:
   enabled: false
+
+thorasReasoningApi:
+  enabled: false
+  podAnnotations: {}
+  containerPort: 8080
+  port: 80
+  limits:
+    memory: 2048Mi
+  requests:
+    cpu: 128m
+    memory: 8Mi


### PR DESCRIPTION
# Why are we making this change?

We need to be able to deploy the Thoras Reasoning API

**It's currently disabled by default**

# What's changing?

* Add Thoras Reasoning API
* Fix CI config so that we only try to publish a new release when there's a new chart version
* Add unit tests