### PR TITLE
Allow configuring forecast resources

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -56,10 +56,14 @@ spec:
             {{- end }}
           - name: "THORAS_VERSION"
             value: {{ .Chart.Version | replace "+" "_" }}
-          {{- if .Values.thorasForecast.requestCpu }}
           - name: "FORECAST_RESOURCE_REQUESTS_CPU"
-            value: {{ .Values.thorasForecast.requestCpu | quote }}
-          {{- end }}
+            value: {{ .Values.thorasForecast.requests.cpu | quote }}
+          - name: "FORECAST_RESOURCE_LIMITS_CPU"
+            value: {{ .Values.thorasForecast.limits.cpu | quote }}
+          - name: "FORECAST_RESOURCE_REQUESTS_MEMORY"
+            value: {{ .Values.thorasForecast.requests.memory | quote }}
+          - name: "FORECAST_RESOURCE_LIMITS_MEMORY"
+            value: {{ .Values.thorasForecast.limits.memory | quote }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
           - name: THORAS_NS

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -56,13 +56,13 @@ spec:
             {{- end }}
           - name: "THORAS_VERSION"
             value: {{ .Chart.Version | replace "+" "_" }}
-          - name: "FORECAST_RESOURCE_REQUESTS_CPU"
+          - name: "SERVICE_FORECAST_RESOURCE_REQUESTS_CPU"
             value: {{ .Values.thorasForecast.requests.cpu | quote }}
-          - name: "FORECAST_RESOURCE_LIMITS_CPU"
+          - name: "SERVICE_FORECAST_RESOURCE_LIMITS_CPU"
             value: {{ .Values.thorasForecast.limits.cpu | quote }}
-          - name: "FORECAST_RESOURCE_REQUESTS_MEMORY"
+          - name: "SERVICE_FORECAST_RESOURCE_REQUESTS_MEMORY"
             value: {{ .Values.thorasForecast.requests.memory | quote }}
-          - name: "FORECAST_RESOURCE_LIMITS_MEMORY"
+          - name: "SERVICE_FORECAST_RESOURCE_LIMITS_MEMORY"
             value: {{ .Values.thorasForecast.limits.memory | quote }}
           - name: "MODEL_IMAGE"
             value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -58,3 +58,69 @@ tests:
       - equal:
           path: .spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_TOLERATIONS')].value
           value: "[]"
+  ############################
+  # Resource allocation
+  ############################
+
+  ### CPU
+  # Requests
+  - it: Ensure FORECAST_RESOURCE_REQUESTS_CPU is set
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_CPU')].value
+          value: "256m"
+  - it: Ensure FORECAST_RESOURCE_REQUESTS_CPU overrides are honored
+    set:
+      thorasForecast:
+        requests:
+          cpu: "2"
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_CPU')].value
+          value: "2"
+  # Limits
+  - it: Ensure FORECAST_RESOURCE_LIMITS_CPU is set
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_CPU')].value
+          value: "4"
+  - it: Ensure FORECAST_RESOURCE_LIMITS_CPU overrides are honored
+    set:
+      thorasForecast:
+        limits:
+          cpu: "2"
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_CPU')].value
+          value: "2"
+  ### Memory
+  # Requests
+  - it: Ensure FORECAST_RESOURCE_REQUESTS_MEMORY is set
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_MEMORY')].value
+          value: "256Mi"
+  - it: Ensure FORECAST_RESOURCE_REQUESTS_MEMORY overrides are honored
+    set:
+      thorasForecast:
+        requests:
+          memory: "4Gi"
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_MEMORY')].value
+          value: "4Gi"
+  # Limits
+  - it: Ensure FORECAST_RESOURCE_LIMITS_MEMORY is set
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_MEMORY')].value
+          value: "8Gi"
+  - it: Ensure FORECAST_RESOURCE_LIMITS_MEMORY overrides are honored
+    set:
+      thorasForecast:
+        limits:
+          memory: "2Gi"
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_MEMORY')].value
+          value: "2Gi"

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -67,7 +67,7 @@ tests:
   - it: Ensure FORECAST_RESOURCE_REQUESTS_CPU is set
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_CPU')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_REQUESTS_CPU')].value
           value: "256m"
   - it: Ensure FORECAST_RESOURCE_REQUESTS_CPU overrides are honored
     set:
@@ -76,13 +76,13 @@ tests:
           cpu: "2"
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_CPU')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_REQUESTS_CPU')].value
           value: "2"
   # Limits
   - it: Ensure FORECAST_RESOURCE_LIMITS_CPU is set
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_CPU')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_LIMITS_CPU')].value
           value: "4"
   - it: Ensure FORECAST_RESOURCE_LIMITS_CPU overrides are honored
     set:
@@ -91,14 +91,14 @@ tests:
           cpu: "2"
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_CPU')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_LIMITS_CPU')].value
           value: "2"
   ### Memory
   # Requests
   - it: Ensure FORECAST_RESOURCE_REQUESTS_MEMORY is set
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_MEMORY')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_REQUESTS_MEMORY')].value
           value: "256Mi"
   - it: Ensure FORECAST_RESOURCE_REQUESTS_MEMORY overrides are honored
     set:
@@ -107,13 +107,13 @@ tests:
           memory: "4Gi"
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_REQUESTS_MEMORY')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_REQUESTS_MEMORY')].value
           value: "4Gi"
   # Limits
   - it: Ensure FORECAST_RESOURCE_LIMITS_MEMORY is set
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_MEMORY')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_LIMITS_MEMORY')].value
           value: "8Gi"
   - it: Ensure FORECAST_RESOURCE_LIMITS_MEMORY overrides are honored
     set:
@@ -122,5 +122,5 @@ tests:
           memory: "2Gi"
     asserts:
       - equal:
-          path: $.spec.template.spec.containers[0].env[?(@.name == 'FORECAST_RESOURCE_LIMITS_MEMORY')].value
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_RESOURCE_LIMITS_MEMORY')].value
           value: "2Gi"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -164,7 +164,12 @@ thorasMonitorV2:
 
 thorasForecast:
   skipCache: false
-  requestCpu:
+  requests:
+    cpu: "256m"
+    memory: "256Mi"
+  limits:
+    memory: "8Gi"
+    cpu: "4"
   worker:
     enabled: false
     replicas: 1


### PR DESCRIPTION
# Why are we making this change?

Users need the ability to configure compute requests and limits for the forecast job so they can manage their nodes and resources efficiently. Let's give them that!

# What's changing?

Allow passing in requests and limits for cpu and memory to the operator so it can configure forecast cronjobs with those values

Also add some sane defaults