### PR TITLE
Upgrade Elastic and Timescale versions

### DIFF
--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -14,7 +14,7 @@ Default containers should match snapshots:
           secretKeyRef:
             key: password
             name: thoras-elastic-password
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.12.1
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.17.4
     imagePullPolicy: IfNotPresent
     name: elasticsearch
     ports:

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -13,10 +13,10 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[0].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.12.1
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.17.4
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.17.2-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.19.2-pg16
   - it: Default containers should match snapshots
     set:
       thorasVersion: dev

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -66,7 +66,7 @@ metricsCollector:
       cpu: "16m"
       memory: "32Mi"
   search:
-    imageTag: "8.12.1"
+    imageTag: "8.17.4"
     name: elasticsearch
     containerPort: 9200
     limits:
@@ -85,7 +85,7 @@ metricsCollector:
       cpu: "16m"
       memory: "32Mi"
   timescale:
-    imageTag: "2.17.2-pg16"
+    imageTag: "2.19.2-pg16"
     name: timescale
     containerPort: 5432
     limits:


### PR DESCRIPTION
# Why are we making this change?

Keep on the latest/greatest to address possible security vulnerabilities.

# What's changing?

Updating timescale and elastic images to the latest tags.
