### PR TITLE
Remove duplicate SERVICE_LOG_LEVEL

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -170,8 +170,6 @@ spec:
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
           - name: SERVICE_POSTGRESQL_DSN
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
-          - name: "SERVICE_LOG_LEVEL"
-            value: {{ default .Values.logLevel .Values.metricsCollector.collector.logLevel }}
           - name: "POSTGRES_PASSWORD"
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -87,8 +87,6 @@ Default containers should match snapshots:
         value: $(DATABASE_HOST)/thoras?sslmode=disable
       - name: SERVICE_POSTGRESQL_DSN
         value: $(DATABASE_HOST)/thoras?sslmode=disable
-      - name: SERVICE_LOG_LEVEL
-        value: info
       - name: POSTGRES_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
# Why are we making this change?

Fixes the following error: 

```49046 warnings.go:70] spec.template.spec.containers[2].env[6]: hides previous definition of "SERVICE_LOG_LEVEL", which may be dropped when using apply```

Introduced in https://github.com/thoras-ai/helm-charts/pull/165

# What's changing?

Remove the duplicate `SERVICE_LOG_LEVEL` on the collector