### PR TITLE
Make helm unit tests more flexible with environment variable checks

### DIFF
--- a/charts/thoras/tests/reasoning_api_deployment_test.yaml
+++ b/charts/thoras/tests/reasoning_api_deployment_test.yaml
@@ -11,5 +11,5 @@ tests:
             baseUrl: "http://whats-good"
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[4].value
+          path: $..spec.containers[0].env[?(@.name == 'PROMETHEUS_BASE_URL')].value
           value: "http://whats-good"

--- a/charts/thoras/tests/secrets_collector_test.yaml
+++ b/charts/thoras/tests/secrets_collector_test.yaml
@@ -8,10 +8,10 @@ tests:
       slackWebhookUrlSecretRefKey: "url"
     asserts:
       - equal:
-          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.name
+          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
           value: "frou-frou"
       - equal:
-          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.key
+          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
           value: "url"
 
   - it: Points all apps to default slack secret, if no existing secret provided provided
@@ -19,9 +19,9 @@ tests:
       - collector/deployment.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.name
+          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
           value: "thoras-slack"
       - equal:
-          path: spec.template.spec.containers[1].env[2].valueFrom.secretKeyRef.key
+          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
           value: "webhookUrl"
 

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -56,17 +56,17 @@ tests:
         enabled: true
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          path: $..spec.containers[0].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name
           value: "frou-frou"
       - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          path: $..spec.containers[0].env[?(@.name =~ /SLACK_WEBHOOK_URL/)].valueFrom.secretKeyRef.key
           value: "url"
 
   - it: Points all apps to default slack secret, if no existing secret provided provided
     templates:
       - api-server/deployment.yaml
       - api-server-v2/deployment.yaml
-      # - collector/deployment.yaml
+      - collector/deployment.yaml
       - dashboard/deployment.yaml
       - monitor/deployment.yaml
       - operator/deployment.yaml
@@ -78,9 +78,9 @@ tests:
         enabled: true
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          path: $..spec.containers[-1].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name
           value: "thoras-slack"
       - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          path: $..spec.containers[-1].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.key
           value: "webhookUrl"
 


### PR DESCRIPTION
# Why are we making this change?

When adding a new environment variable for some services, I was burned by tests that were too rigid in the expected order of environment variables.

# What's changing?

Updating some tests to care less about the index of environment variables and more about what the environment variables look like, using [jsonpath](https://github.com/json-path/JsonPath)
