### PR TITLE
Default to single replica for services

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: 3
+  replicas: {{ .Values.thorasApiServerV2.replicas }}
   selector:
     matchLabels:
       app: thoras-api-server-v2

--- a/charts/thoras/templates/api-server/deployment.yaml
+++ b/charts/thoras/templates/api-server/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: 3
+  replicas: {{ .Values.thorasApiServer.replicas }}
   selector:
     matchLabels:
       app: thoras-api-server

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: thoras-operator
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.thorasOperator.replicas }}
   selector:
     matchLabels:
       app: thoras-operator

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.thorasReasoningApi.replicas }}
   selector:
     matchLabels:
       app: thoras-reasoning-api

--- a/charts/thoras/tests/dashboard_deployment_test.yaml
+++ b/charts/thoras/tests/dashboard_deployment_test.yaml
@@ -5,6 +5,8 @@ tests:
   - it: Deployment name and image should be correct
     set:
       thorasVersion: TEST
+      thorasDashboard:
+        replicas: 12
     asserts:
       - isKind:
           of: Deployment
@@ -14,3 +16,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard:TEST
+      - equal:
+          path: spec.replicas
+          value: 12

--- a/charts/thoras/tests/deployments_test.yaml
+++ b/charts/thoras/tests/deployments_test.yaml
@@ -11,6 +11,15 @@ set:
   thorasVersion: 1.0.0-alpha
   thorasReasoningApi:
     enabled: true
+    replicas: 12
+  thorasOperator:
+    replicas: 12
+  thorasDashboard:
+    replicas: 12
+  thorasApiServer:
+    replicas: 12
+  thorasApiServerV2:
+    replicas: 12
 tests:
   - it: Deployment name and image registry should be correct
     asserts:
@@ -38,3 +47,8 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
           value: RELEASE-NAME
+  - it: Sets replicas
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 12

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -35,6 +35,8 @@ slackWebhookUrlSecretRefName: ""
 slackWebhookUrlSecretRefKey: ""
 
 thorasOperator:
+  # Operator is a singleton -- don't change this :)
+  replicas: 1
   podAnnotations: {}
   limits:
     memory: 2000Mi
@@ -65,6 +67,7 @@ metricsCollector:
 
 thorasApiServer:
   containerPort: 8443
+  replicas: 1
   podAnnotations: {}
   limits:
     memory: 2000Mi
@@ -77,6 +80,7 @@ thorasApiServer:
 thorasApiServerV2:
   containerPort: 8080
   podAnnotations: {}
+  replicas: 1
   limits:
     memory: 2000Mi
   requests:
@@ -100,7 +104,7 @@ thorasDashboard:
     cpu: 100m
     memory: 100Mi
   port: 80
-  replicas: 3
+  replicas: 1
   service:
     type: ClusterIP
     annotations: {}


### PR DESCRIPTION
# Why are we making this change?

The best practice for open source helm charts is to default deployments to 1 replica because:

- Letting the user decide what they need is more aligned with a user-driven config approach, which is more ideal
- It's less expensive
- Avoids premature scaling
- Is easier to understand and navigate for new users

# What's changing?

Default replicas to 1 for all `Deployments`