### PR TITLE
Add POSTGRES_PASSWORD to collector environment

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -172,3 +172,8 @@ spec:
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
           - name: "SERVICE_LOG_LEVEL"
             value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}
+          - name: "POSTGRES_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: thoras-timescale-password
+                key: password

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -89,6 +89,11 @@ Default containers should match snapshots:
         value: $(DATABASE_HOST)/thoras?sslmode=disable
       - name: SERVICE_LOG_LEVEL
         value: info
+      - name: POSTGRES_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: password
+            name: thoras-timescale-password
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?

Restoring the `POSTGRES_PASSWORD` removed erroneously in #156 so that the collector can set the correct password on startup.