### PR TITLE
Add forecast worker timeout

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -73,6 +73,13 @@ helm install \
 | ------------------------ | ------- | -------------- | --------------------------------------------- |
 | thorasForecast.imageTag  | String  | .thorasVersion | Image tag for Thoras Forecast job             |
 | thorasForecast.skipCache | Boolean | false          | Directs the forecaster to skip to model cache |
+| thorasForecast.worker.enabled | Boolean | false          | Determines whether or not to spin up `thoras-forecast-worker` deployment (required if `thorasOperator.forecastQueue.enabled = true`) |
+| thorasForecast.worker.replicas  | Number  | 1 | Number of `thoras-forecast-worker` replicas to use             |
+| thorasForecast.worker.pollingInterval  | Number  | 15 | Polling interval to check for work for `thoras-forecast-workers`      |
+| thorasForecast.worker.forecastTimeout  | Number  | 600 | Maximum time (in seconds) spent on a single forecast by the `thoras-forecast-worker`   |
+
+
+
 
 ## Thoras Operator
 

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasForecast.logLevel }}
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
+          - name: FORECAST_TIMEOUT
+            value: "{{ default 600 .Values.thorasForecast.worker.forecastTimeout }}"
         resources:
           requests:
             cpu: {{ .Values.thorasForecast.worker.requests.cpu }}

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -19,6 +19,7 @@ tests:
           requests:
             cpu: 1500m
             memory: 100Mi
+          forecastTimeout: 600
     asserts:
       - isKind:
           of: Deployment
@@ -47,3 +48,12 @@ tests:
             - "worker"
             - "--polling_interval"
             - "30"
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: "LOGLEVEL"
+              value: info
+            - name: API_BASE_URL
+              value: "http://thoras-api-server-v2"
+            - name: FORECAST_TIMEOUT
+              value: "600"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -183,6 +183,7 @@ thorasForecast:
     requests:
       cpu: 1
       memory: 250Mi
+    forecastTimeout: 600
 
 thorasAgent:
   enabled: false


### PR DESCRIPTION
# Why are we making this change?
Now that we have a queue based methodology for forecasting, we need to prevent the queue from getting backed up by enforcing a timeout in the event of a long running forecast.

# What's changing?
Added a new env var to the forecast worker + true-up docs for the worker

