### PR TITLE
Add blob api service

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -102,7 +102,8 @@ helm install \
 | metricsCollector.search.imageTag                                | String  | 8.12.1           | Elasticsearch image tag                                                       |
 | metricsCollector.search.name                                    | String  | elasticsearch    | Elasticsearch container name                                                  |
 | metricsCollector.search.containerPort                           | Number  | 9200             | Elasticsearch port                                                            |
-| metricsCollector.blobService.containerPort                      | Number  | 80               | Blob service port                                                             |
+| metricsCollector.blobService.port                               | Number  | 80               | Blob service external port                                                    |
+| metricsCollector.blobService.containerPort                      | Number  | 8080             | Blob service internal port                                                    |
 | metricsCollector.purge.ttl                                      | String  | 30d              | How long to keep metrics data in Elasticsearch                                |
 | metricsCollector.purge.schedule                                 | String  | 00 00 \* \* \*   | Cron expression for metrics purge job                                         |
 | metricsCollector.slackErrorsEnabled                             | Boolean | false            | Determines if error-level logs are sent to `slackWebHookUrl`                  |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -102,6 +102,7 @@ helm install \
 | metricsCollector.search.imageTag                                | String  | 8.12.1           | Elasticsearch image tag                                                       |
 | metricsCollector.search.name                                    | String  | elasticsearch    | Elasticsearch container name                                                  |
 | metricsCollector.search.containerPort                           | Number  | 9200             | Elasticsearch port                                                            |
+| metricsCollector.blobService.containerPort                      | Number  | 80               | Blob service port                                                             |
 | metricsCollector.purge.ttl                                      | String  | 30d              | How long to keep metrics data in Elasticsearch                                |
 | metricsCollector.purge.schedule                                 | String  | 00 00 \* \* \*   | Cron expression for metrics purge job                                         |
 | metricsCollector.slackErrorsEnabled                             | Boolean | false            | Determines if error-level logs are sent to `slackWebHookUrl`                  |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -59,13 +59,15 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-v2-api-server
-        command: ["/app/api-server", "-p", {{ .Values.thorasApiServerV2.containerPort | quote }}]
+        command: ["/app/api-server"]
         env:
           - name: DATABASE_HOST
             valueFrom:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: host
+          - name: SERVICE_PORT
+            value: {{ .Values.thorasApiServerV2.containerPort | quote }}
           - name: SERVICE_POSTGRESQL_DSN
             value: "$(DATABASE_HOST)/thoras"
           - name: "ELASTICSEARCH_URL"

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -28,12 +28,6 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.thorasApiServerV2.serviceAccount.name }}
-      {{- if .Values.metricsCollector.persistence.enabled }}
-      volumes:
-        - name: elastic-search-data
-          persistentVolumeClaim:
-            claimName:  elastic-search-data
-      {{- end }}
       initContainers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         name: wait-for-postgres
@@ -60,19 +54,7 @@ spec:
             if [ $retries -ge $max_retries ]; then
               echo "Failed to connect to database after $max_retries retries"
               exit 1
-            else
-              mkdir -p /var/lib/share/blobs
-              chown -R 1000:1000 /var/lib/share/blobs
             fi
-        {{- if .Values.metricsCollector.persistence.enabled }}
-        volumeMounts:
-          - name: elastic-search-data
-            mountPath: /var/lib/share
-          {{- with .Values.thorasApiServerV2.additionalPvSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
-        {{- end }}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -111,23 +93,12 @@ spec:
             value: {{ .Values.thorasReasoning.connectors.prometheus.baseUrl }}
           - name: SERVICE_CLUSTER_NAME
             value: "{{ .Values.cluster.name }}"
-          - name: SERVICE_STORAGE_FILE_PATH
-            value: "/var/lib/share"
+          - name: SERVICE_BLOB_SERVICE_API_URL
+            value: "http://thoras-blob-api.thoras.svc.cluster.local"
           - name: SERVICE_TIMESCALE_PRIMARY
             value: {{ .Values.thorasApiServerV2.timescalePrimary | quote}}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond | quote }}
-        {{- if .Values.metricsCollector.persistence.enabled }}
-        volumeMounts:
-          - name: elastic-search-data
-            mountPath: /var/lib/share
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 0
-          {{- with .Values.thorasApiServerV2.additionalPvSecurityContext }}
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-        {{- end }}
         ports:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
         resources:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -101,7 +101,7 @@ spec:
         name: timescaledb
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         ports:
-        - containerPort: 5432
+        - containerPort: {{ .Values.metricsCollector.timescale.containerPort }}
         env:
           - name: "POSTGRES_PASSWORD"
             valueFrom:

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -37,7 +37,10 @@ spec:
         args:
           - |
             mkdir -p /var/lib/share/elasticsearch/data
+
+            # migrate non-elastic data to the new location
             find /var/lib/share/elasticsearch -not -name postgresql -not -name data -not -name blobs -mindepth 1 -maxdepth 1 -exec mv {} /var/lib/share/elasticsearch/data \;
+
             chown -R 1000:0 /var/lib/share/elasticsearch/data
             rm -f /var/lib/share/elasticsearch/data/node.lock
         {{- with .Values.metricsCollector.additionalPvSecurityContext }}
@@ -47,13 +50,18 @@ spec:
         volumeMounts:
           - mountPath: /var/lib/share/elasticsearch
             name: elastic-search-data
-      - name: fix-timescale-dir-ownership
+      - name: fix-dir-ownership
         image: {{ .Values.imageCredentials.registry }}/alpine:{{ .Values.metricsCollector.init.imageTag }}
         command: ["/bin/sh", "-c"]
         args:
           - |
