### PR TITLE
Don't build release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-      - 'release**'
+  # Allows manual triggering in the GitHub UI
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
# Why are we making this change?

We shouldn't immediately build branches prefixed with `release` but should be able to manually trigger the workflow via the github UI.