### PR TITLE
528 Disabling Reasoning in helm chart should work as expected

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -66,8 +66,10 @@ spec:
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
-          - name: API_BASE_URL
+          - name: OPERATOR_THORAS_API_BASE_URL
             value: "http://thoras-api-server-v2"
+          - name: OPERATOR_REASONING_ENABLED
+            value: "{{ .Values.thorasReasoning.enabled }}"
           - name: FORECAST_IMAGE_PULL_POLICY
             value: "{{ .Values.imagePullPolicy }}"
         command: [

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if $.Values.thorasReasoning.api.enabled }}
+{{ if $.Values.thorasReasoning.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/thoras/templates/reasoning-api/service.yaml
+++ b/charts/thoras/templates/reasoning-api/service.yaml
@@ -1,4 +1,4 @@
-{{ if $.Values.thorasReasoning.api.enabled }}
+{{ if $.Values.thorasReasoning.enabled }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/thoras/tests/component_not_enabled_test.yaml
+++ b/charts/thoras/tests/component_not_enabled_test.yaml
@@ -11,8 +11,7 @@ tests:
           of: Deployment
     set:
       thorasReasoning:
-        api:
-          enabled: true
+        enabled: true
 
   - it: Doesn't render Deployment when not enabled
     asserts:

--- a/charts/thoras/tests/deployments_test.yaml
+++ b/charts/thoras/tests/deployments_test.yaml
@@ -10,8 +10,8 @@ templates:
 set:
   thorasVersion: 1.0.0-alpha
   thorasReasoning:
+    enabled: true
     api:
-      enabled: true
       replicas: 12
   thorasOperator:
     replicas: 12

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -1,0 +1,21 @@
+suite: Operator
+templates:
+  - operator/deployment.yaml
+tests:
+  - it: Ensure OPERATOR_REASONING_ENABLED not exists when reasoning is disabled
+    set:
+      thorasReasoning:
+        enabled: false
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'OPERATOR_REASONING_ENABLED')].value
+          value: "false"
+  - it: Ensure OPERATOR_REASONING_ENABLED not exists when reasoning is enabled
+    set:
+      thorasReasoning:
+        enabled: true
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'OPERATOR_REASONING_ENABLED')].value
+          value: "true"
+

--- a/charts/thoras/tests/reasoning_api_deployment_test.yaml
+++ b/charts/thoras/tests/reasoning_api_deployment_test.yaml
@@ -1,16 +1,26 @@
 suite: Reasoning
+templates:
+  - reasoning-api/deployment.yaml
 tests:
   - it: Set prometheus URL correctly
-    templates:
-      - reasoning-api/deployment.yaml
     set:
       thorasReasoning:
-        api:
-          enabled: true
+        enabled: true
         connectors:
           prometheus:
             baseUrl: "http://whats-good"
     asserts:
       - equal:
-          path: $..spec.containers[0].env[?(@.name == 'PROMETHEUS_BASE_URL')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'PROMETHEUS_BASE_URL')].value
           value: "http://whats-good"
+  - it: Disabling reasoning still disables the reasoning API deployment and service objects
+    set:
+      thorasReasoning:
+        enabled: false
+    asserts:
+      - notExists:
+          kind: Deployment
+          name: reasoning-api
+      - notExists:
+          kind: Service
+          name: reasoning-api

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -53,8 +53,7 @@ tests:
       thorasMonitor:
         enabled: true
       thorasReasoning:
-        api:
-          enabled: true
+        enabled: true
     asserts:
       - equal:
           path: $..spec.containers[0].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name
@@ -76,8 +75,7 @@ tests:
       thorasMonitor:
         enabled: true
       thorasReasoning:
-        api:
-          enabled: true
+        enabled: true
     asserts:
       - equal:
           path: $..spec.containers[-1].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -139,11 +139,11 @@ thorasAgent:
   podAnnotations: {}
 
 thorasReasoning:
+  enabled: false
   connectors:
     prometheus:
       baseUrl: "http://localhost"
   api:
-    enabled: false
     podAnnotations: {}
     containerPort: 8080
     port: 80


### PR DESCRIPTION
… testings

# Why are we making this change?
Customers able to configure reasoning and disable the reasoning feature if needed.

related to https://github.com/orgs/thoras-ai/projects/6/views/3?pane=issue&itemId=93006500&issue=thoras-ai%7Cplatform%7C528

# What's changing?

- Implementing enabled toggle within the thorasReasoning configuration to control by the user. 
- Updating the deployment and service configuration files and unit testings to respond with its changes. 
- Updating API_BASE_URL to OPERATOR_THORAS_API_BASE_URL