### PR TITLE
Pass SERVICE_CLUSTER _NAME environment variable from value.yaml

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -68,6 +68,8 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
           - name: "SERVICE_PROMETHEUS_API_URL"
             value: {{ .Values.thorasReasoning.connectors.prometheus.baseUrl }}
+          - name: SERVICE_CLUSTER_NAME
+            value: "{{ .Values.cluster.name }}"
         volumeMounts:
           - name: tls
             mountPath: /app/cert.pem

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -85,4 +85,15 @@ tests:
       - equal:
           path: $..spec.containers[-1].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.key
           value: "webhookUrl"
+          
+  - it: Should set the SERVICE_CLUSTER_NAME environment variables
+    templates:
+      - api-server-v2/deployment.yaml
+    set:
+      cluster: 
+        name: "test_dev"
+    asserts:
+      - equal:
+          path: $..spec.containers[0].env[?(@.name =~ /SERVICE_CLUSTER_NAME$/)].value
+          value: "test_dev"
 

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,7 @@
 ---
 thorasVersion: "4.1.0"
+cluster: 
+  name: ""
 
 imageCredentials:
   registry: "us-east4-docker.pkg.dev/thoras-registry/platform"


### PR DESCRIPTION
# Why are we making this change?
Update our helm chart to allow customers to pass in the name of the cluster in a way that propagates the cluster name to an environment variable in the services application


# What's changing?
- Customers can define the name of their cluster in the helm chart installation config (values.yaml)
- Adding unit test that asserts this behavior works in the helm chart

