### PR TITLE
Use camel-casing for queriesPerSecond

### DIFF
--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -55,9 +55,9 @@ spec:
             value: "{{ .Values.thorasAgent.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: SERVICE_CLUSTER_NAME
             value: "{{ .Values.cluster.name }}"
-          {{- if (.Values.thorasAgent.queries_per_second | default .Values.queries_per_second) }}
+          {{- if (.Values.thorasAgent.queriesPerSecond | default .Values.queriesPerSecond) }}
           - name: SERVICE_QUERIES_PER_SECOND
-            value: {{ .Values.thorasAgent.queries_per_second | default .Values.queries_per_second | quote }}
+            value: {{ .Values.thorasAgent.queriesPerSecond | default .Values.queriesPerSecond | quote }}
           {{- end }}
         ports:
           - containerPort: {{ .Values.thorasAgent.containerPort }}

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -110,9 +110,9 @@ spec:
             value: "/var/lib/share"
           - name: SERVICE_TIMESCALE_PRIMARY
             value: {{ .Values.thorasApiServerV2.timescalePrimary | quote}}
-          {{- if (.Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second) }}
+          {{- if (.Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond) }}
           - name: SERVICE_QUERIES_PER_SECOND
-            value: {{ .Values.thorasApiServerV2.queries_per_second | default .Values.queries_per_second | quote }}
+            value: {{ .Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond | quote }}
           {{- end }}
         volumeMounts:
           {{- if .Values.metricsCollector.persistence.enabled }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -90,9 +90,9 @@ spec:
             value: "{{ .Values.imagePullPolicy }}"
           - name: MODEL_SKIP_CACHE
             value: "{{ .Values.thorasForecast.skipCache }}"
-          {{- if (.Values.thorasOperator.queries_per_second | default .Values.queries_per_second) }}
+          {{- if (.Values.thorasOperator.queriesPerSecond | default .Values.queriesPerSecond) }}
           - name: SERVICE_QUERIES_PER_SECOND
-            value: {{ .Values.thorasOperator.queries_per_second | default .Values.queries_per_second | quote }}
+            value: {{ .Values.thorasOperator.queriesPerSecond | default .Values.queriesPerSecond | quote }}
           {{- end }}
         command: [
           "/app/operator"


### PR DESCRIPTION
# Why are we making this change?

We prefer `camelCase` to `snake_casing` for value overrides.