### PR TITLE
Added Nginx reverse proxy to dashboard exposing api server

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.thorasDashboard.serviceAccount.name }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: thoras-dashboard-nginx-config
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-dashboard:{{ default .Values.thorasVersion .Values.thorasDashboard.imageTag }}
         name: thoras-dashboard
@@ -76,3 +80,12 @@ spec:
           requests:
             cpu: {{ .Values.thorasDashboard.requests.cpu }}
             memory: {{ .Values.thorasDashboard.requests.memory }}
+      - name: thoras-api-proxy
+        image: {{ .Values.imageCredentials.registry }}/nginx:{{ .Values.thorasDashboard.nginx.imageTag }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        ports:
+        - containerPort: {{ .Values.thorasDashboard.nginxContainerPort }}
+        volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf

--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thoras-dashboard-nginx-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  nginx.conf: |
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      server {
+        listen {{ .Values.thorasDashboard.nginxContainerPort }};
+
+        location /v1/ {
+          proxy_pass http://thoras-api-server-v2;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+          proxy_pass http://localhost:{{ .Values.thorasDashboard.containerPort }};
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+      }
+    }

--- a/charts/thoras/templates/dashboard/service.yaml
+++ b/charts/thoras/templates/dashboard/service.yaml
@@ -33,6 +33,6 @@ spec:
   ports:
   - port: {{ .Values.thorasDashboard.port }}
     protocol: TCP
-    targetPort: {{ .Values.thorasDashboard.containerPort }}
+    targetPort: {{ .Values.thorasDashboard.nginxContainerPort }}
   selector:
     app: thoras-dashboard

--- a/charts/thoras/tests/__snapshot__/dashboard_service_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_service_test.yaml.snap
@@ -9,7 +9,7 @@ Default matches snapshot:
       ports:
         - port: 80
           protocol: TCP
-          targetPort: 3000
+          targetPort: 80
       selector:
         app: thoras-dashboard
       type: ClusterIP

--- a/charts/thoras/tests/dashboard_deployment_test.yaml
+++ b/charts/thoras/tests/dashboard_deployment_test.yaml
@@ -17,5 +17,20 @@ tests:
           path: spec.template.spec.containers[0].image
           value: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard:TEST
       - equal:
+          path: spec.template.spec.containers[1].image
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/nginx:alpine
+      - equal:
+          path: spec.template.spec.containers[1].volumeMounts[0]
+          value:
+            name: nginx-config
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+      - equal:
           path: spec.replicas
           value: 12
+      - equal:
+          path: spec.template.spec.volumes[0]
+          value:
+            name: nginx-config
+            configMap:
+              name: thoras-dashboard-nginx-config

--- a/charts/thoras/tests/dashboard_service_test.yaml
+++ b/charts/thoras/tests/dashboard_service_test.yaml
@@ -49,7 +49,7 @@ tests:
     set:
       thorasDashboard:
         port: 5000
-        containerPort: 4000
+        nginxContainerPort: 4000
     asserts:
       - equal:
           path: spec.ports[0].port

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -65,7 +65,6 @@ tests:
     templates:
       - api-server-v2/deployment.yaml
       - collector/deployment.yaml
-      # - dashboard/deployment.yaml
       - monitor/deployment.yaml
       - operator/deployment.yaml
       - reasoning-api/deployment.yaml

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -65,7 +65,7 @@ tests:
     templates:
       - api-server-v2/deployment.yaml
       - collector/deployment.yaml
-      - dashboard/deployment.yaml
+      # - dashboard/deployment.yaml
       - monitor/deployment.yaml
       - operator/deployment.yaml
       - reasoning-api/deployment.yaml
@@ -80,6 +80,18 @@ tests:
           value: "thoras-slack"
       - equal:
           path: $..spec.containers[-1].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.key
+          value: "webhookUrl"
+
+  - it: Dashboard default slack secret, if no existing secret provided provided
+    templates:
+      - dashboard/deployment.yaml
+    set:
+    asserts:
+      - equal:
+          path: $..spec.containers[0].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name
+          value: "thoras-slack"
+      - equal:
+          path: $..spec.containers[0].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.key
           value: "webhookUrl"
 
   - it: Should set the SERVICE_CLUSTER_NAME environment variables

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -108,6 +108,9 @@ thorasDashboard:
     create: true
   podAnnotations: {}
   containerPort: 3000
+  nginxContainerPort: 80
+  nginx:
+    imageTag: "alpine"
   limits:
     memory: 2000Mi
   requests:


### PR DESCRIPTION
# Why are we making this change?

To streamline communication between the frontend and the API server, we are exposing the API server on the same port as the dashboard. This eliminates the need for a Backend-for-Frontend (BFF) layer, allowing the frontend to make direct HTTP requests to the API server.

# What's changing?

An Nginx container has been added to the dashboard pod, acting as a reverse proxy for both the dashboard and the API server on the same port. This ensures seamless integration while maintaining a simplified architecture.

