### PR TITLE
added forecast-worker pods

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.thorasForecast.worker.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thoras-forecast-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas:  {{ .Values.thorasForecast.worker.replicas }}
+  selector:
+    matchLabels:
+      app: thoras-forecast-worker
+  template:
+    metadata:
+      labels:
+        app: thoras-forecast-worker
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        {{- with .Values.thorasForecast.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: thoras-operator
+      containers:
+      - image: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        name: thoras-forecast-worker
+        command: [
+          "worker",
+          "--polling_interval",
+          "{{ .Values.thorasForecast.worker.pollingInterval }}"
+        ]
+        env:
+          - name: "LOGLEVEL"
+            value: {{ default .Values.logLevel .Values.thorasForecast.logLevel }}
+          - name: API_BASE_URL
+            value: "http://thoras-api-server-v2"
+        resources:
+          requests:
+            cpu: {{ .Values.thorasForecast.worker.requests.cpu }}
+            memory: {{ .Values.thorasForecast.worker.requests.memory }}
+          limits:
+            cpu: {{ .Values.thorasForecast.worker.limits.cpu }}
+            memory: {{ .Values.thorasForecast.worker.limits.memory }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -1,0 +1,49 @@
+suite: forecast-worker
+templates:
+  - forecast-worker/deployment.yaml
+set:
+  thorasForecast:
+    imageTag: "TEST"
+    worker:
+      enabled: true
+tests:
+  - it: Ensure SERVICE_REASONING_ENABLED not exists when reasoning is disabled
+    set:
+      thorasForecast:
+        worker:
+          replicas: 10
+          pollingInterval: 30
+          limits:
+            memory: 2.5Gi
+            cpu: 4
+          requests:
+            cpu: 1500m
+            memory: 100Mi
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: thoras-forecast-worker
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-forecast:TEST
+      - equal:
+          path: spec.replicas
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests
+          value:
+            cpu: 1500m
+            memory: 100Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits
+          value:
+            memory: 2.5Gi
+            cpu: 4
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - "worker"
+            - "--polling_interval"
+            - "30"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -136,6 +136,17 @@ thorasMonitorV2:
 thorasForecast:
   skipCache: false
   requestCpu:
+  worker:
+    enabled: false
+    replicas: 1
+    pollingInterval: 15
+    podAnnotations: {}
+    limits:
+      memory: 2Gi
+      cpu: 2
+    requests:
+      cpu: 1
+      memory: 250Mi
 
 thorasAgent:
   enabled: false


### PR DESCRIPTION
# Why are we making this change?

Thoras will be migrating to a queue based forecast architecture. 

# What's changing?

Added `thorasForecast.worker.enabled`. When set to true the forecast worker pods will spin up. 