+            # fix timescale directory
             mkdir -p /var/lib/share/postgresql
             chown -R 1000:1000 /var/lib/share/postgresql
+
+            # fix blobs directory
+            mkdir -p /var/lib/share/blobs
+            chown -R 1000:1000 /var/lib/share/blobs
         {{- with .Values.metricsCollector.additionalPvSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -201,6 +209,38 @@ spec:
                 key: password
           - name: SERVICE_COLLECTION_PARALLELIZATION
             value: "{{ .Values.metricsCollector.collector.parallelization | default 20}}"
+      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        name: thoras-blob-api
+        command: ["/app/blob-service", "-p", "80"]
+        env:
+          - name: SERVICE_SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+            {{- if and .Values.slackWebhookUrlSecretRefName .Values.slackWebhookUrlSecretRefKey }}
+                name: {{ .Values.slackWebhookUrlSecretRefName }}
+                key: {{ .Values.slackWebhookUrlSecretRefKey }}
+            {{- else }}
+                name: thoras-slack
+                key: webhookUrl
+            {{- end }}
+          - name: SERVICE_SLACK_ERRORS_ENABLED
+            value: "{{ .Values.metricsCollector.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
+          - name: "SERVICE_LOG_LEVEL"
+            value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
+          - name: SERVICE_STORAGE_FILE_PATH
+            value: "/var/lib/share"
+        {{- if .Values.metricsCollector.persistence.enabled }}
+        volumeMounts:
+          - mountPath: /var/lib/share
+            name: elastic-search-data
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 0
+          {{- with .Values.metricsCollector.additionalPvSecurityContext }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -212,8 +212,10 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-blob-api
-        command: ["/app/blob-service", "-p", "80"]
+        command: ["/app/blob-service"]
         env:
+          - name: SERVICE_PORT
+            value: {{ .Values.metricsCollector.blobService.containerPort | quote }}
           - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/collector/service.yaml
+++ b/charts/thoras/templates/collector/service.yaml
@@ -24,3 +24,16 @@ spec:
     targetPort: {{ .Values.metricsCollector.timescale.containerPort }}
   selector:
     app: metrics-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: thoras-blob-api
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: {{ .Values.metricsCollector.blobService.containerPort }}
+    protocol: TCP
+    targetPort: {{ .Values.metricsCollector.blobService.containerPort }}
+  selector:
+    app: metrics-collector

--- a/charts/thoras/templates/collector/service.yaml
+++ b/charts/thoras/templates/collector/service.yaml
@@ -15,7 +15,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.metricsCollector.timescale.name }}
+  name: timescale
   namespace: {{ .Release.Namespace }}
 spec:
   ports:

--- a/charts/thoras/templates/collector/service.yaml
+++ b/charts/thoras/templates/collector/service.yaml
@@ -32,7 +32,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - port: {{ .Values.metricsCollector.blobService.containerPort }}
+  - port: {{ .Values.metricsCollector.blobService.port }}
     protocol: TCP
     targetPort: {{ .Values.metricsCollector.blobService.containerPort }}
   selector:

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -2,42 +2,6 @@ suite: API Service Layer Deployment
 templates:
   - api-server-v2/deployment.yaml
 tests:
-  - it: Should use additional securityContext if specified
-    set:
-      metricsCollector:
-        persistence:
-          enabled: true
-      thorasApiServerV2:
-        additionalPvSecurityContext:
-          additionalField: "additionalValue"
-    asserts:
-      - isSubset:
-          path: spec.template.spec.containers[0].securityContext
-          content:
-            runAsUser: 1000
-            runAsGroup: 0
-            additionalField: "additionalValue"
-      - isSubset:
-          path: spec.template.spec.initContainers[*].securityContext
-          content:
-            additionalField: "additionalValue"
-  - it: Should not use additional securityContext if not specified
-    set:
-      metricsCollector:
-        persistence:
-          enabled: true
-    asserts:
-      - isSubset:
-          path: spec.template.spec.containers[*].securityContext
-          content:
-            runAsUser: 1000
-            runAsGroup: 0
-      - notExists:
-          path: spec.template.spec.initContainers[*].securityContext
-  - it: Should not have any securityContext if persistence is disabled
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[*].securityContext
   - it: Should set tolerations if specified
     set:
       tolerations:

--- a/charts/thoras/tests/deployments_test.yaml
+++ b/charts/thoras/tests/deployments_test.yaml
@@ -14,8 +14,6 @@ set:
     replicas: 12
   thorasDashboard:
     replicas: 12
-  thorasApiServer:
-    replicas: 12
   thorasApiServerV2:
     replicas: 12
 tests:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -73,18 +73,6 @@ metricsCollector:
     containerPort: 5432
   additionalPvSecurityContext: {}
 
-thorasApiServer:
-  containerPort: 8443
-  replicas: 1
-  podAnnotations: {}
-  limits:
-    memory: 2000Mi
-  requests:
-    cpu: 100m
-    memory: 100Mi
-  port: 443
-  logLevel: "debug"
-
 thorasApiServerV2:
   rbac:
     create: true

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -71,6 +71,8 @@ metricsCollector:
     imageTag: "2.17.2-pg16"
     name: timescale
     containerPort: 5432
+  blobService:
+    containerPort: 80
   additionalPvSecurityContext: {}
 
 thorasApiServerV2:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -72,7 +72,8 @@ metricsCollector:
     name: timescale
     containerPort: 5432
   blobService:
-    containerPort: 80
+    containerPort: 8080
+    port: 80
   additionalPvSecurityContext: {}
 
 thorasApiServerV2:


### PR DESCRIPTION
# Why are we making this change?

In order to unbind the API service layer from the PVC and the collector deployment, we're adding a micro service that handles storage of blobs that will collocate inside the collector pod.
