### PR TITLE
Add API_BASE_URL environment var to other deployments

### DIFF
--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -42,8 +42,6 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2"
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
@@ -58,6 +56,8 @@ spec:
             value: "{{ .Values.thorasApiServer.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasApiServer.logLevel }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
         volumeMounts:
           - name: tls
             mountPath: /apps/packages/thoras-external-metrics-server/cert.pem

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -98,6 +98,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -98,8 +98,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2"
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:
@@ -119,3 +117,5 @@ spec:
             value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -64,10 +64,10 @@ spec:
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasDashboard.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasDashboard.logLevel }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: FORECAST_IMAGE_PULL_POLICY
             value: "{{ .Values.imagePullPolicy }}"
         resources:

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -70,8 +70,6 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2"
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
@@ -86,4 +84,6 @@ spec:
             value: "{{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
 {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -58,12 +58,12 @@ spec:
           {{- end }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2"
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: FORECAST_IMAGE_PULL_POLICY
             value: "{{ .Values.imagePullPolicy }}"
         args:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -58,6 +58,8 @@ spec:
           {{- end }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -54,10 +54,10 @@ spec:
             value: "{{ .Values.thorasReasoningApi.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasReasoningApi.logLevel }}
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2"
           - name: "PROMETHEUS_BASE_URL"
             value: {{ .Values.thorasReasoningApi.connectors.prometheus.baseUrl }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
         ports:
         - containerPort: {{ .Values.thorasReasoningApi.containerPort }}
         resources:

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -35,6 +35,8 @@ spec:
         name: thoras-reasoning-api
         command: ["/usr/local/bin/reasoning_api"]
         env:
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -35,8 +35,6 @@ spec:
         name: thoras-reasoning-api
         command: ["/usr/local/bin/reasoning_api"]
         env:
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2"
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:
@@ -56,6 +54,8 @@ spec:
             value: "{{ .Values.thorasReasoningApi.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasReasoningApi.logLevel }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
           - name: "PROMETHEUS_BASE_URL"
             value: {{ .Values.thorasReasoningApi.connectors.prometheus.baseUrl }}
         ports:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -61,6 +61,8 @@ Default containers should match snapshots:
         value: "false"
       - name: LOGLEVEL
         value: info
+      - name: API_BASE_URL
+        value: http://thoras-api-server-v2
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?

We need to plumb the `API_BASE_URL` to the API service layer to all the deployments that will use the service layer.

# What's changing?

Adding an environment variable `API_BASE_URL` to deployments in addition to the `dashboard` deployment.
