### PR TITLE
Configure operator to use correct namespace

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -58,6 +58,10 @@ spec:
           {{- end }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
+          - name: THORAS_NS
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"


### PR DESCRIPTION
# Why are we making this change?

Users can configure which namespace to run Thoras in. That config needs to propagate to the operator to ensure CronJobs get created in the correct namespace

# What's changing?

Pass user-defined Thoras namespace into the operator env var