### PR TITLE
Set default field for forecast_buffer_percentage

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -286,6 +286,7 @@ spec:
                       x-kubernetes-int-or-string: true
                     forecast_buffer_percentage:
                       x-kubernetes-int-or-string: true
+                      default: "0"
                 reasoning:
                   type: object
                   required:


### PR DESCRIPTION
# Why are we making this change?

It's important that if the user doesn't specify a forecast buffer percentage that the system continues to chug along. So let's provide a sane default

# What's changing?

Set `forecast_buffer_percentage` default to `"0"`
