### PR TITLE
Allow assigning workloads to nodes

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -64,6 +64,7 @@ helm install \
 | slackWebhookUrl           | String  | ""                                               | Slack Webhook URL destination for notifications.             |
 | slackErrorsEnabled        | Boolean | false                                            | Determines if error-level logs are sent to `slackWebHookUrl` |
 | queriesPerSecond          | String  | "50"                                             | Sets a maximum threshold for K8s API qps                     |
+| nodeSelector              | Object  | {}                                               | Node selectors to designate specific nodes to run Thoras workloads |
 
 ## Thoras Forecast
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -126,3 +126,7 @@ spec:
           requests:
             cpu: {{ .Values.thorasApiServerV2.requests.cpu }}
             memory: {{ .Values.thorasApiServerV2.requests.memory }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -51,3 +51,7 @@ spec:
               - |
                 ./metrics-collector purge metrics \
                 --metric-ttl={{ .Values.metricsCollector.purge.ttl }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -187,3 +187,7 @@ spec:
                 key: password
           - name: SERVICE_COLLECTION_PARALLELIZATION
             value: "{{ .Values.metricsCollector.collector.parallelization | default 20}}"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/collector/purge-forecast-hook.yaml
+++ b/charts/thoras/templates/collector/purge-forecast-hook.yaml
@@ -23,3 +23,7 @@ spec:
         args:
           - |
             ./metrics-collector purge cronjobs
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -89,3 +89,7 @@ spec:
           - name: nginx-config
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/monitor-v2/deployment.yaml
+++ b/charts/thoras/templates/monitor-v2/deployment.yaml
@@ -48,4 +48,8 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_THORAS_API_BASE_URL
             value: "http://thoras-api-server-v2"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -86,4 +86,9 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
 {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -92,6 +92,15 @@ spec:
             value: "{{ .Values.thorasForecast.skipCache }}"
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasOperator.queriesPerSecond | default .Values.queriesPerSecond | quote }}
+          {{- with .Values.nodeSelector }}
+            {{- $result := list -}}
+            {{- range $key, $value := . }}
+              {{- $result = append $result (printf "%s:%s" $key $value) }}
+            {{- end }}
+            {{- $finalString := join "," $result }}
+          - name: FORECAST_NODE_SELECTOR
+            value: {{ $finalString }}
+          {{- end }}
         command: [
           "/app/operator"
         ]
@@ -112,3 +121,7 @@ spec:
           requests:
             cpu: {{ .Values.thorasOperator.requests.cpu }}
             memory: {{ .Values.thorasOperator.requests.memory }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -74,4 +74,8 @@ spec:
           requests:
             cpu: {{ .Values.thorasReasoning.api.requests.cpu }}
             memory: {{ .Values.thorasReasoning.api.requests.memory }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{ end }}

--- a/charts/thoras/tests/collector_cronjob_test.yaml
+++ b/charts/thoras/tests/collector_cronjob_test.yaml
@@ -54,3 +54,14 @@ tests:
               secretKeyRef:
                 name: someSecretName
                 key: someSecretKey
+
+  - it: Has nodeSelector set when nodeSelector specified
+    set:
+      nodeSelector:
+        color: green
+    asserts:
+      - isSubset:
+          path: .spec.jobTemplate.spec.template.spec
+          content:
+            nodeSelector:
+              color: green

--- a/charts/thoras/tests/deployments_test.yaml
+++ b/charts/thoras/tests/deployments_test.yaml
@@ -1,9 +1,7 @@
 suite: Deployments
 templates:
   - api-server-v2/deployment.yaml
-  # - collector/deployment.yaml
   - dashboard/deployment.yaml
-  # - monitor/deployment.yaml
   - operator/deployment.yaml
   - reasoning-api/deployment.yaml
 set:
@@ -52,3 +50,13 @@ tests:
       - equal:
           path: spec.replicas
           value: 12
+  - it: Has nodeSelector set when nodeSelector specified
+    set:
+      nodeSelector:
+        color: green
+    asserts:
+      - isSubset:
+          path: .spec.template.spec
+          content:
+            nodeSelector:
+              color: green

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -26,3 +26,12 @@ tests:
       - equal:
           path: $.spec.template.spec.containers[0].env[?(@.name == 'MODEL_SKIP_CACHE')].value
           value: "true"
+  - it: Has FORECAST_NODE_SELECTOR set when nodeSelector specified
+    set:
+      nodeSelector:
+        color: green
+        bestGame: sekiro
+    asserts:
+      - equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == 'FORECAST_NODE_SELECTOR')].value
+          value: "bestGame:sekiro,color:green"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -160,3 +160,6 @@ thorasReasoning:
 
 # K8s client max queries per second
 queriesPerSecond: "50"
+
+# nodeSelector is used to assign components to specific nodes
+nodeSelector: {}


### PR DESCRIPTION
# Why are we making this change?

Users need the ability to assign workloads to nodes with specific labels. This can be done multiple ways but one of the [simplest and most common ways is via node labels](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/). Our helm chart should provide the ability to run the Thoras platform on nodes with a specific label
 
# What's changing?

* Provide users the ability to run Thoras on nodes with a particular label
* Unit tests
* Updated docs
