### PR TITLE
Add Postgres config to metrics purge cronjob

### DIFF
--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -32,6 +32,18 @@ spec:
                 value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
               - name: "LOGLEVEL"
                 value: {{ default .Values.logLevel .Values.metricsCollector.purge.logLevel }}
+              - name: "POSTGRES_PASSWORD"
+                valueFrom:
+                  secretKeyRef:
+                    name: thoras-timescale-password
+                    key: password
+              - name: DATABASE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: thoras-timescale-password
+                    key: host
+              - name: DATABASE_URL
+                value: "$(DATABASE_HOST)/thoras?sslmode=disable"
             command: ["/bin/sh", "-c"]
             args:
               - |

--- a/charts/thoras/tests/collector_cronjob_test.yaml
+++ b/charts/thoras/tests/collector_cronjob_test.yaml
@@ -1,0 +1,41 @@
+suite: CollectorCronjob
+templates:
+  - collector/cronjob.yaml
+tests:
+  - it: Should have the correct kind, name and image
+    set:
+      thorasVersion: dev
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: thoras-metrics-purge
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
+  - it: Should have postgress set
+    asserts:
+      - isNotNull:
+          path: .spec.jobTemplate.spec.template.spec.containers[0].env
+      - contains:
+          path: .spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: "POSTGRES_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: thoras-timescale-password
+      - contains:
+          path: .spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: "DATABASE_HOST"
+            valueFrom:
+              secretKeyRef:
+                name: thoras-timescale-password
+                key: host
+      - contains:
+          path: .spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: "DATABASE_URL"
+            value: "$(DATABASE_HOST)/thoras?sslmode=disable"


### PR DESCRIPTION
# Reason for Change

The user's nightly metrics purge cron job is failing due to missing PostgreSQL environment variables.

# Change Summary

PostgreSQL environment variables have been added to the metrics cron job to resolve the issue and ensure successful execution.

fixes thoras-ai/platform#580