### PR TITLE
Add configurable prometheus base URL for reasoning api

### DIFF
--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -54,6 +54,8 @@ spec:
             value: "{{ .Values.thorasReasoningApi.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasReasoningApi.logLevel }}
+          - name: "PROMETHEUS_BASE_URL"
+            value: {{ .Values.thorasReasoningApi.connectors.prometheus.baseUrl }}
         ports:
         - containerPort: {{ .Values.thorasReasoningApi.containerPort }}
         resources:

--- a/charts/thoras/tests/reasoning_api_deployment_test.yaml
+++ b/charts/thoras/tests/reasoning_api_deployment_test.yaml
@@ -1,0 +1,15 @@
+suite: Reasoning
+tests:
+  - it: Set prometheus URL correctly
+    templates:
+      - reasoning-api/deployment.yaml
+    set:
+      thorasReasoningApi:
+        enabled: true
+        connectors:
+          prometheus:
+            baseUrl: "http://whats-good"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[4].value
+          value: "http://whats-good"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -125,3 +125,6 @@ thorasReasoningApi:
   requests:
     cpu: 128m
     memory: 8Mi
+  connectors:
+    prometheus:
+      baseUrl: "http://localhost"


### PR DESCRIPTION
# Why are we making this change?

* Customers need the ability to configure their prometheus base URL for us to ingest prome metrics

# What's changing?

* Give customers the ability to configure prometheus base endpoint via  `thorasReasoningApi.connectors.prometheus.baseUrl` value

# Callouts

* This is a smallest useful thing -- we talked about probably needing something more sophisticated for managing connector config in the long term

