### PR TITLE
Add exclude_metrics back into AST CRD

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -517,6 +517,19 @@ spec:
                       - type
                       type: object
                     type: array
+                  exclude_metrics:
+                    description: Metrics from HPA for thoras to ignore
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
                   mode:
                     enum:
                     - autonomous


### PR DESCRIPTION
# Why are we making this change?

The `exclude_metrics` was dropped from the AST CRD in https://github.com/thoras-ai/helm-charts/pull/164 when it shouldn't have been.

