### PR TITLE
Don't migrate blobs directory

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         args:
           - |
             mkdir -p /var/lib/share/elasticsearch/data
-            find /var/lib/share/elasticsearch -not -name postgresql -not -name data -mindepth 1 -maxdepth 1 -exec mv {} /var/lib/share/elasticsearch/data \;
+            find /var/lib/share/elasticsearch -not -name postgresql -not -name data -not -name blobs -mindepth 1 -maxdepth 1 -exec mv {} /var/lib/share/elasticsearch/data \;
             chown -R 1000:0 /var/lib/share/elasticsearch/data
             rm -f /var/lib/share/elasticsearch/data/node.lock
         volumeMounts:


### PR DESCRIPTION
# Why are we making this change?

We should exclude the blobs directory when migrating elastic data. In the future, it would be great to remove the elastic migration once all of our customers have upgraded to a timescale version.