### PR TITLE
added init to start of metrics collector

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -127,6 +127,7 @@ spec:
             # run any migrations, accounting for upgrade/downgrade scenarios
             ./scripts/migrate_database.sh
         {{- end}}
+            ./metrics-collector init
             ./metrics-collector collect -c 60
         env:
           - name: THORAS_NS

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -38,6 +38,7 @@ Default containers should match snapshots:
             echo "fatal: giving up on elasticsearch availability"
             exit 1
         fi
+        ./metrics-collector init
         ./metrics-collector collect -c 60
     command:
       - /bin/sh


### PR DESCRIPTION
# Why are we making this change?

Elasticsearch should be initialized with indices before starting the metrics collector 


# What's changing?

Added init script to start of metrics collector 
