### PR TITLE
Added reasoning metrics list

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -274,7 +274,28 @@ spec:
                       x-kubernetes-int-or-string: true
                     forecast_buffer_percentage:
                       x-kubernetes-int-or-string: true
-
+                reasoning:
+                  type: object
+                  required:
+                    - metrics
+                  properties:
+                    metrics:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                            - type
+                            - name
+                            - query
+                        properties:
+                          type:
+                            type: string
+                            pattern: ^(prom)$
+                          name:
+                            type: string
+                            pattern: ^[a-zA-Z0-9_-]+$
+                          query:
+                            type: string
             status:
               type: object
               properties:

--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -284,16 +284,16 @@ spec:
                       items:
                         type: object
                         required:
-                            - type
+                            - connector
                             - name
                             - query
                         properties:
-                          type:
+                          connector:
                             type: string
-                            pattern: ^(prom)$
+                            pattern: '^(prometheus)$'
                           name:
                             type: string
-                            pattern: ^[a-zA-Z0-9_-]+$
+                            pattern: '^[a-zA-Z0-9_-]+$'
                           query:
                             type: string
             status:


### PR DESCRIPTION
# Why are we making this change?

Preparing the AIScaleTarget CRD for a new reasoning feature. 

# What's changing?

Added new `spec.reasoning.metrics` list that allows the user to configure where their custom metrics live and how to query them. 

Example:
```yaml
apiVersion: thoras.ai/v1
kind: AIScaleTarget
metadata:
  name: game-server
  namespace: battle-all-nite
spec:
  horizontal:
    mode: autonomous
  model:
    forecast_blocks: 60m
    forecast_cron: '*/15 * * * *'
    mode: balanced
  reasoning:
    metrics:
    - name: http_requests_total
      query: http_requests_total{environment=~"staging|testing|development",method!="GET"}
      connector: prometheus
  scaleTargetRef:
    kind: Deployment
    name: game-server
  vertical:
    mode: recommendation
```
