### PR TITLE
Update docs to reflect current thorasVersion

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -52,7 +52,7 @@ helm install \
 
 | Key                       | Type    | Default                                          | Description                                                        |
 | ------------------------- | ------- | ------------------------------------------------ | ------------------------------------------------------------------ |
-| thorasVersion             | String  | 4.7.0                                            | Thoras app version                                                 |
+| thorasVersion             | String  | 4.8.2                                            | Thoras app version                                                 |
 | imageCredentials.registry | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                            |
 | imageCredentials.username | String  | \_json_key_base64                                | Container registry username                                        |
 | imageCredentials.password | String  | ""                                               | Container registry auth string                                     |


### PR DESCRIPTION
# Why are we making this change?

Docs should be aligned w/default Thoras version

# What's changing?

Update README w/correct thoras version

