### PR TITLE
Pass environment var to v1 monitor about v2's state

### DIFF
--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -88,6 +88,8 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasMonitor.logLevel }}
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
+          - name: V2_MONITOR_ENABLED
+            value: {{ .Values.thorasMonitorV2.enabled | default false | quote }}
         resources:
           limits:
             memory: {{ .Values.thorasMonitor.limits.memory }}


### PR DESCRIPTION
# Why are we making this change?

As we add functionality to the v2 monitor, the v1 monitor needs to know whether it owns notifying about a particular alert or not.

# What's changing?

Adding a new `V2_MONITOR_ENABLED` to the v1 monitor container.
