### PR TITLE
Add SERVICE_TIMESCALE_PRIMARY environment variable

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -114,6 +114,7 @@ helm install \
 | thorasApiServer.requests.memory    | String  | 1000Mi  | Thoras API memory request                                    |
 | thorasApiServer.slackErrorsEnabled | Boolean | false   | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasApiServer.logLevel           | String  | Nil     | Logging level                                                |
+| thorasApiServer.timescalePrimary   | Boolean | false   | Use timescale as the primary data source, not elastic        |
 
 ## Thoras Dashboard
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -108,10 +108,8 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_STORAGE_FILE_PATH
             value: "/var/lib/share"
-          {{- if .Values.thorasApiServerV2.timescalePrimary }}
           - name: SERVICE_TIMESCALE_PRIMARY
-            value: "true"
-          {{- end }}
+            value: {{ .Values.thorasApiServerV2.timescalePrimary | quote}}
           {{- if (.Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second) }}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second | quote }}

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -108,6 +108,10 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_STORAGE_FILE_PATH
             value: "/var/lib/share"
+          {{- if .Values.thorasApiServerV2.timescalePrimary }}
+          - name: SERVICE_TIMESCALE_PRIMARY
+            value: "true"
+          {{- end }}
           {{- if (.Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second) }}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second | quote }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -98,6 +98,7 @@ thorasApiServerV2:
     memory: 100Mi
   port: 80
   logLevel: "info"
+  timescalePrimary: false
 
 thorasDashboard:
   enabled: true


### PR DESCRIPTION
# Why are we making this change?

We need a feature flag for enabling timescale as the primary data source instead of Elastic.
