### PR TITLE
Add prometheus api URL to service layer environment

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -59,6 +59,8 @@ spec:
             value: "{{ .Values.thorasApiServerV2.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "SERVICE_LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
+          - name: "SERVICE_PROMETHEUS_API_URL"
+            value: {{ .Values.thorasReasoning.connectors.prometheus.baseUrl }}
         volumeMounts:
           - name: tls
             mountPath: /app/cert.pem

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if $.Values.thorasReasoningApi.enabled }}
+{{ if $.Values.thorasReasoning.api.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.thorasReasoningApi.replicas }}
+  replicas: {{ .Values.thorasReasoning.api.replicas }}
   selector:
     matchLabels:
       app: thoras-reasoning-api
@@ -23,14 +23,14 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-      {{- with .Values.thorasReasoningApi.podAnnotations }}
+      {{- with .Values.thorasReasoning.api.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: thoras-collector
       containers:
-      - image: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasReasoningApi.imageTag }}
+      - image: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasReasoning.api.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-reasoning-api
         command:
@@ -59,19 +59,19 @@ spec:
                 key: webhookUrl
             {{- end }}
           - name: SLACK_ERRORS_ENABLED
-            value: "{{ .Values.thorasReasoningApi.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+            value: "{{ .Values.thorasReasoning.api.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
-            value: {{ default .Values.logLevel .Values.thorasReasoningApi.logLevel }}
+            value: {{ default .Values.logLevel .Values.thorasReasoning.api.logLevel }}
           - name: "PROMETHEUS_BASE_URL"
-            value: {{ .Values.thorasReasoningApi.connectors.prometheus.baseUrl }}
+            value: {{ .Values.thorasReasoning.connectors.prometheus.baseUrl }}
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
         ports:
-        - containerPort: {{ .Values.thorasReasoningApi.containerPort }}
+        - containerPort: {{ .Values.thorasReasoning.api.containerPort }}
         resources:
           limits:
-            memory: {{ .Values.thorasReasoningApi.limits.memory }}
+            memory: {{ .Values.thorasReasoning.api.limits.memory }}
           requests:
-            cpu: {{ .Values.thorasReasoningApi.requests.cpu }}
-            memory: {{ .Values.thorasReasoningApi.requests.memory }}
+            cpu: {{ .Values.thorasReasoning.api.requests.cpu }}
+            memory: {{ .Values.thorasReasoning.api.requests.memory }}
 {{ end }}

--- a/charts/thoras/templates/reasoning-api/service.yaml
+++ b/charts/thoras/templates/reasoning-api/service.yaml
@@ -1,4 +1,4 @@
-{{ if $.Values.thorasReasoningApi.enabled }}
+{{ if $.Values.thorasReasoning.api.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -7,9 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - port: {{ .Values.thorasReasoningApi.port }}
+  - port: {{ .Values.thorasReasoning.api.port }}
     protocol: TCP
-    targetPort: {{ .Values.thorasReasoningApi.containerPort }}
+    targetPort: {{ .Values.thorasReasoning.api.containerPort }}
   selector:
     app: thoras-reasoning-api
 {{ end }}

--- a/charts/thoras/tests/component_not_enabled_test.yaml
+++ b/charts/thoras/tests/component_not_enabled_test.yaml
@@ -10,8 +10,9 @@ tests:
       - isKind:
           of: Deployment
     set:
-      thorasReasoningApi:
-        enabled: true
+      thorasReasoning:
+        api:
+          enabled: true
 
   - it: Doesn't render Deployment when not enabled
     asserts:

--- a/charts/thoras/tests/deployments_test.yaml
+++ b/charts/thoras/tests/deployments_test.yaml
@@ -9,9 +9,10 @@ templates:
   - reasoning-api/deployment.yaml
 set:
   thorasVersion: 1.0.0-alpha
-  thorasReasoningApi:
-    enabled: true
-    replicas: 12
+  thorasReasoning:
+    api:
+      enabled: true
+      replicas: 12
   thorasOperator:
     replicas: 12
   thorasDashboard:

--- a/charts/thoras/tests/reasoning_api_deployment_test.yaml
+++ b/charts/thoras/tests/reasoning_api_deployment_test.yaml
@@ -4,8 +4,9 @@ tests:
     templates:
       - reasoning-api/deployment.yaml
     set:
-      thorasReasoningApi:
-        enabled: true
+      thorasReasoning:
+        api:
+          enabled: true
         connectors:
           prometheus:
             baseUrl: "http://whats-good"

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -52,8 +52,9 @@ tests:
       slackWebhookUrlSecretRefKey: "url"
       thorasMonitor:
         enabled: true
-      thorasReasoningApi:
-        enabled: true
+      thorasReasoning:
+        api:
+          enabled: true
     asserts:
       - equal:
           path: $..spec.containers[0].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name
@@ -74,8 +75,9 @@ tests:
     set:
       thorasMonitor:
         enabled: true
-      thorasReasoningApi:
-        enabled: true
+      thorasReasoning:
+        api:
+          enabled: true
     asserts:
       - equal:
           path: $..spec.containers[-1].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -132,16 +132,17 @@ thorasAgent:
   containerPort: 9100
   podAnnotations: {}
 
-thorasReasoningApi:
-  enabled: false
-  podAnnotations: {}
-  containerPort: 8080
-  port: 80
-  limits:
-    memory: 2048Mi
-  requests:
-    cpu: 128m
-    memory: 8Mi
+thorasReasoning:
   connectors:
     prometheus:
       baseUrl: "http://localhost"
+  api:
+    enabled: false
+    podAnnotations: {}
+    containerPort: 8080
+    port: 80
+    limits:
+      memory: 2048Mi
+    requests:
+      cpu: 128m
+      memory: 8Mi


### PR DESCRIPTION
# Why are we making this change?

For the service layer to query prometheus, it needs the URL to prometheus

# What's changing?

Adding the `SERVICE_PROMETHEUS_API_URL` environment variable which points to the prometheus base url
