### PR TITLE
Pass the THORAS_NS env var to the service layer

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -101,6 +101,10 @@ spec:
             value: {{ .Values.thorasApiServerV2.timescalePrimary | quote}}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond | quote }}
+          - name: SERVICE_THORAS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         ports:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
         resources:


### PR DESCRIPTION
# Why are we making this change?

We recently started using the `THORAS_NS` value in the service layer and need to make sure it stays updated.