### PR TITLE
Add node tolerations

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -50,28 +50,29 @@ helm install \
 
 ## Global
 
-| Key                       | Type    | Default                                          | Description                                                  |
-| ------------------------- | ------- | ------------------------------------------------ | ------------------------------------------------------------ |
-| thorasVersion             | String  | 4.7.0                                            | Thoras app version                                           |
-| imageCredentials.registry | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                      |
-| imageCredentials.username | String  | \_json_key_base64                                | Container registry username                                  |
-| imageCredentials.password | String  | ""                                               | Container registry auth string                               |
-| resourceQuota.enabled     | Bool    | false                                            | Enables resource quotas within Thoras                        |
-| resourceQuota.pods        | Number  | 200                                              | Maximum number of pods allowed                               |
-| resourceQuota.cronjobs    | Number  | 200                                              | Maximum number of cronjobs allowed                           |
-| resourceQuota.jobs        | Number  | 200                                              | Maximum number of jobs allowed                               |
-| logLevel                  | String  | info                                             | Default log level                                            |
-| slackWebhookUrl           | String  | ""                                               | Slack Webhook URL destination for notifications.             |
-| slackErrorsEnabled        | Boolean | false                                            | Determines if error-level logs are sent to `slackWebHookUrl` |
-| queriesPerSecond          | String  | "50"                                             | Sets a maximum threshold for K8s API qps                     |
+| Key                       | Type    | Default                                          | Description                                                        |
+| ------------------------- | ------- | ------------------------------------------------ | ------------------------------------------------------------------ |
+| thorasVersion             | String  | 4.7.0                                            | Thoras app version                                                 |
+| imageCredentials.registry | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                            |
+| imageCredentials.username | String  | \_json_key_base64                                | Container registry username                                        |
+| imageCredentials.password | String  | ""                                               | Container registry auth string                                     |
+| resourceQuota.enabled     | Bool    | false                                            | Enables resource quotas within Thoras                              |
+| resourceQuota.pods        | Number  | 200                                              | Maximum number of pods allowed                                     |
+| resourceQuota.cronjobs    | Number  | 200                                              | Maximum number of cronjobs allowed                                 |
+| resourceQuota.jobs        | Number  | 200                                              | Maximum number of jobs allowed                                     |
+| logLevel                  | String  | info                                             | Default log level                                                  |
+| slackWebhookUrl           | String  | ""                                               | Slack Webhook URL destination for notifications.                   |
+| slackErrorsEnabled        | Boolean | false                                            | Determines if error-level logs are sent to `slackWebHookUrl`       |
+| queriesPerSecond          | String  | "50"                                             | Sets a maximum threshold for K8s API qps                           |
 | nodeSelector              | Object  | {}                                               | Node selectors to designate specific nodes to run Thoras workloads |
+| tolerations               | Array   | []                                               | Node taint tolerations to be used for to set up Thoras workloads   |
 
 ## Thoras Forecast
 
 | Key                      | Type    | Default        | Description                                   |
 | ------------------------ | ------- | -------------- | --------------------------------------------- |
 | thorasForecast.imageTag  | String  | .thorasVersion | Image tag for Thoras Forecast job             |
-| thorasForecast.skipCache | Boolean |  false         | Directs the forecaster to skip to model cache |
+| thorasForecast.skipCache | Boolean | false          | Directs the forecaster to skip to model cache |
 
 ## Thoras Operator
 
@@ -88,7 +89,7 @@ helm install \
 ## Thoras Metrics Collector
 
 | Key                                                             | Type    | Default          | Description                                                                   |
-| --------------------------------------------------------------- | ------- | ---------------- | ------------------------------------------------------------------------------|
+| --------------------------------------------------------------- | ------- | ---------------- | ----------------------------------------------------------------------------- |
 | metricsCollector.persistence.enabled                            | Bool    | false            | Enables persistence for Thoras metrics collector                              |
 | metricsCollector.persistence.volumeName                         | String  | ""               | PV name for PVC. Keep blank if using dynamic provisioning                     |
 | metricsCollector.persistence.createEFSStorageClass.fileSystemId | String  | ""               | Create dynamic PV provisioner for EFS by specifying EFS id                    |
