### PR TITLE
Migrate to go collector

### DIFF
--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -14,11 +14,11 @@ spec:
           serviceAccountName: thoras-collector
           restartPolicy: OnFailure
           containers:
-          - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
+          - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
             name: metrics-collector
             imagePullPolicy: "{{ .Values.imagePullPolicy }}"
             env:
-              - name: "ES_HOST"
+              - name: "ELASTICSEARCH_URL"
                 valueFrom:
                   secretKeyRef:
                     name: thoras-elastic-password
@@ -35,7 +35,5 @@ spec:
             command: ["/bin/sh", "-c"]
             args:
               - |
-                node index.js \
-                purge \
-                --es=${ES_HOST} \
+                ./metrics-collector purge metrics \
                 --ttl={{ .Values.metricsCollector.purge.ttl }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -70,17 +70,16 @@ spec:
           runAsUser: 1000
           runAsGroup: 0
         {{- end }}
-      - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
+      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: {{ .Values.metricsCollector.collector.name }}
         command: ["/bin/sh", "-c"]
         args:
           - |
-            # Don't start app until ES is available
             retries=0
             max_retries=48
             until [ $retries -eq $max_retries ]; do
-              if curl -s --connect-timeout 5 --fail -XGET ${ES_HOST}; then
+              if wget --spider -T 5 -q ${ELASTICSEARCH_URL}; then
                 echo "elasticsearch ready"
                 break
               else
@@ -93,13 +92,13 @@ spec:
                 echo "fatal: giving up on elasticsearch availability"
                 exit 1
             fi
-            node index.js start --es=${ES_HOST}
+            ./metrics-collector collect -c 60
         env:
           - name: THORAS_NS
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: "ES_HOST"
+          - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:
                 name: thoras-elastic-password

--- a/charts/thoras/templates/collector/purge-forecast-hook.yaml
+++ b/charts/thoras/templates/collector/purge-forecast-hook.yaml
@@ -16,8 +16,10 @@ spec:
       serviceAccountName: thoras-operator
       restartPolicy: OnFailure
       containers:
-      - image: {{ .Values.imageCredentials.registry }}/thoras-collector:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
+      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
         name: metrics-collector
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command: ["/bin/sh", "-c"]
         args:
-          - purgeCronjobs
+          - |
+            ./metrics-collector purge cronjobs

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -22,11 +22,10 @@ Default containers should match snapshots:
   2: |
     args:
       - |
-        # Don't start app until ES is available
         retries=0
         max_retries=48
         until [ $retries -eq $max_retries ]; do
-          if curl -s --connect-timeout 5 --fail -XGET ${ES_HOST}; then
+          if wget --spider -T 5 -q ${ELASTICSEARCH_URL}; then
             echo "elasticsearch ready"
             break
           else
@@ -39,7 +38,7 @@ Default containers should match snapshots:
             echo "fatal: giving up on elasticsearch availability"
             exit 1
         fi
-        node index.js start --es=${ES_HOST}
+        ./metrics-collector collect -c 60
     command:
       - /bin/sh
       - -c
@@ -48,7 +47,7 @@ Default containers should match snapshots:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      - name: ES_HOST
+      - name: ELASTICSEARCH_URL
         valueFrom:
           secretKeyRef:
             key: host
@@ -62,6 +61,6 @@ Default containers should match snapshots:
         value: "false"
       - name: LOGLEVEL
         value: info
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-collector:dev
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     name: thoras-collector

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.12.1
       - equal:
           path: spec.template.spec.containers[1].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-collector:TEST
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
   - it: Default containers should match snapshots
     set:
       thorasVersion: dev

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -57,7 +57,7 @@ metricsCollector:
     name: elasticsearch
     containerPort: 9200
   purge:
-    ttl: 30d
+    ttl: 30
     schedule: "00 00 * * *"
   init:
     imageTag: "latest"


### PR DESCRIPTION
# Why are we making this change?

Migrating to a newer better metrics collector 

# What's changing?

Removing old metrics collector image in favor of a newer one. 