### PR TITLE
Allow thoras op to scale any resource

### DIFF
--- a/charts/thoras/templates/component-clusterrole.yaml
+++ b/charts/thoras/templates/component-clusterrole.yaml
@@ -18,10 +18,10 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apps
+  - '*'
   resources:
-  - deployments/scale
-  - deployments/status
+  - '*/scale'
+  - '*/status'
   verbs:
   - get
   - patch


### PR DESCRIPTION
# Why are we making this change?

Thoras clients would like for Thoras to scale workloads that are not deployments.

# What's changing?

Updated thoras operator service account RBAC to allow it to get/update any scale subresource (rollouts, statefulsets)