### PR TITLE
Enable secret-by-reference

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -38,8 +38,6 @@ spec:
         name: thoras-v2-api-server
         command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
         env:
-          - name: SERVICE_REASONING_API_URL
-            value: "http://thoras-reasoning-api.thoras.svc.cluster.local"
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:
@@ -48,8 +46,15 @@ spec:
           - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
                 name: thoras-slack
                 key: webhookUrl
+            {{- end }}
+          - name: SERVICE_REASONING_API_URL
+            value: "http://thoras-reasoning-api.thoras.svc.cluster.local"
           - name: SERVICE_SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasApiServerV2.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "SERVICE_LOGLEVEL"

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -45,8 +45,13 @@ spec:
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
                 name: thoras-slack
                 key: webhookUrl
+            {{- end }}
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -107,8 +107,13 @@ spec:
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
                 name: thoras-slack
                 key: webhookUrl
+            {{- end }}
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/collector/rbac.yaml
+++ b/charts/thoras/templates/collector/rbac.yaml
@@ -10,7 +10,11 @@ metadata:
   name: thoras-collector
   namespace: {{ .Release.Namespace }}
 imagePullSecrets:
+{{- if .Values.imageCredentials.secretRef }}
+  - name: {{ .Values.imageCredentials.secretRef }}
+{{- else }}
   - name: thoras-secret-registry
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -37,6 +37,16 @@ spec:
         env:
           - name: "ES_INDEX"
             value: "thoras-metrics"
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
+                name: thoras-slack
+                key: webhookUrl
+            {{- end }}
           - name: "ES_HOST"
             valueFrom:
               secretKeyRef:
@@ -52,11 +62,6 @@ spec:
           {{- end }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
-          - name: SLACK_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                name: thoras-slack
-                key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: API_BASE_URL

--- a/charts/thoras/templates/dashboard/rbac.yaml
+++ b/charts/thoras/templates/dashboard/rbac.yaml
@@ -1,5 +1,22 @@
 {{- if and .Values.thorasDashboard.rbac.create .Values.thorasDashboard.enabled }}
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ .Values.thorasDashboard.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+imagePullSecrets:
+{{- if .Values.imageCredentials.secretRef }}
+  - name: {{ .Values.imageCredentials.secretRef }}
+{{- else }}
+  - name: thoras-secret-registry
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -82,19 +99,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["delete"]
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-  name: {{ .Values.thorasDashboard.serviceAccount.name }}
-  namespace: {{ .Release.Namespace }}
-imagePullSecrets:
-  - name: thoras-secret-registry
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -73,8 +73,13 @@ spec:
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
                 name: thoras-slack
                 key: webhookUrl
+            {{- end }}
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.slackWebhookUrl }}
 ---
 apiVersion: v1
 data:
@@ -5,3 +6,4 @@ data:
 kind: Secret
 metadata:
   name: thoras-slack
+{{- end }}

--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.slackWebhookUrl }}
+{{- if not .Values.slackWebhookUrlSecretRefName }}
 ---
 apiVersion: v1
 data:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -40,6 +40,16 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
+                name: thoras-slack
+                key: webhookUrl
+            {{- end }}
           - name: "THORAS_VERSION"
             value: {{ .Chart.Version | replace "+" "_" }}
           {{- if .Values.thorasForecast.requestCpu }}
@@ -48,11 +58,6 @@ spec:
           {{- end }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
-          - name: SLACK_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                name: thoras-slack
-                key: webhookUrl
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/operator/rbac.yaml
+++ b/charts/thoras/templates/operator/rbac.yaml
@@ -10,7 +10,11 @@ metadata:
   name: thoras-operator
   namespace: {{ .Release.Namespace }}
 imagePullSecrets:
+{{- if .Values.imageCredentials.secretRef }}
+  - name: {{ .Values.imageCredentials.secretRef }}
+{{- else }}
   - name: thoras-secret-registry
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -43,8 +43,13 @@ spec:
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
                 name: thoras-slack
                 key: webhookUrl
+            {{- end }}
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasReasoningApi.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/registry-secret.yaml
+++ b/charts/thoras/templates/registry-secret.yaml
@@ -1,5 +1,4 @@
-{{- /* The following line is a hack that enforces a required .Values.imageCredentials */}}
-{{- $_ := .Values.imageCredentials.password | required ".Values.imageCredentials.password is required." -}}
+{{- if .Values.imageCredentials.password }}
 ---
 apiVersion: v1
 kind: Secret
@@ -14,3 +13,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}

