### PR TITLE
Use dbmate to migrate database

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -32,12 +32,36 @@ spec:
         - name: tls
           secret:
             secretName: thoras-api-server-cert
+      {{- if .Values.metricsCollector.timescale.enabled }}
+      initContainers:
+      - name: migrate-database
+        image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.migration.imageTag }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            until /app/dbmate --migrations-dir /app/migrations/ migrate
+            do
+              echo "Waiting for timescaledb...";
+              sleep 10
+            done
+        env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: thoras-timescale-password
+                key: host
+      {{- end}}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-v2-api-server
         command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
         env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: thoras-timescale-password
+                key: host
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -32,36 +32,19 @@ spec:
         - name: tls
           secret:
             secretName: thoras-api-server-cert
-      {{- if .Values.metricsCollector.timescale.enabled }}
-      initContainers:
-      - name: migrate-database
-        image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.migration.imageTag }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            until /app/dbmate --migrations-dir /app/migrations/ migrate
-            do
-              echo "Waiting for timescaledb...";
-              sleep 10
-            done
-        env:
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: thoras-timescale-password
-                key: host
-      {{- end}}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-v2-api-server
         command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
         env:
-          - name: DATABASE_URL
+          - name: DATABASE_HOST
             valueFrom:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: host
+          - name: DATABASE_URL
+            value: "$(DATABASE_HOST)/thoras"
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -59,8 +59,10 @@ spec:
             value: "true"
           - name: bootstrap.memory_lock
             value: "false"
+          {{- if .Values.metricsCollector.persistence.enabled }}
           - name: path.data
             value: /var/lib/share/elasticsearch/data
+          {{- end}}
           - name: "ELASTIC_PASSWORD"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -121,6 +121,12 @@ spec:
                 echo "fatal: giving up on elasticsearch availability"
                 exit 1
             fi
+        {{- if .Values.metricsCollector.timescale.enabled }}
+            # try to create the "thoras" database if it doesn't exist
+            psql ${DATABASE_HOST} -tc "SELECT 1 FROM pg_database WHERE datname = 'thoras'" | grep -q 1 || psql ${DATABASE_HOST} -c "CREATE DATABASE thoras"
+            # run any migrations, accounting for upgrade/downgrade scenarios
+            ./scripts/migrate_database.sh
+        {{- end}}
             ./metrics-collector collect -c 60
         env:
           - name: THORAS_NS
@@ -148,3 +154,10 @@ spec:
             value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
+          - name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: thoras-timescale-password
+                key: host
+          - name: DATABASE_URL
+            value: "$(DATABASE_HOST)/thoras?sslmode=disable"

--- a/charts/thoras/templates/collector/secret.yaml
+++ b/charts/thoras/templates/collector/secret.yaml
@@ -21,4 +21,4 @@ data:
   {{- $secretData := (get $secretObj "data") | default dict }}
   {{- $pgPassword := (get $secretData "password") | default ((.Values.metricsCollector.timescale.password | default $newPgPassword) | b64enc) }}
   password: {{ $pgPassword | quote }}
-  host: {{ (printf "postgres://postgres:%s@%s:%d?sslmode=disable" ($pgPassword | b64dec) .Values.metricsCollector.timescale.name (.Values.metricsCollector.timescale.containerPort | int)) | b64enc | quote }}
+  host: {{ (printf "postgres://postgres:%s@%s:%d" ($pgPassword | b64dec) .Values.metricsCollector.timescale.name (.Values.metricsCollector.timescale.containerPort | int)) | b64enc | quote }}

--- a/charts/thoras/templates/collector/secret.yaml
+++ b/charts/thoras/templates/collector/secret.yaml
@@ -21,4 +21,4 @@ data:
   {{- $secretData := (get $secretObj "data") | default dict }}
   {{- $pgPassword := (get $secretData "password") | default ((.Values.metricsCollector.timescale.password | default $newPgPassword) | b64enc) }}
   password: {{ $pgPassword | quote }}
-  host: {{ (printf "postgres://postgres:%s@%s:%d" ($pgPassword | b64dec) .Values.metricsCollector.timescale.name (.Values.metricsCollector.timescale.containerPort | int)) | b64enc | quote }}
+  host: {{ (printf "postgres://postgres:%s@%s:%d?sslmode=disable" ($pgPassword | b64dec) .Values.metricsCollector.timescale.name (.Values.metricsCollector.timescale.containerPort | int)) | b64enc | quote }}

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -9,8 +9,6 @@ Default containers should match snapshots:
         value: "true"
       - name: bootstrap.memory_lock
         value: "false"
-      - name: path.data
-        value: /var/lib/share/elasticsearch/data
       - name: ELASTIC_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -63,6 +63,13 @@ Default containers should match snapshots:
         value: info
       - name: API_BASE_URL
         value: http://thoras-api-server-v2
+      - name: DATABASE_HOST
+        valueFrom:
+          secretKeyRef:
+            key: host
+            name: thoras-timescale-password
+      - name: DATABASE_URL
+        value: $(DATABASE_HOST)/thoras?sslmode=disable
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?

We need an init container that will migrate timescale database versions.

# What's changing?

I'm adding an init container that will wait for timescaledb and then migrate the database versions. I put the init container on the v2 service because (a) the migrations will likely be associated with a API service layer change and (b) because the init container can't be in the same deployment as the timescaledb container because it requires timescaledb to be up and running before it can run.