### PR TITLE
Set a default max qps for all services

### DIFF
--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -55,10 +55,8 @@ spec:
             value: "{{ .Values.thorasAgent.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: SERVICE_CLUSTER_NAME
             value: "{{ .Values.cluster.name }}"
-          {{- if (.Values.thorasAgent.queriesPerSecond | default .Values.queriesPerSecond) }}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasAgent.queriesPerSecond | default .Values.queriesPerSecond | quote }}
-          {{- end }}
         ports:
           - containerPort: {{ .Values.thorasAgent.containerPort }}
         resources:

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -110,10 +110,8 @@ spec:
             value: "/var/lib/share"
           - name: SERVICE_TIMESCALE_PRIMARY
             value: {{ .Values.thorasApiServerV2.timescalePrimary | quote}}
-          {{- if (.Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond) }}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond | quote }}
-          {{- end }}
         volumeMounts:
           {{- if .Values.metricsCollector.persistence.enabled }}
           - name: elastic-search-data

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -90,10 +90,8 @@ spec:
             value: "{{ .Values.imagePullPolicy }}"
           - name: MODEL_SKIP_CACHE
             value: "{{ .Values.thorasForecast.skipCache }}"
-          {{- if (.Values.thorasOperator.queriesPerSecond | default .Values.queriesPerSecond) }}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasOperator.queriesPerSecond | default .Values.queriesPerSecond | quote }}
-          {{- end }}
         command: [
           "/app/operator"
         ]

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -157,3 +157,6 @@ thorasReasoning:
     requests:
       cpu: 128m
       memory: 8Mi
+
+# K8s client max queries per second
+queriesPerSecond: "50"


### PR DESCRIPTION
# Why are we making this change?

We want to set a liberal limit to the Kubernetes client QPS so that Thoras supports large installations out-of-the-box. This value doesn't mean the client will call the k8s api this many times -- only if it's needed

# What's changing?

Explicitly set qps for all services that use the k8s client, and default it to 50