--- a/charts/thoras/templates/registry-secret.yaml
+++ b/charts/thoras/templates/registry-secret.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.imageCredentials.password .Values.imageCredentials.secretRef }}
+{{- fail "Error: Both '.Values.imageCredentials.password' and '.Values.imageCredentials.secretRef' are set, but only one should be defined" }}
+{{- end }}
 {{- if .Values.imageCredentials.password }}
 ---
 apiVersion: v1

--- a/charts/thoras/tests/secrets_collector_test.yaml
+++ b/charts/thoras/tests/secrets_collector_test.yaml
@@ -1,0 +1,27 @@
+suite: SecretsCollector
+tests:
+  - it: Points all apps to existing slack secret, if provided
+    templates:
+      - collector/deployment.yaml
+    set:
+      slackWebhookUrlSecretRefName: "frou-frou"
+      slackWebhookUrlSecretRefKey: "url"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.name
+          value: "frou-frou"
+      - equal:
+          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.key
+          value: "url"
+
+  - it: Points all apps to default slack secret, if no existing secret provided provided
+    templates:
+      - collector/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.name
+          value: "thoras-slack"
+      - equal:
+          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.key
+          value: "webhookUrl"
+

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -1,0 +1,60 @@
+suite: Secrets
+tests:
+  - it: Creates the registry secret if password is set
+    template: registry-secret.yaml
+    set:
+      imageCredentials:
+        password: "frou-frou"
+    asserts:
+      - isKind:
+          of: Secret
+  - it: Doesn't create the registry secret if secretRef set
+    template: registry-secret.yaml
+    set:
+      imageCredentials:
+        secretRef: "frou-frou"
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: Fails if both password and reference defined
+    template: registry-secret.yaml
+    set:
+      imageCredentials:
+        secretRef: "some-reference"
+        password: "blah"
+    asserts:
+      - failedTemplate: {}
+  - it: Uses the reference name if it's passed
+    templates:
+      - collector/rbac.yaml
+      - operator/rbac.yaml
+      - dashboard/rbac.yaml
+    set:
+      imageCredentials:
+        secretRef: "frou-frou"
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: imagePullSecrets[0].name
+          pattern: "frou-frou"
+
+
+
+      # - matchRegex:
+      #     path: spec.template.spec.containers[0].image
+      #     pattern: ^us-east4-docker\.pkg\.dev\/thoras-registry\/platform\/.*$
+  # - it: Should have helm recommended labels
+  #   template: monitor/deployment.yaml
+  #   asserts:
+  #     - equal:
+  #         path: metadata.labels["app.kubernetes.io/name"]
+  #         value: thoras
+  #     - matchRegex:
+  #         path: metadata.labels["helm.sh/chart"]
+  #         pattern: ^thoras-\d\.\d\.\d$
+  #     - equal:
+  #         path: metadata.labels["app.kubernetes.io/managed-by"]
+  #         value: Helm
+  #     - equal:
+  #         path: metadata.labels["app.kubernetes.io/instance"]
+  #         value: RELEASE-NAME

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -34,27 +34,53 @@ tests:
         secretRef: "frou-frou"
     documentIndex: 0
     asserts:
-      - matchRegex:
+      - equal:
           path: imagePullSecrets[0].name
-          pattern: "frou-frou"
+          value: "frou-frou"
 
