### PR TITLE
Move securityContext from pod to container

### DIFF
--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -41,13 +41,13 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+        securityContext:
+          # the agent requires elevated privileges to collect ebpf traces
+          privileged: true
       # drawn from https://github.com/kubeservice-stack/kubservice-charts/blob/6be7b9fb081abd2255dc83854dbed2d7d11e0973/charts/kubeservice-ebpf-exporter/values.yaml#L67-L69
       tolerations:
         - effect: NoSchedule
           operator: Exists
-      securityContext:
-        # the agent requires elevated privileges to collect ebpf traces
-        privileged: true
       # it may be desirable to set a high priority class to ensure that a DaemonSet Pod
       # preempts running Pods
       # priorityClassName: important


### PR DESCRIPTION
# Why are we making this change?

In order to collect eBPF metrics, the agent container must be running with `securityContext: privileged: true`, not the pod.

# What's changing?

I'm moving the `securityContext` block to the container from the pod. Without doing this, we get permission errors when starting the agent, like this:

```
time=2024-11-05T17:31:22.310Z level=ERROR msg="Failed to initialize collector" err="loading eBPF objects: field TcpCleanupRbuf: program tcp_cleanup_rbuf: load program: operation not permitted (MEMLOCK may be too low, consider rlimit.RemoveMemlock)"
panic: loading eBPF objects: field TcpCleanupRbuf: program tcp_cleanup_rbuf: load program: operation not permitted (MEMLOCK may be too low, consider rlimit.RemoveMemlock)
```
