### PR TITLE
Added Metric Insights CRDS

### DIFF
--- a/charts/thoras/templates/crd/metricconnector.yaml
+++ b/charts/thoras/templates/crd/metricconnector.yaml
@@ -1,0 +1,238 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: metricconnectors.thoras.ai
+spec:
+  group: thoras.ai
+  names:
+    kind: MetricConnector
+    listKind: MetricConnectorList
+    plural: metricconnectors
+    singular: metricconnector
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                config:
+                  description:
+                    Configuration for the connector.  The specific fields
+                    within this struct depend on the value of `Type`.
+                  properties:
+                    datadog:
+                      description: Coming soon.. To own on DVD & Video.
+                      type: object
+                    prometheus:
+                      properties:
+                        BasicAuth:
+                          description:
+                            Basic authentication credentials. Can be a Secret
+                            reference.
+                          properties:
+                            secretKeyRef:
+                              description: |-
+                                SecretKeyRef is a reference to a Kubernetes Secret containing the value of the field.
+                                Takes precedence over Value if both are set.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            value:
+                              description:
+                                Value is the literal value of the field.  If
+                                secretKeyRef is also set, this value will be ignored.
+                              type: string
+                          type: object
+                        caFile:
+                          description:
+                            Path to the CA certificate file.  Can be a Secret
+                            reference.
+                          properties:
+                            secretKeyRef:
+                              description: |-
+                                SecretKeyRef is a reference to a Kubernetes Secret containing the value of the field.
+                                Takes precedence over Value if both are set.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            value:
+                              description:
+                                Value is the literal value of the field.  If
+                                secretKeyRef is also set, this value will be ignored.
+                              type: string
+                          type: object
+                        certFile:
+                          description:
+                            Path to the client certificate file. Can be a
+                            Secret reference.
+                          properties:
+                            secretKeyRef:
+                              description: |-
+                                SecretKeyRef is a reference to a Kubernetes Secret containing the value of the field.
+                                Takes precedence over Value if both are set.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            value:
+                              description:
+                                Value is the literal value of the field.  If
+                                secretKeyRef is also set, this value will be ignored.
+                              type: string
+                          type: object
+                        insecureSkipVerify:
+                          description: Whether to skip TLS certificate verification.
+                          type: boolean
+                        keyFile:
+                          description:
+                            Path to the client key file. Can be a Secret
+                            reference.
+                          properties:
+                            secretKeyRef:
+                              description: |-
+                                SecretKeyRef is a reference to a Kubernetes Secret containing the value of the field.
+                                Takes precedence over Value if both are set.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            value:
+                              description:
+                                Value is the literal value of the field.  If
+                                secretKeyRef is also set, this value will be ignored.
+                              type: string
+                          type: object
+                        url:
+                          description: URL of the Prometheus server.
+                          type: string
+                      type: object
+                  type: object
+                rateLimit:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: Number of requests to send to the connector per minute.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                type:
+                  description:
+                    Type of the connector.  Must be one of "prometheus" or
+                    "datadog".
+                  enum:
+                    - prometheus
+                    - datadog
+                  type: string
+              required:
+                - config
+                - type
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/charts/thoras/templates/crd/metricinsights.yaml
+++ b/charts/thoras/templates/crd/metricinsights.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: metricinsights.thoras.ai
+spec:
+  group: thoras.ai
+  names:
+    kind: MetricInsights
+    listKind: MetricInsightsList
+    plural: metricinsights
+    singular: metricinsights
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                compute:
+                  properties:
+                    concurrency:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description:
+                        Number of workers allowed to process metrics at one
+                        time
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                connectorRefs:
+                  description:
+                    List of MetricInsightsConnector names in this namespace
+                    to use for this insight
+                  items:
+                    type: string
+                  type: array
+              type: object
+            status:
+              properties:
+                events:
+                  description: List of relevant events for this MetricInsights job.
+                  items:
+                    properties:
+                      message:
+                        type: string
+                      type:
+                        description: Type of event
+                        type: string
+                    type: object
+                  type: array
+                metricsProcessed:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: Metrics processed so far this job
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                totalMetrics:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: Total Metrics to process this job
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true


### PR DESCRIPTION
# Why are we making this change?

The new Metric Insights feature will need CRDs to be configured. 


# What's changing?

Added two new CRDs. Examples: 

```
---
kind: MetricConnector
apiVersion: thoras.ai/v1
metadata:
  name: prom-connector
  namespace: example
spec:
  type: prometheus
  rateLimit: 5k
  config:
    prometheus:
      url: https://prometheus-server.example.com
      BasicAuth:
        secretKeyRef:
          name: prom-secret
          key: basicauth
---
kind: MetricInsights
apiVersion: thoras.ai/v1
metadata:
  name: prom-insights
  namespace: example
spec:
  connectorRefs:
  - prom-connector
  compute:
    concurrency: '5'
```

