### PR TITLE
Add private single_metric scope field to connector CRD, for narrowing data ingest for development

### DIFF
--- a/charts/thoras/templates/crd/metricconnector.yaml
+++ b/charts/thoras/templates/crd/metricconnector.yaml
@@ -47,6 +47,12 @@ spec:
                       type: object
                     prometheus:
                       properties:
+                        limit_to_single_metric:
+                          description: >-
+                            Optional prometheus query to limit the scope of data ingestion. 
+                            This is used for internal development and allows specifying 
+                            a subset of the time series data.
+                          type: string
                         BasicAuth:
                           description:
                             Basic authentication credentials. Can be a Secret


### PR DESCRIPTION
# Why are we making this change?
As a Thoras engineer, I should be able to configure the Reasoning engine's metrics insights feature to ingest a specific subset of a timeseries db (versus ingesting the entire database) so that I can have a smaller batch of data to develop against. Having a way of narrowing the data will make it easier to focus on feature development because the pipelines will be quicker and there will be less metric data, making it more clear



# What's changing?
The [MetricsConnector](https://github.com/thoras-ai/helm-charts/blob/main/charts/thoras/templates/crd/metricconnector.yaml) CRD has a field that allows the user to specify a prometheus query to limit how much data is ingested from "the whole thing" to "just a single metric"

related to [574](https://github.com/orgs/thoras-ai/projects/6/views/3?pane=issue&itemId=93877997&issue=thoras-ai%7Cplatform%7C574)

# Testing

Deploying CRD locally and get the detailed information about the resource. 
```
Name:         my-metric-connector
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  thoras.ai/v1
Kind:         MetricConnector
Metadata:
  Creation Timestamp:  2025-01-21T04:43:28Z
  Generation:          1
  Resource Version:    18828
  UID:                 ce24c0a0-21e8-4657-adf6-6c8b26c65428
Spec:
  Config:
    Prometheus:
      Query:  up{job="kubernetes-node"}
      URL:    http://prometheus-server:9090
  Type:       prometheus
Events:       <none>
```

