### PR TITLE
Give agent service account permission to query K8s for deployments and pods

### DIFF
--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -60,4 +60,5 @@ spec:
       # preempts running Pods
       # priorityClassName: important
       terminationGracePeriodSeconds: 30
+      hostNetwork: true
 {{- end }}

--- a/charts/thoras/templates/agent/rbac.yaml
+++ b/charts/thoras/templates/agent/rbac.yaml
@@ -28,6 +28,13 @@ metadata:
   name: {{ .Values.thorasAgent.serviceAccount.name }}
 rules:
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- apiGroups:
   - thoras.ai
   resources:
   - '*'

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -132,7 +132,7 @@ thorasAgent:
   serviceAccount:
     name: thoras-agent
   frequency: 15
-  containerPort: 9100
+  containerPort: 9101
   podAnnotations: {}
 
 thorasReasoning:


### PR DESCRIPTION
# Why are we making this change?

In order to map IP addresses to deployments, we need to be able to query the k8s API to list the deployments and pods for each deployment.

# What's changing?

Updating the agent rbac rules to allow for `get/list` against any API
