### PR TITLE
Add timescale migration init container using goose

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -32,6 +32,27 @@ spec:
         - name: tls
           secret:
             secretName: thoras-api-server-cert
+      {{- if .Values.metricsCollector.timescale.enabled }}
+      initContainers:
+      - name: migrate-database
+        image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.migration.imageTag }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            until /app/goose up -dir /app/migrations/
+            do
+              echo "Waiting for timescaledb...";
+              sleep 10
+            done
+        env:
+          - name: GOOSE_DRIVER
+            value: postgres
+          - name: GOOSE_DBSTRING
+            valueFrom:
+              secretKeyRef:
+                name: thoras-timescale-password
+                key: host
+      {{- end}}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -59,8 +59,10 @@ spec:
             value: "true"
           - name: bootstrap.memory_lock
             value: "false"
+          {{- if .Values.metricsCollector.persistence.enabled }}
           - name: path.data
             value: /var/lib/share/elasticsearch/data
+          {{- end}}
           - name: "ELASTIC_PASSWORD"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -9,8 +9,6 @@ Default containers should match snapshots:
         value: "true"
       - name: bootstrap.memory_lock
         value: "false"
-      - name: path.data
-        value: /var/lib/share/elasticsearch/data
       - name: ELASTIC_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
# Why are we making this change?

We need an init container that will migrate timescale database versions.

# What's changing?

I'm adding an init container that will wait for timescaledb and then migrate the database versions. I put the init container on the v2 service because (a) the migrations will likely be associated with a API service layer change and (b) because the init container can't be in the same deployment as the timescaledb container because it requires timescaledb to be up and running before it can run.
