### PR TITLE
Propagate node tolerations to cleanup job

### DIFF
--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -55,3 +55,8 @@ spec:
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+

--- a/charts/thoras/templates/collector/cronjob.yaml
+++ b/charts/thoras/templates/collector/cronjob.yaml
@@ -59,4 +59,3 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-

--- a/charts/thoras/tests/all_deployments_test.yaml
+++ b/charts/thoras/tests/all_deployments_test.yaml
@@ -14,11 +14,6 @@ set:
     unittesting: true
   thorasReasoning:
     enabled: true
-  tolerations:
-    - key: "key"
-      operator: "Equal"
-      value: "value"
-      effect: "NoSchedule"
 tests:
   - it: Object type correct
     asserts:
@@ -31,6 +26,12 @@ tests:
       - exists:
           path: spec.template.spec.containers[*].resources.requests
   - it: Has correct tolerations
+    set:
+      tolerations:
+        - key: "key"
+          operator: "Equal"
+          value: "value"
+          effect: "NoSchedule"
     asserts:
       - contains:
           path: spec.template.spec.tolerations
@@ -39,3 +40,13 @@ tests:
             operator: "Equal"
             value: "value"
             effect: "NoSchedule"
+  - it: Has nodeSelector set when nodeSelector specified
+    set:
+      nodeSelector:
+        color: green
+    asserts:
+      - isSubset:
+          path: .spec.template.spec
+          content:
+            nodeSelector:
+              color: green

--- a/charts/thoras/tests/all_deployments_test.yaml
+++ b/charts/thoras/tests/all_deployments_test.yaml
@@ -14,6 +14,11 @@ set:
     unittesting: true
   thorasReasoning:
     enabled: true
+  tolerations:
+    - key: "key"
+      operator: "Equal"
+      value: "value"
+      effect: "NoSchedule"
 tests:
   - it: Object type correct
     asserts:
@@ -25,3 +30,12 @@ tests:
           path: spec.template.spec.containers[*].resources.limits
       - exists:
           path: spec.template.spec.containers[*].resources.requests
+  - it: Has correct tolerations
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "key"
+            operator: "Equal"
+            value: "value"
+            effect: "NoSchedule"

--- a/charts/thoras/tests/collector_cronjob_test.yaml
+++ b/charts/thoras/tests/collector_cronjob_test.yaml
@@ -1,6 +1,12 @@
 suite: CollectorCronjob
 templates:
   - collector/cronjob.yaml
+set:
+  tolerations:
+    - key: "key"
+      operator: "Equal"
+      value: "value"
+      effect: "NoSchedule"
 tests:
   - it: Should have the correct kind, name and image
     set:
@@ -65,3 +71,13 @@ tests:
           content:
             nodeSelector:
               color: green
+
+  - it: Has correct node tolerations
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.tolerations
+          content:
+            key: "key"
+            operator: "Equal"
+            value: "value"
+            effect: "NoSchedule"

--- a/charts/thoras/tests/select_deployments_test.yaml
+++ b/charts/thoras/tests/select_deployments_test.yaml
@@ -46,13 +46,3 @@ tests:
       - equal:
           path: spec.replicas
           value: 12
-  - it: Has nodeSelector set when nodeSelector specified
-    set:
-      nodeSelector:
-        color: green
-    asserts:
-      - isSubset:
-          path: .spec.template.spec
-          content:
-            nodeSelector:
-              color: green


### PR DESCRIPTION
# Why are we making this change?

Users expect node tolerations to propagate to all workloads, even the metric cleanup job. Let's make sure it does


# What's changing?

* Propagate node tolerations to the metric cleanup job
* Add unit test that ensures every deployment always gets tolerations
* Move nodeSelector test to the "all deployments" test
