### PR TITLE
Ensure resource specs on all deployments

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -43,6 +43,12 @@ spec:
 
             chown -R 1000:0 /var/lib/share/elasticsearch/data
             rm -f /var/lib/share/elasticsearch/data/node.lock
+        resources:
+          limits:
+            memory: {{ .Values.metricsCollector.init.limits.memory }}
+          requests:
+            cpu: {{ .Values.metricsCollector.init.requests.cpu }}
+            memory: {{ .Values.metricsCollector.init.requests.memory }}
         {{- with .Values.metricsCollector.additionalPvSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -62,6 +68,12 @@ spec:
             # fix blobs directory
             mkdir -p /var/lib/share/blobs
             chown -R 1000:1000 /var/lib/share/blobs
+        resources:
+          limits:
+            memory: {{ .Values.metricsCollector.init.limits.memory }}
+          requests:
+            cpu: {{ .Values.metricsCollector.init.requests.cpu }}
+            memory: {{ .Values.metricsCollector.init.requests.memory }}
         {{- with .Values.metricsCollector.additionalPvSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -94,6 +106,12 @@ spec:
               secretKeyRef:
                 name: thoras-elastic-password
                 key: password
+        resources:
+          limits:
+            memory: {{ .Values.metricsCollector.search.limits.memory }}
+          requests:
+            cpu: {{ .Values.metricsCollector.search.requests.cpu }}
+            memory: {{ .Values.metricsCollector.search.requests.memory }}
         {{- if .Values.metricsCollector.persistence.enabled }}
         volumeMounts:
           - mountPath: /var/lib/share/elasticsearch
@@ -118,6 +136,12 @@ spec:
                 key: password
           - name: "PGDATA"
             value: /var/lib/share/postgresql
+        resources:
+          limits:
+            memory: {{ .Values.metricsCollector.timescale.limits.memory }}
+          requests:
+            cpu: {{ .Values.metricsCollector.timescale.requests.cpu }}
+            memory: {{ .Values.metricsCollector.timescale.requests.memory }}
         {{- if .Values.metricsCollector.persistence.enabled }}
         volumeMounts:
           - mountPath: /var/lib/share
@@ -209,6 +233,12 @@ spec:
                 key: password
           - name: SERVICE_COLLECTION_PARALLELIZATION
             value: "{{ .Values.metricsCollector.collector.parallelization | default 20}}"
+        resources:
+          limits:
+            memory: {{ .Values.metricsCollector.collector.limits.memory }}
+          requests:
+            cpu: {{ .Values.metricsCollector.collector.requests.cpu }}
+            memory: {{ .Values.metricsCollector.collector.requests.memory }}
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.collector.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: thoras-blob-api
@@ -232,6 +262,12 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
           - name: SERVICE_STORAGE_FILE_PATH
             value: "/var/lib/share"
+        resources:
+          limits:
+            memory: {{ .Values.metricsCollector.blobService.limits.memory }}
+          requests:
+            cpu: {{ .Values.metricsCollector.blobService.requests.cpu }}
+            memory: {{ .Values.metricsCollector.blobService.requests.memory }}
         {{- if .Values.metricsCollector.persistence.enabled }}
         volumeMounts:
           - mountPath: /var/lib/share

--- a/charts/thoras/templates/monitor-v2/deployment.yaml
+++ b/charts/thoras/templates/monitor-v2/deployment.yaml
@@ -48,6 +48,12 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_THORAS_API_BASE_URL
             value: "http://thoras-api-server-v2"
+        resources:
+          limits:
+            memory: {{ .Values.thorasMonitorV2.limits.memory }}
+          requests:
+            cpu: {{ .Values.thorasMonitorV2.requests.cpu }}
+            memory: {{ .Values.thorasMonitorV2.requests.memory }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -24,7 +24,9 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
+        {{- if not .Values.thorasMonitor.unittesting }}
         checksum/configmap: {{ include (print $.Template.BasePath "/monitor/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.thorasMonitor.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -86,6 +88,12 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
+        resources:
+          limits:
+            memory: {{ .Values.thorasMonitor.limits.memory }}
+          requests:
+            cpu: {{ .Values.thorasMonitor.requests.cpu }}
+            memory: {{ .Values.thorasMonitor.requests.memory }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -19,6 +19,12 @@ Default containers should match snapshots:
     name: elasticsearch
     ports:
       - containerPort: 9200
+    resources:
+      limits:
+        memory: 8192Mi
+      requests:
+        cpu: 16m
+        memory: 1536Mi
   2: |
     args:
       - |
@@ -97,3 +103,9 @@ Default containers should match snapshots:
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     name: thoras-collector
+    resources:
+      limits:
+        memory: 8192Mi
+      requests:
+        cpu: 16m
+        memory: 32Mi

--- a/charts/thoras/tests/all_deployments_test.yaml
+++ b/charts/thoras/tests/all_deployments_test.yaml
@@ -1,0 +1,27 @@
+suite: All Deployments
+templates:
+  - "*/deployment.yaml"
+set:
+  # Enable all deployments
+  thorasForecast:
+    worker:
+      enabled: true
+  thorasMonitor:
+    enabled: true
+    unittesting: true
+  thorasMonitorV2:
+    enabled: true
+    unittesting: true
+  thorasReasoning:
+    enabled: true
+tests:
+  - it: Object type correct
+    asserts:
+      - isKind:
+          of: Deployment
+  - it: Ensure resource requests and limits set
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[*].resources.limits
+      - exists:
+          path: spec.template.spec.containers[*].resources.requests

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -1,4 +1,4 @@
-suite: forecast-worker
+suite: Forecast Worker
 templates:
   - forecast-worker/deployment.yaml
 set:

--- a/charts/thoras/tests/select_deployments_test.yaml
+++ b/charts/thoras/tests/select_deployments_test.yaml
@@ -1,4 +1,4 @@
-suite: Deployments
+suite: Select Deployments
 templates:
   - api-server-v2/deployment.yaml
   - dashboard/deployment.yaml
@@ -17,10 +17,8 @@ set:
   thorasApiServerV2:
     replicas: 12
 tests:
-  - it: Deployment name and image registry should be correct
+  - it: Image registry should be correct
     asserts:
-      - isKind:
-          of: Deployment
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: ^us-east4-docker\.pkg\.dev\/thoras-registry\/platform\/.*$

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -58,22 +58,47 @@ metricsCollector:
   podAnnotations: {}
   collector:
     name: thoras-collector
+    limits:
+      memory: "8192Mi"
+    requests:
+      cpu: "16m"
+      memory: "32Mi"
   search:
     imageTag: "8.12.1"
     name: elasticsearch
     containerPort: 9200
+    limits:
+      memory: "8192Mi"
+    requests:
+      cpu: "16m"
+      memory: "1536Mi"
   purge:
     ttl: 30
     schedule: "00 00 * * *"
   init:
     imageTag: "latest"
+    limits:
+      memory: "8192Mi"
+    requests:
+      cpu: "16m"
+      memory: "32Mi"
   timescale:
     imageTag: "2.17.2-pg16"
     name: timescale
     containerPort: 5432
+    limits:
+      memory: "8192Mi"
+    requests:
+      cpu: "16m"
+      memory: "128Mi"
   blobService:
     containerPort: 8080
     port: 80
+    limits:
+      memory: "8192Mi"
+    requests:
+      cpu: "16m"
+      memory: "128Mi"
   additionalPvSecurityContext: {}
 
 thorasApiServerV2:
@@ -119,11 +144,23 @@ thorasDashboard:
 
 thorasMonitor:
   enabled: false
+  unittesting: false
+  limits:
+    memory: "8192Mi"
+  requests:
+    cpu: "16m"
+    memory: "64Mi"
   podAnnotations: {}
   config: |
 
 thorasMonitorV2:
   enabled: false
+  unittesting: false
+  limits:
+    memory: "8192Mi"
+  requests:
+    cpu: "16m"
+    memory: "32Mi"
 
 thorasForecast:
   skipCache: false


### PR DESCRIPTION
# Why are we making this change?

Ensuring all containers come with sane defaults for resource specs and the ability to override them is a basic chart feature we should already have. This gives users the ability to trust k8s will provision the necessary compute for components as well the ability to customize to their own needs

# What's changing?

* Add resource spec to deployments missing them
* Add unit tests that ensure all deployments have resource spec