### PR TITLE
Make enqueue forecast setting a string

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -105,10 +105,8 @@ spec:
           - name: FORECAST_NODE_SELECTOR
             value: {{ $finalString }}
           {{- end }}
-          {{- if .Values.thorasOperator.forecastQueue.enabled }}
           - name: SERVICE_ENQUEUE_FORECASTS
-            value: true
-          {{- end }}
+            value: {{ .Values.thorasOperator.forecastQueue.enabled | quote }}
           - name: SERVICE_FORECAST_TOLERATIONS
             value: {{ .Values.tolerations | toJson | quote }}
         command: [


### PR DESCRIPTION
# Why are we making this change?

This env var needs to be a string, not a bool.


