### PR TITLE
Allow configuring of cache windows

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -133,6 +133,8 @@ helm install \
 | thorasApiServerV2.logLevel                    | String  | Nil     | Logging level                                                                 |
 | thorasApiServerV2.timescalePrimary            | Boolean | false   | Use timescale as the primary data source, not elastic                         |
 | thorasApiServerV2.queriesPerSecond            | String  | "50"    | Sets a maximum threshold for K8s API qps                                      |
+| thorasApiServerV2.catalogRefreshInterval      | String  | "60s"   | Frequency of updates to catalog following k8s updates                         |
+| thorasApiServerV2.cacheWindow                 | String  | "10s"   | Maximum staleness of data before querying k8s for updates                     |
 | thorasApiServerV2.additionalPvSecurityContext | Object  | {}      | Allows assigning additional securityContext objects to workloads that use PVs |
 
 ## Thoras Dashboard

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -101,6 +101,10 @@ spec:
             value: {{ .Values.thorasApiServerV2.timescalePrimary | quote}}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond | quote }}
+          - name: SERVICE_CATALOG_REFRESH_INTERVAL
+            value: {{ .Values.thorasApiServerV2.catalogRefreshInterval | quote }}
+          - name: SERVICE_CACHE_WINDOW
+            value: {{ .Values.thorasApiServerV2.cacheWindow | quote }}
           - name: SERVICE_THORAS_NAMESPACE
             valueFrom:
               fieldRef:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -119,6 +119,8 @@ thorasApiServerV2:
   port: 80
   logLevel: "info"
   timescalePrimary: false
+  catalogRefreshInterval: "60s"
+  cacheWindow: "10s"
   additionalPvSecurityContext: {}
 
 thorasDashboard:


### PR DESCRIPTION
# Why are we making this change?

We need to expose the cache windows as settings for customizing during test runs.

# What's changing?

Exposing both `SERVICE_CACHE_WINDOW` and `SERVICE_CATALOG_REFRESH_INTERVAL` as helm chart values.