@@ -109,8 +110,8 @@ helm install \
 
 ## Thoras API Server
 
-| Key                                           |  Type   | Default | Description                                                                   |
-| -------------------------------------         | ------- | ------- | ------------------------------------------------------------------------------|
+| Key                                           | Type    | Default | Description                                                                   |
+| --------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------- |
 | thorasApiServerV2.podAnnotations              | Object  | {}      | Pod Annotations for Thoras Thoras API                                         |
 | thorasApiServerV2.containerPort               | Number  | 8443    | Thoras API port                                                               |
 | thorasApiServerV2.port                        | Number  | 443     | Thoras API service port                                                       |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -140,3 +140,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -205,3 +205,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -93,3 +93,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/monitor-v2/deployment.yaml
+++ b/charts/thoras/templates/monitor-v2/deployment.yaml
@@ -52,4 +52,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -90,5 +90,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -125,3 +125,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -101,6 +101,8 @@ spec:
           - name: FORECAST_NODE_SELECTOR
             value: {{ $finalString }}
           {{- end }}
+          - name: SERVICE_FORECAST_TOLERATIONS
+            value: {{ .Values.tolerations | toJson | quote }}
         command: [
           "/app/operator"
         ]

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -78,4 +78,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{ end }}

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[*].securityContext
-  - it: Should tolerations if specified
+  - it: Should set tolerations if specified
     set:
       tolerations:
         - key: "example-key"

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -38,3 +38,20 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[*].securityContext
+  - it: Should tolerations if specified
+    set:
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+  - it: Should not have tolerations if not specified
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -86,7 +86,7 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[*].securityContext
-  - it: Should tolerations if specified
+  - it: Should set tolerations if specified
     set:
       tolerations:
         - key: "example-key"

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -36,7 +36,7 @@ tests:
           value:
             - name: elastic-search-data
               persistentVolumeClaim:
-                claimName:  elastic-search-data
+                claimName: elastic-search-data
       - equal:
           path: spec.template.spec.containers[0].volumeMounts
           value:
@@ -50,7 +50,7 @@ tests:
             name: timescaledb
           any: true
 
-### Security context tests
+  ### Security context tests
   - it: Should use additional securityContext if specified
     set:
       metricsCollector:
@@ -86,3 +86,20 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[*].securityContext
+  - it: Should tolerations if specified
+    set:
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+  - it: Should not have tolerations if not specified
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/thoras/tests/dashboard_deployment_test.yaml
+++ b/charts/thoras/tests/dashboard_deployment_test.yaml
@@ -34,7 +34,7 @@ tests:
             name: nginx-config
             configMap:
               name: thoras-dashboard-nginx-config
-  - it: Should tolerations if specified
+  - it: Should set tolerations if specified
     set:
       tolerations:
         - key: "example-key"

--- a/charts/thoras/tests/dashboard_deployment_test.yaml
+++ b/charts/thoras/tests/dashboard_deployment_test.yaml
@@ -34,3 +34,20 @@ tests:
             name: nginx-config
             configMap:
               name: thoras-dashboard-nginx-config
+  - it: Should tolerations if specified
+    set:
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+  - it: Should not have tolerations if not specified
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/thoras/tests/monitor_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_deployment_test.yaml
@@ -36,7 +36,7 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
           value: RELEASE-NAME
-  - it: Should tolerations if specified
+  - it: Should set tolerations if specified
     template: monitor/deployment.yaml
     set:
       tolerations:

--- a/charts/thoras/tests/monitor_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_deployment_test.yaml
@@ -36,3 +36,21 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
           value: RELEASE-NAME
