### PR TITLE
fix: rename collector second init container

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         volumeMounts:
           - mountPath: /var/lib/share/elasticsearch
             name: elastic-search-data
-      - name: fix-dir-ownership
+      - name: fix-dir-ownership-postgresql
         image: {{ .Values.imageCredentials.registry }}/alpine:{{ .Values.metricsCollector.init.imageTag }}
         command: ["/bin/sh", "-c"]
         args:


### PR DESCRIPTION
# Why are we making this change?

The collector deployment has the same name for both init containers. It fails to install due to this.

```bash
Error: 1 error occurred:
  │     * Deployment.apps "metrics-collector" is invalid: spec.template.spec.initContainers[1].name: Duplicate value: "fix-dir-ownership"
```

# What's changing?

Change the name of the second init container. The chart installs with this change.