### PR TITLE
Add configurable persistence accessMode for the PVC

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -94,6 +94,7 @@ helm install \
 | metricsCollector.persistence.createEFSStorageClass.fileSystemId | String  | ""               | Create dynamic PV provisioner for EFS by specifying EFS id                    |
 | metricsCollector.persistence.storageClassName                   | String  | ""               | Storage class for PVC                                                         |
 | metricsCollector.persistence.pvcStorageRequestSize              | String  | "3Gi"            | Inform PV backend of minimal volume requirements                              |
+| metricsCollector.persistence.accessMode                         | String  | "ReadWriteOnce"  | The accessMode applied to the PVC                                             |
 | metricsCollector.collector.name                                 | String  | thoras-collector | Thoras collector container name                                               |
 | metricsCollector.collector.logLevel                             | String  | Nil              | Logging level                                                                 |
 | metricsCollector.podAnnotations                                 | Object  | {}               | Pod Annotations for Thoras metrics collector                                  |

--- a/charts/thoras/templates/collector/pvc.yaml
+++ b/charts/thoras/templates/collector/pvc.yaml
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   storageClassName: {{ .Values.metricsCollector.persistence.storageClassName }}
   accessModes:
-    - {{ .Values.metricsCollector.persistence.accessMode | default "ReadWriteOnce" | quote }}
+    - {{ .Values.metricsCollector.persistence.accessMode | default "ReadWriteOnce" }}
   resources:
     requests:
       storage: {{ .Values.metricsCollector.persistence.pvcStorageRequestSize }}

--- a/charts/thoras/templates/collector/pvc.yaml
+++ b/charts/thoras/templates/collector/pvc.yaml
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   storageClassName: {{ .Values.metricsCollector.persistence.storageClassName }}
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.metricsCollector.persistence.accessMode | default "ReadWriteOnce" | quote }}
   resources:
     requests:
       storage: {{ .Values.metricsCollector.persistence.pvcStorageRequestSize }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -51,6 +51,7 @@ metricsCollector:
     enabled: false
     volumeName: ""
     storageClassName: "efs-sc-thoras"
+    accessMode: "ReadWriteOnce"
     createEFSStorageClass:
       fileSystemId: ""
     pvcStorageRequestSize: "3Gi"


### PR DESCRIPTION
# Why are we making this change?

Customers should be able to set an access mode to something other than `ReadWriteOnce` if they want to decouple the service layer from the timescale/collector pod.