### PR TITLE
Export api service layer prometheus scrape endpoint

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       {{- with .Values.thorasApiServerV2.podAnnotations }}
       annotations:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ .Values.thorasApiServerV2.containerPort | quote}}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:


### PR DESCRIPTION
# Why are we making this change?

We need to tell prometheus where to scrape our API service metrics.

# What's changing?

Adding annotation for the API service layer prometheus endpoint.