+  - it: Should tolerations if specified
+    template: monitor/deployment.yaml
+    set:
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+  - it: Should not have tolerations if not specified
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/thoras/tests/monitor_v2_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_v2_deployment_test.yaml
@@ -3,12 +3,11 @@ templates:
   - monitor-v2/deployment.yaml
 set:
   thorasVersion: 1.0.0-alpha
+  thorasMonitorV2:
+    enabled: true
 tests:
   - it: Should create deployment when thorasMonitorV2.enabled is true
     template: monitor-v2/deployment.yaml
-    set:
-      thorasMonitorV2:
-        enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].name
@@ -21,3 +20,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: Should tolerations if specified
+    template: monitor-v2/deployment.yaml
+    set:
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+  - it: Should not have tolerations if not specified
+    template: monitor-v2/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/thoras/tests/monitor_v2_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_v2_deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: Should tolerations if specified
+  - it: Should set tolerations if specified
     template: monitor-v2/deployment.yaml
     set:
       tolerations:

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -48,7 +48,13 @@ tests:
             key: "example-key"
             operator: "Exists"
             effect: "NoSchedule"
+      - equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_TOLERATIONS')].value
+          value: '[{"effect":"NoSchedule","key":"example-key","operator":"Exists"}]'
   - it: Should not have tolerations if not specified
     asserts:
       - notExists:
           path: spec.template.spec.tolerations
+      - equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_TOLERATIONS')].value
+          value: "[]"

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
       - equal:
           path: .spec.template.spec.containers[0].env[?(@.name == 'FORECAST_NODE_SELECTOR')].value
           value: "bestGame:sekiro,color:green"
-  - it: Should tolerations if specified
+  - it: Should set tolerations if specified
     set:
       tolerations:
         - key: "example-key"

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -35,3 +35,20 @@ tests:
       - equal:
           path: .spec.template.spec.containers[0].env[?(@.name == 'FORECAST_NODE_SELECTOR')].value
           value: "bestGame:sekiro,color:green"
+  - it: Should tolerations if specified
+    set:
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+  - it: Should not have tolerations if not specified
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/thoras/tests/reasoning_api_deployment_test.yaml
+++ b/charts/thoras/tests/reasoning_api_deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
       - notExists:
           kind: Service
           name: reasoning-api
-  - it: Should tolerations if specified
+  - it: Should set tolerations if specified
     set:
       tolerations:
         - key: "example-key"

--- a/charts/thoras/tests/reasoning_api_deployment_test.yaml
+++ b/charts/thoras/tests/reasoning_api_deployment_test.yaml
@@ -1,11 +1,13 @@
 suite: Reasoning
 templates:
   - reasoning-api/deployment.yaml
+set:
+  thorasReasoning:
+    enabled: true
 tests:
   - it: Set prometheus URL correctly
     set:
       thorasReasoning:
-        enabled: true
         connectors:
           prometheus:
             baseUrl: "http://whats-good"
@@ -24,3 +26,20 @@ tests:
       - notExists:
           kind: Service
           name: reasoning-api
+  - it: Should tolerations if specified
+    set:
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+  - it: Should not have tolerations if not specified
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -165,3 +165,5 @@ queriesPerSecond: "50"
 
 # nodeSelector is used to assign components to specific nodes
 nodeSelector: {}
+
+tolerations: {}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -166,4 +166,4 @@ queriesPerSecond: "50"
 # nodeSelector is used to assign components to specific nodes
 nodeSelector: {}
 
-tolerations: {}
+tolerations: []


### PR DESCRIPTION
# Why are we making this change?

Thoras users would like to have the ability to have node groups specifically for thoras workloads. 

# What's changing?

Added `tolerations` value that is[ 1:1 with pod tolerations schema](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)

```
tolerations:
- key: "key1"
  operator: "Equal"
  value: "value1"
  effect: "NoSchedule"
```