### PR TITLE
Increase cpu requests from timescale/et al.

### DIFF
--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -23,7 +23,7 @@ Default containers should match snapshots:
       limits:
         memory: 8192Mi
       requests:
-        cpu: 16m
+        cpu: 200m
         memory: 1536Mi
   2: |
     args:
@@ -107,5 +107,5 @@ Default containers should match snapshots:
       limits:
         memory: 8192Mi
       requests:
-        cpu: 16m
+        cpu: 200m
         memory: 32Mi

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -63,7 +63,7 @@ metricsCollector:
     limits:
       memory: "8192Mi"
     requests:
-      cpu: "16m"
+      cpu: "200m"
       memory: "32Mi"
   search:
     imageTag: "8.17.4"
@@ -72,7 +72,7 @@ metricsCollector:
     limits:
       memory: "8192Mi"
     requests:
-      cpu: "16m"
+      cpu: "200m"
       memory: "1536Mi"
   purge:
     ttl: 30
@@ -91,7 +91,7 @@ metricsCollector:
     limits:
       memory: "8192Mi"
     requests:
-      cpu: "16m"
+      cpu: "400m"
       memory: "128Mi"
   blobService:
     containerPort: 8080


### PR DESCRIPTION
# Why are we making this change?

16m is much to small for timescale. Increase this to a larger number and pushing request limits for other collector services higher as well.
