### PR TITLE
Added MODEL_SKIP_CACHE to op

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -66,9 +66,10 @@ helm install \
 
 ## Thoras Forecast
 
-| Key                     | Type   | Default        | Description                       |
-| ----------------------- | ------ | -------------- | --------------------------------- |
-| thorasForecast.imageTag | String | .thorasVersion | Image tag for Thoras Forecast job |
+| Key                      | Type    | Default        | Description                                   |
+| ------------------------ | ------- | -------------- | --------------------------------------------- |
+| thorasForecast.imageTag  | String  | .thorasVersion | Image tag for Thoras Forecast job             |
+| thorasForecast.skipCache | Boolean |  false         | Directs the forecaster to skip to model cache |
 
 ## Thoras Operator
 

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -88,6 +88,8 @@ spec:
             value: "{{ .Values.thorasReasoning.enabled }}"
           - name: FORECAST_IMAGE_PULL_POLICY
             value: "{{ .Values.imagePullPolicy }}"
+          - name: MODEL_SKIP_CACHE
+            value: "{{ .Values.thorasForecast.skipCache }}"
         command: [
           "/app/operator"
         ]

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -18,4 +18,11 @@ tests:
       - equal:
           path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_REASONING_ENABLED')].value
           value: "true"
-
+  - it: Ensure MODEL_SKIP_CACHE not exists when reasoning is enabled
+    set:
+      thorasForecast:
+        skipCache: true
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'MODEL_SKIP_CACHE')].value
+          value: "true"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -131,6 +131,7 @@ thorasMonitorV2:
   enabled: false
 
 thorasForecast:
+  skipCache: false
   requestCpu:
 
 thorasAgent:


### PR DESCRIPTION
# Why are we making this change?

Thoras forecaster now has the ability to disable the model cache! 

# What's changing?

Added value `thorasForecast.skipCache`

