### PR TITLE
Make default enabled timescale DB

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -76,7 +76,6 @@ spec:
           runAsUser: 1000
           runAsGroup: 0
         {{- end }}
-      {{- if .Values.metricsCollector.timescale.enabled }}
       - image: {{ .Values.imageCredentials.registry }}/timescaledb:{{ .Values.metricsCollector.timescale.imageTag }}
         name: timescaledb
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -98,7 +97,6 @@ spec:
           runAsUser: 1000
           runAsGroup: 0
         {{- end }}
-      {{- end }}
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: {{ .Values.metricsCollector.collector.name }}
@@ -121,12 +119,12 @@ spec:
                 echo "fatal: giving up on elasticsearch availability"
                 exit 1
             fi
-        {{- if .Values.metricsCollector.timescale.enabled }}
+
             # try to create the "thoras" database if it doesn't exist
             psql ${DATABASE_HOST} -tc "SELECT 1 FROM pg_database WHERE datname = 'thoras'" | grep -q 1 || psql ${DATABASE_HOST} -c "CREATE DATABASE thoras"
             # run any migrations, accounting for upgrade/downgrade scenarios
             ./scripts/migrate_database.sh
-        {{- end}}
+            
             ./metrics-collector collect -c 60
         env:
           - name: THORAS_NS

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -38,6 +38,12 @@ Default containers should match snapshots:
             echo "fatal: giving up on elasticsearch availability"
             exit 1
         fi
+
+        # try to create the "thoras" database if it doesn't exist
+        psql ${DATABASE_HOST} -tc "SELECT 1 FROM pg_database WHERE datname = 'thoras'" | grep -q 1 || psql ${DATABASE_HOST} -c "CREATE DATABASE thoras"
+        # run any migrations, accounting for upgrade/downgrade scenarios
+        ./scripts/migrate_database.sh
+
         ./metrics-collector init
         ./metrics-collector collect -c 60
     command:

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
           path: spec.template.spec.containers[0].image
           value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.12.1
       - equal:
-          path: spec.template.spec.containers[1].image
+          path: spec.template.spec.containers[2].image
           value: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
   - it: Default containers should match snapshots
     set:
@@ -24,7 +24,7 @@ tests:
       - matchSnapshot:
           path: spec.template.spec.containers[0]
       - matchSnapshot:
-          path: spec.template.spec.containers[1]
+          path: spec.template.spec.containers[2]
   - it: Should mount pvc when in persistence mode
     set:
       metricsCollector:
@@ -42,18 +42,7 @@ tests:
           value:
             - mountPath: /var/lib/share/elasticsearch
               name: elastic-search-data
-  - it: Should not create timescale container when not enabled
-    asserts:
-      - notContains:
-          path: $..spec.containers
-          content:
-            name: timescaledb
-          any: true
-  - it: Should create timescale container when enabled
-    set:
-      metricsCollector:
-        timescale:
-          enabled: true
+  - it: Should always create timescale container 
     asserts:
       - contains:
           path: $..spec.containers

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -15,8 +15,8 @@ tests:
           path: spec.template.spec.containers[0].image
           value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.12.1
       - equal:
-          path: spec.template.spec.containers[2].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
+          path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.17.2-pg16
   - it: Default containers should match snapshots
     set:
       thorasVersion: dev
@@ -24,7 +24,7 @@ tests:
       - matchSnapshot:
           path: spec.template.spec.containers[0]
       - matchSnapshot:
-          path: spec.template.spec.containers[2]
+          path: spec.template.spec.containers[?(@.name == 'thoras-collector')]
   - it: Should mount pvc when in persistence mode
     set:
       metricsCollector:

--- a/charts/thoras/tests/secrets_collector_test.yaml
+++ b/charts/thoras/tests/secrets_collector_test.yaml
@@ -8,10 +8,10 @@ tests:
       slackWebhookUrlSecretRefKey: "url"
     asserts:
       - equal:
-          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
           value: "frou-frou"
       - equal:
-          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
           value: "url"
 
   - it: Points all apps to default slack secret, if no existing secret provided provided
@@ -19,9 +19,9 @@ tests:
       - collector/deployment.yaml
     asserts:
       - equal:
-          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
           value: "thoras-slack"
       - equal:
-          path: $..spec.containers[1].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
           value: "webhookUrl"
 

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,7 +65,6 @@ metricsCollector:
   init:
     imageTag: "latest"
   timescale:
-    enabled: false
     imageTag: "2.17.2-pg16"
     name: timescale
     containerPort: 5432


### PR DESCRIPTION
# Why are we making this change?
TimescaleDB is always configured to run even when no timescale-related values are present in the config. 

# What's changing?
1. Remove timescale container validation
2. Update the unit testings accordingly
3. Update default timescale input passing in the values.yml