### PR TITLE
Run chart releaser for release** branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'release**'
 
 jobs:
   release:


### PR DESCRIPTION
# Why are we making this change?

In order to tag hotfix releases, we need to run the chart releaser when the version changes on any branch prefixed with `release` 

# What's changing?

Updating our github release action to include branches prefixed with `release`
