### PR TITLE
494 Create end-to-end scaffolding go app for monitor-v2

### DIFF
--- a/charts/thoras/templates/monitor-v2/deployment.yaml
+++ b/charts/thoras/templates/monitor-v2/deployment.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.thorasMonitorV2.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thoras-monitor-v2
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: thoras-monitor-v2
+  template:
+    metadata:
+      labels:
+        app: thoras-monitor-v2
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: thoras-monitor-v2
+      containers:
+        - name: thoras-monitor-v2
+          image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasMonitorV2.imageTag }}
+          imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+          command: ["/app/monitor"]
+{{- end }}

--- a/charts/thoras/templates/monitor-v2/rbac.yaml
+++ b/charts/thoras/templates/monitor-v2/rbac.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.thorasMonitorV2.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: thoras-monitor-v2
+  namespace: {{ .Release.Namespace }}
+imagePullSecrets:
+{{- if .Values.imageCredentials.secretRef }}
+  - name: {{ .Values.imageCredentials.secretRef }}
+{{- else }}
+  - name: thoras-secret-registry
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: thoras-monitor-v2
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - thoras.ai
+  resources:
+  - 'AIScaleTarget'
+  - 'aiscaletargets/status'
+  - 'aiscaletargets'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: thoras-monitor-v2
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: thoras-monitor-v2
+subjects:
+- kind: ServiceAccount
+  name: thoras-monitor-v2
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/thoras/templates/operator/rbac.yaml
+++ b/charts/thoras/templates/operator/rbac.yaml
@@ -24,25 +24,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: thoras-operator
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: thoras-operator
-subjects:
-- kind: ServiceAccount
-  name: thoras-operator
-  namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
   name: thoras-collector-thoras-operator
   namespace: {{ .Release.Namespace }}
 roleRef:

--- a/charts/thoras/tests/monitor_v2_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_v2_deployment_test.yaml
@@ -1,0 +1,24 @@
+suite: Monitor-V2
+templates:
+  - monitor-v2/deployment.yaml
+set:
+  thorasVersion: 1.0.0-alpha
+tests:
+  - it: Should create deployment when thorasMonitorV2.enabled is true
+    template: monitor-v2/deployment.yaml
+    set:
+      thorasMonitorV2:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: thoras-monitor-v2
+  - it: Should create deployment when thorasMonitorV2.enabled is false
+    template: monitor-v2/deployment.yaml
+    set:
+      thorasMonitorV2:
+        enabled: false
+    asserts:
+      - notExists:
+          path: $..kind
+          value: Deployment

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -124,6 +124,9 @@ thorasMonitor:
   podAnnotations: {}
   config: |
 
+thorasMonitorV2:
+  enabled: false
+
 thorasForecast:
   requestCpu:
 


### PR DESCRIPTION
# Why are we making this change?
create the the ability to deploy new app monitor-v2 via helm chart.
(https://github.com/thoras-ai/platform/issues/494)

# What's changing?

There's a new top-level config block in our helm chart called thorasMonitorV2.enabled
When this variable is set to true, a new Kubernetes Deployment is created in the Thoras installation
There are unit tests that assert no deployment is created when the variable is false and vice versa