### PR TITLE
Run reasoning api via gunicorn in prod

### DIFF
--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -33,7 +33,15 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasReasoningApi.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-reasoning-api
-        command: ["/usr/local/bin/reasoning_api"]
+        command:
+          - "gunicorn"
+          - "--workers"
+          - "4"
+          - "-k"
+          - "gevent"
+          - "--bind"
+          - "0.0.0.0:8080"
+          - "forecast.api.routes:app"
         env:
           - name: "ELASTICSEARCH_URL"
             valueFrom:


### PR DESCRIPTION
# Why are we making this change?

Since python's single-threaded, Flask by itself is not sufficient for non-development use-cases. We need a WSGI server to act as a reverse proxy so concurrent HTTP calls are managed properly. Luckily this is a well-established pattern and easy to do

# What's changing?

Run reasoning API via gunicorn