### PR TITLE
Allow queries-per-second overrides

### DIFF
--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -55,6 +55,10 @@ spec:
             value: "{{ .Values.thorasAgent.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: SERVICE_CLUSTER_NAME
             value: "{{ .Values.cluster.name }}"
+          {{- if (.Values.thorasAgent.queries_per_second | default .Values.queries_per_second) }}
+          - name: SERVICE_QUERIES_PER_SECOND
+            value: {{ .Values.thorasAgent.queries_per_second | default .Values.queries_per_second | quote }}
+          {{- end }}
         ports:
           - containerPort: {{ .Values.thorasAgent.containerPort }}
         resources:

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -108,6 +108,10 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_STORAGE_FILE_PATH
             value: "/var/lib/share"
+          {{- if (.Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second) }}
+          - name: SERVICE_QUERIES_PER_SECOND
+            value: {{ .Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second | quote }}
+          {{- end }}
         volumeMounts:
           {{- if .Values.metricsCollector.persistence.enabled }}
           - name: elastic-search-data

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -88,6 +88,10 @@ spec:
             value: "{{ .Values.thorasReasoning.enabled }}"
           - name: FORECAST_IMAGE_PULL_POLICY
             value: "{{ .Values.imagePullPolicy }}"
+          {{- if (.Values.thorasOperator.queries_per_second | default .Values.queries_per_second) }}
+          - name: SERVICE_QUERIES_PER_SECOND
+            value: {{ .Values.thorasOperator.queries_per_second | default .Values.queries_per_second | quote }}
+          {{- end }}
         command: [
           "/app/operator"
         ]


### PR DESCRIPTION
# Why are we making this change?

We need a way to override the default k8s rate limiting "queries per second" or QPS. Future work to introduce short-window caching of target k8s queries.
