### PR TITLE
Make PVC requests.storage configurable

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -82,6 +82,7 @@ helm install \
 | metricsCollector.persistence.volumeName | String | "" | PV name for PVC. Keep blank if using dynamic provisioning |
 | metricsCollector.persistence.createEFSStorageClass.fileSystemId | String | "" | Create dynamic PV provisioner for EFS by specifying EFS id  |
 | metricsCollector.persistence.storageClassName | String | "" | Storage class for PVC |
+| metricsCollector.persistence.pvcStorageRequestSize | String | "3Gi" | Inform PV backend of minimal volume requirements |
 | metricsCollector.collector.name | String | thoras-collector | Thoras collector container name |
 | metricsCollector.collector.logLevel | String | Nil | Logging level |
 | metricsCollector.podAnnotations | Object | {} | Pod Annotations for Thoras metrics collector  |

--- a/charts/thoras/templates/collector/pvc.yaml
+++ b/charts/thoras/templates/collector/pvc.yaml
@@ -19,5 +19,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 3Gi
+      storage: {{ .Values.metricsCollector.persistence.pvcStorageRequestSize }}
 {{- end }}

--- a/charts/thoras/tests/pvc_test.yaml
+++ b/charts/thoras/tests/pvc_test.yaml
@@ -1,0 +1,34 @@
+suite: PersistentVolumeClaim
+tests:
+  - it: Interpolates PVC storage request size
+    templates:
+      - collector/pvc.yaml
+    set:
+      metricsCollector:
+        persistence:
+          enabled: true
+          pvcStorageRequestSize: "10Gi"
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: "10Gi"
+
+  - it: Interpolates default PVC storage request size
+    templates:
+      - collector/pvc.yaml
+    set:
+      metricsCollector:
+        persistence:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: "3Gi"
+
+  - it: Doesn't create PVC by default
+    templates:
+      - collector/pvc.yaml
+    set:
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -49,6 +49,7 @@ metricsCollector:
     storageClassName: "efs-sc-thoras"
     createEFSStorageClass:
       fileSystemId: ""
+    pvcStorageRequestSize: "3Gi"
   podAnnotations: {}
   collector:
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?

Users need to be able to specify `spec.resources.requests.storage` on their PVC -- especially in case they're using a fixed storage size backend (such as AWS EBS)

# What's changing?

* Make `spec.resources.requests.storage` configurable
* Default to "3Gi"
* Add unit tests
* Update documentation
