### PR TITLE
External metrics crd

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -89,6 +89,167 @@ spec:
                                 x-kubernetes-int-or-string: true
                         required:
                           - name
+
+
+
+                scale_metrics:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        pattern: '^(Object|Resource|Pods|External)$'
+                      object:
+                        type: object
+                        required:
+                          - metric
+                          - describedObject
+                          - target
+                        properties:
+                          metric:
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                type: string
+                          describedObject:
+                            type: object
+                            required:
+                              - kind
+                              - name
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                          target:
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              type:
+                                type: string
+                                pattern: '^(Utilization|Value|AverageValue)$'
+                              averageUtilization:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              averageValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              value:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                      pods:
+                        type: object
+                        required:
+                          - metric
+                          - describedObject
+                          - target
+                        properties:
+                          metric:
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                type: string
+                          describedObject:
+                            type: object
+                            required:
+                              - kind
+                              - name
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                          target:
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              type:
+                                type: string
+                                pattern: '^(Utilization|Value|AverageValue)$'
+                              averageUtilization:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              averageValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              value:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                      resource:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              type:
+                                type: string
+                              averageUtilization:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              averageValue:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                      external:
+                        type: object
+                        required:
+                          - metric
+                          - target
+                        properties:
+                          metric:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                type: object
+                                properties:
+                                  matchLabels:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                          target:
+                            type: object
+                            properties:
+                              type:
+
+
                 model:
                   type: object
                   required:
@@ -107,6 +268,7 @@ spec:
                       x-kubernetes-int-or-string: true
                     forecast_buffer_percentage:
                       x-kubernetes-int-or-string: true
+
             status:
               type: object
               properties:

--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -89,9 +89,6 @@ spec:
                                 x-kubernetes-int-or-string: true
                         required:
                           - name
-
-
-
                 scale_metrics:
                   type: array
                   items:
@@ -234,6 +231,8 @@ spec:
                         properties:
                           metric:
                             type: object
+                            required:
+                              - name
                             properties:
                               name:
                                 type: string
@@ -246,10 +245,17 @@ spec:
                                       type: string
                           target:
                             type: object
+                            required:
+                              - type
                             properties:
                               type:
-
-
+                                type: string
+                              value:
+                                type: string
+                              averageValue:
+                                type: string
+                              averageUtilization:
+                                type: string
                 model:
                   type: object
                   required:


### PR DESCRIPTION
# Why are we making this change?

This enhancement introduces a new feature that allows Thoras users to specify metrics for the Thoras Forecaster to use for predictions and recommendations, independent of the metrics used by the target HPA for scaling.

# What's changing?

A new `spec.scale_metrics` property has been added to the AIScaleTarget CRD. Example configuration:

```
---
apiVersion: thoras.ai/v1
kind: AIScaleTarget
metadata:
  name: nginx-target
  namespace: keda
spec:
  horizontal:
    mode: recommendation
  model:
    forecast_buffer_percentage: 10%
    forecast_cron: '*/10 * * * *'
    mode: balanced
  scale_metrics:
  - external:
      metric:
        name: s0-aws-cloudwatch
        selector:
          matchLabels:
            scaledobject.keda.sh/name: rtb-bidder
      target:
        averageValue: "1"
        type: AverageValue
    type: External
  scaleTargetRef:
    kind: Deployment
    name: avg-deployment
```