### PR TITLE
Update slack error reporting-related env vars

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -150,12 +150,12 @@ helm install \
 
 ## Thoras Agent
 
-| Key                   | Type    | Default        | Description                                                            |
-| --------------------- | ------- | -------------- | ---------------------------------------------------------------------- |
-| thorasAgent.enabled   | Bool    | false          | Enable the Thoras Agent (opt-in, for now)                              |
-| thorasAgent.imageTag  | String  | .thorasVersion | Image tag for Thoras Agent daemon set                                  |
-| thorasAgent.slackErrorsEnabled | Boolean | false   | Determines if error-level logs are sent to `slackWebHookUrl` |
-| thorasAgent.frequency | Integer | 15             | Frequency, in seconds, of agent polling for service map communications |
+| Key                            | Type    | Default        | Description                                                            |
+| ------------------------------ | ------- | -------------- | ---------------------------------------------------------------------- |
+| thorasAgent.enabled            | Bool    | false          | Enable the Thoras Agent (opt-in, for now)                              |
+| thorasAgent.imageTag           | String  | .thorasVersion | Image tag for Thoras Agent daemon set                                  |
+| thorasAgent.slackErrorsEnabled | Boolean | false          | Determines if error-level logs are sent to `slackWebHookUrl`           |
+| thorasAgent.frequency          | Integer | 15             | Frequency, in seconds, of agent polling for service map communications |
 
 ## Example Thoras Monitor with default config
 

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -154,6 +154,7 @@ helm install \
 | --------------------- | ------- | -------------- | ---------------------------------------------------------------------- |
 | thorasAgent.enabled   | Bool    | false          | Enable the Thoras Agent (opt-in, for now)                              |
 | thorasAgent.imageTag  | String  | .thorasVersion | Image tag for Thoras Agent daemon set                                  |
+| thorasAgent.slackErrorsEnabled | Boolean | false   | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasAgent.frequency | Integer | 15             | Frequency, in seconds, of agent polling for service map communications |
 
 ## Example Thoras Monitor with default config

--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -41,6 +41,20 @@ spec:
             value: {{ .Values.thorasAgent.frequency | quote }}
           - name: "SERVICE_PORT"
             value: {{ .Values.thorasAgent.containerPort | quote }}
+          - name: SERVICE_SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
+                name: thoras-slack
+                key: webhookUrl
+            {{- end }}
+          - name: SERVICE_SLACK_ERRORS_ENABLED
+            value: "{{ .Values.thorasAgent.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+          - name: SERVICE_CLUSTER_NAME
+            value: "{{ .Values.cluster.name }}"
         ports:
           - containerPort: {{ .Values.thorasAgent.containerPort }}
         resources:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -143,7 +143,7 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: host
-          - name: SLACK_WEBHOOK_URL
+          - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
             {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
@@ -153,8 +153,12 @@ spec:
                 name: thoras-slack
                 key: webhookUrl
             {{- end }}
-          - name: SLACK_ERRORS_ENABLED
+          - name: SERVICE_SLACK_ERRORS_ENABLED
             value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+          - name: SERVICE_CLUSTER_NAME
+            value: "{{ .Values.cluster.name }}"
+          - name: SERVICE_LOG_LEVEL
+            value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
           - name: DATABASE_HOST

--- a/charts/thoras/templates/monitor-v2/deployment.yaml
+++ b/charts/thoras/templates/monitor-v2/deployment.yaml
@@ -25,8 +25,25 @@ spec:
     spec:
       serviceAccountName: thoras-monitor-v2
       containers:
-        - name: thoras-monitor-v2
-          image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasMonitorV2.imageTag }}
-          imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-          command: ["/app/monitor"]
+      - name: thoras-monitor-v2
+        image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasMonitorV2.imageTag }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command: ["/app/monitor"]
+        env:
+          - name: SERVICE_LOG_LEVEL
+            value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
+          - name: SERVICE_SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
+                name: thoras-slack
+                key: webhookUrl
+            {{- end }}
+          - name: SERVICE_SLACK_ERRORS_ENABLED
+            value: "{{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+          - name: SERVICE_CLUSTER_NAME
+            value: "{{ .Values.cluster.name }}"
 {{- end }}

--- a/charts/thoras/templates/monitor-v2/deployment.yaml
+++ b/charts/thoras/templates/monitor-v2/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         command: ["/app/monitor"]
         env:
           - name: SERVICE_LOG_LEVEL
-            value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
+            value: {{ .Values.thorasMonitorV2.logLevel | default .Values.thorasMonitor.logLevel | default .Values.logLevel | quote }}
           - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
@@ -43,7 +43,7 @@ spec:
                 key: webhookUrl
             {{- end }}
           - name: SERVICE_SLACK_ERRORS_ENABLED
-            value: "{{ .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+            value: "{{ .Values.thorasMonitorV2.slackErrorsEnabled | default .Values.thorasMonitor.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: SERVICE_CLUSTER_NAME
             value: "{{ .Values.cluster.name }}"
 {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -62,10 +62,22 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SLACK_ERRORS_ENABLED
+          - name: SERVICE_SLACK_ERRORS_ENABLED
             value: "{{ .Values.thorasOperator.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
-          - name: "LOGLEVEL"
+          - name: SERVICE_SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
+                name: thoras-slack
+                key: webhookUrl
+            {{- end }}
+          - name: SERVICE_LOG_LEVEL
             value: {{ default .Values.logLevel .Values.thorasOperator.logLevel }}
+          - name: SERVICE_CLUSTER_NAME
+            value: "{{ .Values.cluster.name }}"
           - name: SERVICE_THORAS_API_BASE_URL
             value: "http://thoras-api-server-v2"
           - name: SERVICE_REASONING_ENABLED

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -65,13 +65,17 @@ Default containers should match snapshots:
           secretKeyRef:
             key: host
             name: thoras-elastic-password
-      - name: SLACK_WEBHOOK_URL
+      - name: SERVICE_SLACK_WEBHOOK_URL
         valueFrom:
           secretKeyRef:
             key: webhookUrl
             name: thoras-slack
-      - name: SLACK_ERRORS_ENABLED
+      - name: SERVICE_SLACK_ERRORS_ENABLED
         value: "false"
+      - name: SERVICE_CLUSTER_NAME
+        value: ""
+      - name: SERVICE_LOG_LEVEL
+        value: info
       - name: API_BASE_URL
         value: http://thoras-api-server-v2
       - name: DATABASE_HOST

--- a/charts/thoras/tests/secrets_collector_test.yaml
+++ b/charts/thoras/tests/secrets_collector_test.yaml
@@ -8,10 +8,10 @@ tests:
       slackWebhookUrlSecretRefKey: "url"
     asserts:
       - equal:
-          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SERVICE_SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
           value: "frou-frou"
       - equal:
-          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SERVICE_SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
           value: "url"
 
   - it: Points all apps to default slack secret, if no existing secret provided provided
@@ -19,9 +19,9 @@ tests:
       - collector/deployment.yaml
     asserts:
       - equal:
-          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SERVICE_SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.name
           value: "thoras-slack"
       - equal:
-          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
+          path: $..spec.containers[?(@.name == 'thoras-collector')].env[?(@.name == 'SERVICE_SLACK_WEBHOOK_URL')].valueFrom.secretKeyRef.key
           value: "webhookUrl"
 


### PR DESCRIPTION
# Why are we making this change?

The slack error reporting-related environment variables need to be updated for our services.

# What's changing?

We changed several environment variables around sending error messages to slack, including those for the collector, operator, monitor-v2 and the agent.
