### PR TITLE
Send postgres url to api-v2

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: host
-          - name: DATABASE_URL
+          - name: SERVICE_POSTGRESQL_DSN
             value: "$(DATABASE_HOST)/thoras"
           - name: "ELASTICSEARCH_URL"
             valueFrom:


### PR DESCRIPTION
# Why are we making this change?

The service layer needs the postgres/timescale DB DSN passed to it a certain way so it can connect to postgres to store metrics.

# What's changing?

Changing the environment variable to align with how [huma](https://huma.rocks/features/cli/#passing-options) expects it to be passed.
