### PR TITLE
Add environment variable for reasoning API endpoint

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -38,6 +38,8 @@ spec:
         name: thoras-v2-api-server
         command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
         env:
+          - name: SERVICE_REASONING_API_URL
+            value: "http://thoras-reasoning-api.thoras.svc.cluster.local"
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -45,14 +45,14 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
-          - name: SLACK_WEBHOOK_URL
+          - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
                 name: thoras-slack
                 key: webhookUrl
-          - name: SLACK_ERRORS_ENABLED
+          - name: SERVICE_SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasApiServerV2.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
-          - name: "LOGLEVEL"
+          - name: "SERVICE_LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
         volumeMounts:
           - name: tls


### PR DESCRIPTION
# Why are we making this change?

In order to talk to the internal reasoning API, we need to plumb an environment variable through to the service.

# What's changing?

Adding a `SERVICE_REASONING_API_URL` that points to the reasoning service. It's prefixed with `SERVICE_` because that's how the [huma cli](https://huma.rocks/features/cli/#passing-options) expects environment variables to be prefixed. 

Also fixing a couple other environment variables that were previously being handled by [envconfig](https://github.com/kelseyhightower/envconfig) but weren't changed when we switched them to huma.
