### PR TITLE
Cleanup CronJob should respect Slack secret reference

### DIFF
--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -26,8 +26,13 @@ spec:
               - name: SLACK_WEBHOOK_URL
                 valueFrom:
                   secretKeyRef:
+                  {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                    name: {{ .Values.slackWebhookUrlSecretRefName }}
+                    key: {{ .Values.slackWebhookUrlSecretRefKey }}
+                  {{- else }}
                     name: thoras-slack
                     key: webhookUrl
+                  {{- end }}
               - name: SLACK_ERRORS_ENABLED
                 value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
               - name: DATABASE_HOST

--- a/charts/thoras/tests/collector_cronjob_test.yaml
+++ b/charts/thoras/tests/collector_cronjob_test.yaml
@@ -31,3 +31,26 @@ tests:
           content:
             name: "SERVICE_POSTGRESQL_DSN"
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
+  - it: Uses default slack URL when no value is set
+    asserts:
+      - contains:
+          path: .spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: "SLACK_WEBHOOK_URL"
+            valueFrom:
+              secretKeyRef:
+                name: thoras-slack
+                key: webhookUrl
+  - it: Uses custom slack secret reference when slackWebhookUrlSecretRefName set
+    set:
+      slackWebhookUrlSecretRefName: someSecretName
+      slackWebhookUrlSecretRefKey: someSecretKey
+    asserts:
+      - contains:
+          path: .spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: "SLACK_WEBHOOK_URL"
+            valueFrom:
+              secretKeyRef:
+                name: someSecretName
+                key: someSecretKey


### PR DESCRIPTION
# Why?

Metric retention cronjob currently fails to respect when users specify a Slack secret reference

# What's changing?
This pull request introduces changes to the `charts/thoras` directory, specifically improving the handling of Slack webhook URL configurations and updating the corresponding tests. The most important changes include adding conditional logic for Slack webhook URL secrets in the `cronjob.yaml` file and enhancing the test coverage in the `collector_cronjob_test.yaml` file.

Improvements to Slack webhook URL configuration:

* [`charts/thoras/templates/collector/cronjob.yaml`](diffhunk://#diff-fba3c0b424ee89fa9792d2955fe6edf5b84dff5fe302883e9754c9ec478a26f4R29-R35): Added conditional logic to use custom Slack webhook URL secret references if provided, otherwise default to the existing secret.

Enhancements to test coverage:

* [`charts/thoras/tests/collector_cronjob_test.yaml`](diffhunk://#diff-bbf157cc267e791df1a293a5a3e87c3a954f65df10b0f76d18ead5179ba9d109R34-R56): Added tests to verify the usage of default Slack URL and custom Slack secret references in the environment variables.