### PR TITLE
Add env variable to collector for controlling parallelization

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -185,3 +185,5 @@ spec:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: password
+          - name: SERVICE_COLLECTION_PARALLELIZATION
+            value: "{{ .Values.metricsCollector.collector.parallelization | default 20}}"

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -92,6 +92,8 @@ Default containers should match snapshots:
           secretKeyRef:
             key: password
             name: thoras-timescale-password
+      - name: SERVICE_COLLECTION_PARALLELIZATION
+        value: "20"
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?
The metrics collector now supports collecting metrics in parallel instead of serially.

# What's changing?
This PR adds a new optional field (defaults to 20) that controls the number of AST metrics to be collecting in parallel.
