### PR TITLE
Remove duplicate SERVICE_CLUSTER_NAME env var

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -166,9 +166,9 @@ spec:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: host
+          - name: DATABASE_URL
+            value: "$(DATABASE_HOST)/thoras?sslmode=disable"
           - name: SERVICE_POSTGRESQL_DSN
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
           - name: "SERVICE_LOGLEVEL"
             value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}
-          - name: SERVICE_CLUSTER_NAME
-            value: "{{ .Values.cluster.name }}"

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -83,12 +83,12 @@ Default containers should match snapshots:
           secretKeyRef:
             key: host
             name: thoras-timescale-password
+      - name: DATABASE_URL
+        value: $(DATABASE_HOST)/thoras?sslmode=disable
       - name: SERVICE_POSTGRESQL_DSN
         value: $(DATABASE_HOST)/thoras?sslmode=disable
       - name: SERVICE_LOGLEVEL
         value: info
-      - name: SERVICE_CLUSTER_NAME
-        value: ""
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?

In moving around some environment variables, I introduced a duplicate `SERVICE_CLUSTER_NAME` for the collector deployment, which would trigger a helm chart apply error.

# What's changing?

- Dropping the duplicate `SERVICE_CLUSTER_NAME` env var for the collector
- Also re-adding the `DATABASE_URL` environment variable removed in #156 because the collector still depends on it for migrations.
