### PR TITLE
Make accessmode a var

### DIFF
--- a/charts/thoras/templates/collector/pvc.yaml
+++ b/charts/thoras/templates/collector/pvc.yaml
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   storageClassName: {{ .Values.metricsCollector.persistence.storageClassName }}
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.metricsCollector.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.metricsCollector.persistence.pvcStorageRequestSize }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -54,6 +54,7 @@ metricsCollector:
     createEFSStorageClass:
       fileSystemId: ""
     pvcStorageRequestSize: "3Gi"
+    accessMode: "ReadWriteOnce"
   podAnnotations: {}
   collector:
     name: thoras-collector


### PR DESCRIPTION
# Why are we making this change?

Thoras users will need to be able to config their pvc acessmode

# What's changing?

added `.Values.metricsCollector.persistence.accessMode` and default to ReadWriteOnce