### PR TITLE
Add separate service account for agent

### DIFF
--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: thoras-collector
+      serviceAccountName: {{ .Values.thorasAgent.serviceAccount.name }}
       containers:
       - name: thoras-agent
         image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasAgent.imageTag }}

--- a/charts/thoras/templates/agent/rbac.yaml
+++ b/charts/thoras/templates/agent/rbac.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.thorasAgent.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ .Values.thorasAgent.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+imagePullSecrets:
+{{- if .Values.imageCredentials.secretRef }}
+  - name: {{ .Values.imageCredentials.secretRef }}
+{{- else }}
+  - name: thoras-secret-registry
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ .Values.thorasAgent.serviceAccount.name }}
+rules:
+- apiGroups:
+  - thoras.ai
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ .Values.thorasAgent.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.thorasAgent.serviceAccount.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.thorasAgent.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -127,6 +127,8 @@ thorasForecast:
 
 thorasAgent:
   enabled: false
+  serviceAccount:
+    name: thoras-agent
   frequency: 15
   containerPort: 9100
   podAnnotations: {}


### PR DESCRIPTION
# Why are we making this change?

The thoras agent should use a different service account than the metrics collector.

# What's changing?

When I created the agent, instead of creating a proper RBAC role and service account for it, I reused the same service account from the metrics collector. This was tech debt that this PR now fixes.