### PR TITLE
Restore missing ClusterRoleBinding for the thoras-collector

### DIFF
--- a/charts/thoras/templates/collector/rbac.yaml
+++ b/charts/thoras/templates/collector/rbac.yaml
@@ -33,3 +33,22 @@ subjects:
 - kind: ServiceAccount
   name: thoras-collector
   namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: thoras-collector-thoras-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: thoras-operator
+subjects:
+- kind: ServiceAccount
+  name: thoras-collector
+  namespace: {{ .Release.Namespace }}

--- a/charts/thoras/templates/operator/rbac.yaml
+++ b/charts/thoras/templates/operator/rbac.yaml
@@ -24,7 +24,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: thoras-collector-thoras-operator
+  name: thoras-operator
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -32,5 +32,5 @@ roleRef:
   name: thoras-operator
 subjects:
 - kind: ServiceAccount
-  name: thoras-collector
+  name: thoras-operator
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
# Why are we making this change?

The `thoras-operator -> thoras-operator` ClusterRoleBinding was removed in #142 erroneously and needs to be restored.

# What's changing?

This PR restores the ClusterRoleBinding removed in #142 and moves the `thoras-collector` ClusterRoleBinding to the collector's RBAC files.