### PR TITLE
Updating env variable to SERVICE

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -66,9 +66,9 @@ spec:
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "LOGLEVEL"
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
-          - name: OPERATOR_THORAS_API_BASE_URL
+          - name: SERVICE_THORAS_API_BASE_URL
             value: "http://thoras-api-server-v2"
-          - name: OPERATOR_REASONING_ENABLED
+          - name: SERVICE_REASONING_ENABLED
             value: "{{ .Values.thorasReasoning.enabled }}"
           - name: FORECAST_IMAGE_PULL_POLICY
             value: "{{ .Values.imagePullPolicy }}"

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -2,20 +2,20 @@ suite: Operator
 templates:
   - operator/deployment.yaml
 tests:
-  - it: Ensure OPERATOR_REASONING_ENABLED not exists when reasoning is disabled
+  - it: Ensure SERVICE_REASONING_ENABLED not exists when reasoning is disabled
     set:
       thorasReasoning:
         enabled: false
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'OPERATOR_REASONING_ENABLED')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_REASONING_ENABLED')].value
           value: "false"
-  - it: Ensure OPERATOR_REASONING_ENABLED not exists when reasoning is enabled
+  - it: Ensure SERVICE_REASONING_ENABLED not exists when reasoning is enabled
     set:
       thorasReasoning:
         enabled: true
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'OPERATOR_REASONING_ENABLED')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_REASONING_ENABLED')].value
           value: "true"
 


### PR DESCRIPTION
# Why are we making this change?
Fixing bug with taking the correct prefix environment variables via huma cli. 
related to https://github.com/thoras-ai/helm-charts/pull/147

# What's changing?
Updating OPERATOR to SERVICE prefix