### PR TITLE
Default forecast_blocks to "15m"

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -284,6 +284,7 @@ spec:
                         - type: integer
                         - type: string
                       x-kubernetes-int-or-string: true
+                      default: "15m"
                     forecast_buffer_percentage:
                       x-kubernetes-int-or-string: true
                       default: "0"


### PR DESCRIPTION
# Why are we making this change?

We should provide a sane default window for `forecast_blocks` that aligns with the default cronjob window of once per 15m

# What's changing?

Default `forecast_blocks` to `"15m"`