+# Collector has its own tests for this
+  - it: Points all apps to existing slack secret, if provided
+    templates:
+      - api-server/deployment.yaml
+      - api-server-v2/deployment.yaml
+      - dashboard/deployment.yaml
+      - monitor/deployment.yaml
+      - operator/deployment.yaml
+      - reasoning-api/deployment.yaml
+    set:
+      slackWebhookUrlSecretRefName: "frou-frou"
+      slackWebhookUrlSecretRefKey: "url"
+      thorasMonitor:
+        enabled: true
+      thorasReasoningApi:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: "frou-frou"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: "url"
 
+  - it: Points all apps to default slack secret, if no existing secret provided provided
+    templates:
+      - api-server/deployment.yaml
+      - api-server-v2/deployment.yaml
+      # - collector/deployment.yaml
+      - dashboard/deployment.yaml
+      - monitor/deployment.yaml
+      - operator/deployment.yaml
+      - reasoning-api/deployment.yaml
+    set:
+      thorasMonitor:
+        enabled: true
+      thorasReasoningApi:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: "thoras-slack"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: "webhookUrl"
 
-      # - matchRegex:
-      #     path: spec.template.spec.containers[0].image
-      #     pattern: ^us-east4-docker\.pkg\.dev\/thoras-registry\/platform\/.*$
-  # - it: Should have helm recommended labels
-  #   template: monitor/deployment.yaml
-  #   asserts:
-  #     - equal:
-  #         path: metadata.labels["app.kubernetes.io/name"]
-  #         value: thoras
-  #     - matchRegex:
-  #         path: metadata.labels["helm.sh/chart"]
-  #         pattern: ^thoras-\d\.\d\.\d$
-  #     - equal:
-  #         path: metadata.labels["app.kubernetes.io/managed-by"]
-  #         value: Helm
-  #     - equal:
-  #         path: metadata.labels["app.kubernetes.io/instance"]
-  #         value: RELEASE-NAME

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -22,11 +22,17 @@ imagePullPolicy: "IfNotPresent"
 
 logLevel: info
 
+# Enable Slack errors
+slackErrorsEnabled: false
+
 # Set Slack notification Webhook URL directly (or alternatively use
 # use slackWebhookUrlSecretRef to reference an existing secret
 slackWebhookUrl: ""
-slackWebhookUrlSecretRef: ""
-slackErrorsEnabled: false
+
+# If you'd like to reference an existing secret, use these two values
+# to indicate the secret name and data key
+slackWebhookUrlSecretRefName: ""
+slackWebhookUrlSecretRefKey: ""
 
 thorasOperator:
   podAnnotations: {}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -4,7 +4,13 @@ thorasVersion: "3.2.0"
 imageCredentials:
   registry: "us-east4-docker.pkg.dev/thoras-registry/platform"
   username: "_json_key_base64"
+
+  # Set the license key directly as a variable (or alternatively
+  # use imageCredentials.secretRef to reference an existing secret
   password: ""
+
+  # Reference a pre-existing secret in the Thoras namespace
+  secretRef: ""
 
 resourceQuota:
   enabled: false
@@ -15,7 +21,11 @@ resourceQuota:
 imagePullPolicy: "IfNotPresent"
 
 logLevel: info
+
+# Set Slack notification Webhook URL directly (or alternatively use
+# use slackWebhookUrlSecretRef to reference an existing secret
 slackWebhookUrl: ""
+slackWebhookUrlSecretRef: ""
 slackErrorsEnabled: false
 
 thorasOperator:


### PR DESCRIPTION
# Why are we making this change?

A common pattern that some customers expect is the ability to reference existing secrets instead of passing in sensitive values to the helm chart for secret population.

# What's changing?

* Make it possible to reference an existing registry secret
* Make it possible to reference an existing Slack URL secret
* Add unit tests

# Notes

* I re-ordered some env vars to make the Slack env variables in a consistent order. Shouldn't hurt anything
* Implementing Prometheus endpoint env var for reasoning-api directly after this
