### PR TITLE
Release 4.17.3

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.17.2
+version: 4.17.3

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.17.2](https://img.shields.io/badge/Version-4.17.2-informational?style=flat-square) ![AppVersion: 4.6.4](https://img.shields.io/badge/AppVersion-4.6.4-informational?style=flat-square)
+![Version: 4.17.3](https://img.shields.io/badge/Version-4.17.3-informational?style=flat-square) ![AppVersion: 4.6.4](https://img.shields.io/badge/AppVersion-4.6.4-informational?style=flat-square)
 
 # Install
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -62,6 +62,7 @@ spec:
               exit 1
             else
               mkdir -p /var/lib/share/blobs
+              chown -R 1000:1000 /var/lib/share/blobs
             fi
         {{- if .Values.metricsCollector.persistence.enabled }}
         volumeMounts:


### PR DESCRIPTION
# Why are we making this change?

Need to change ownership on the blob storage directory to clear up a `permission denied` error when accessing blobs.