### PR TITLE
Fix broken unit test for monitor-v2 deployment

### DIFF
--- a/charts/thoras/tests/monitor_v2_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_v2_deployment_test.yaml
@@ -13,12 +13,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].name
           value: thoras-monitor-v2
-  - it: Should create deployment when thorasMonitorV2.enabled is false
+  - it: Should not create deployment when thorasMonitorV2.enabled is false
     template: monitor-v2/deployment.yaml
     set:
       thorasMonitorV2:
         enabled: false
     asserts:
-      - notExists:
-          path: $..kind
-          value: Deployment
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
# Why are we making this change?

When running the tests locally (not in CI, for some reason), the following error is generated:

```
 FAIL  Monitor-V2       charts/thoras/tests/monitor_v2_deployment_test.yaml
        - Should create deployment when thorasMonitorV2.enabled is false

                - asserts[0] `notExists` fail
                        Template:       thoras/templates/monitor-v2/deployment.yaml
```

This PR fixes that error by checking for documents instead of using `notExists`

# What's changing?

Also, this PR fixes the incorrect YAML warning:
![Screenshot 2025-01-07 at 2 42 05 PM](https://github.com/user-attachments/assets/a0a20299-c699-4545-aebd-d9f762f3b84e)



