### PR TITLE
Update ast metric

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -214,48 +214,60 @@ spec:
                                     type: string
                                   averageUtilization:
                                     type: string
-                  vertical:
-                    type: object
-                    required:
-                      - mode
-                    properties:
-                      mode:
-                        type: string
-                      containers:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                            cpu:
-                              type: object
-                              properties:
-                                lowerbound:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                upperbound:
+                    exclude_metrics:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - name
+                          - type
+                        properties:
+                          name:
+                            type: string
+                          type:
+                            type: string
+                vertical:
+                  type: object
+                  required:
+                    - mode
+                  properties:
+                    mode:
+                      type: string
+                    containers:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          cpu:
+                            type: object
+                            properties:
+                              lowerbound:
                                   anyOf:
                                     - type: integer
                                     - type: string
                                   x-kubernetes-int-or-string: true
-                            memory:
-                              type: object
-                              properties:
-                                lowerbound:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                                upperbound:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                          required:
-                            - name
+                              upperbound:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          memory:
+                            type: object
+                            properties:
+                              lowerbound:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              upperbound:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                        required:
+                          - name
                 model:
                   type: object
                   required:

--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -47,215 +47,215 @@ spec:
                   properties:
                     mode:
                       type: string
-                vertical:
-                  type: object
-                  required:
-                    - mode
-                  properties:
-                    mode:
-                      type: string
-                    containers:
+                    additional_metrics:
                       type: array
                       items:
                         type: object
                         properties:
-                          name:
+                          type:
                             type: string
-                          cpu:
+                            pattern: '^(Object|Resource|Pods|External)$'
+                          object:
+                            type: object
+                            required:
+                              - metric
+                              - describedObject
+                              - target
+                            properties:
+                              metric:
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    type: string
+                              describedObject:
+                                type: object
+                                required:
+                                  - kind
+                                  - name
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                              target:
+                                type: object
+                                required:
+                                  - type
+                                properties:
+                                  type:
+                                    type: string
+                                    pattern: '^(Utilization|Value|AverageValue)$'
+                                  averageUtilization:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                          pods:
+                            type: object
+                            required:
+                              - metric
+                              - describedObject
+                              - target
+                            properties:
+                              metric:
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    type: string
+                              describedObject:
+                                type: object
+                                required:
+                                  - kind
+                                  - name
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              target:
+                                type: object
+                                required:
+                                  - type
+                                properties:
+                                  type:
+                                    type: string
+                                    pattern: '^(Utilization|Value|AverageValue)$'
+                                  averageUtilization:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                          resource:
                             type: object
                             properties:
-                              lowerbound:
+                              name:
+                                type: string
+                              target:
+                                type: object
+                                required:
+                                  - type
+                                properties:
+                                  type:
+                                    type: string
+                                  averageUtilization:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  averageValue:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                          external:
+                            type: object
+                            required:
+                              - metric
+                              - target
+                            properties:
+                              metric:
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    type: object
+                                    properties:
+                                      matchLabels:
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                              target:
+                                type: object
+                                required:
+                                  - type
+                                properties:
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                  averageValue:
+                                    type: string
+                                  averageUtilization:
+                                    type: string
+                  vertical:
+                    type: object
+                    required:
+                      - mode
+                    properties:
+                      mode:
+                        type: string
+                      containers:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            cpu:
+                              type: object
+                              properties:
+                                lowerbound:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                upperbound:
                                   anyOf:
                                     - type: integer
                                     - type: string
                                   x-kubernetes-int-or-string: true
-                              upperbound:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                          memory:
-                            type: object
-                            properties:
-                              lowerbound:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                              upperbound:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                        required:
-                          - name
-                scale_metrics:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                        pattern: '^(Object|Resource|Pods|External)$'
-                      object:
-                        type: object
-                        required:
-                          - metric
-                          - describedObject
-                          - target
-                        properties:
-                          metric:
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                type: string
-                              selector:
-                                type: string
-                          describedObject:
-                            type: object
-                            required:
-                              - kind
-                              - name
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                          target:
-                            type: object
-                            required:
-                              - type
-                            properties:
-                              type:
-                                type: string
-                                pattern: '^(Utilization|Value|AverageValue)$'
-                              averageUtilization:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                              averageValue:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                              value:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                      pods:
-                        type: object
-                        required:
-                          - metric
-                          - describedObject
-                          - target
-                        properties:
-                          metric:
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                type: string
-                              selector:
-                                type: string
-                          describedObject:
-                            type: object
-                            required:
-                              - kind
-                              - name
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                              namespace:
-                                type: string
-                          target:
-                            type: object
-                            required:
-                              - type
-                            properties:
-                              type:
-                                type: string
-                                pattern: '^(Utilization|Value|AverageValue)$'
-                              averageUtilization:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                              averageValue:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                              value:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                      resource:
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                          target:
-                            type: object
-                            required:
-                              - type
-                            properties:
-                              type:
-                                type: string
-                              averageUtilization:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              averageValue:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                      external:
-                        type: object
-                        required:
-                          - metric
-                          - target
-                        properties:
-                          metric:
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                type: string
-                              selector:
-                                type: object
-                                properties:
-                                  matchLabels:
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                          target:
-                            type: object
-                            required:
-                              - type
-                            properties:
-                              type:
-                                type: string
-                              value:
-                                type: string
-                              averageValue:
-                                type: string
-                              averageUtilization:
-                                type: string
+                            memory:
+                              type: object
+                              properties:
+                                lowerbound:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                upperbound:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                          required:
+                            - name
                 model:
                   type: object
                   required:


### PR DESCRIPTION
# Why are we making this change?

This change addresses user requests for the ability to exclude metrics from AIScale while retaining the functionality of Horizontal Pod Autoscaling (HPA) based on those same metrics.  This allows for more granular control over resource management and scaling.


# What's changing?

The `exclude_metrics` field has been added to the `spec.horizontal` section of the configuration, allowing users to specify metrics to exclude from AIScale.  The supported metric types are: `External`, `Resource`, and `Object`.  An example configuration is shown below:

```yaml
    exclude_metrics:
      - type: External
        name: aws-alb-latency
      - type: Resource
        name: cpu
      - type: Object
        name: requests-per-second
```

Furthermore, the `spec.scale_metrics` field has been relocated to `spec.horizontal` for improved configuration organization and clarity.
