### PR TITLE
Move prometheus-scrape-annotations

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -136,6 +136,7 @@ helm install \
 | thorasApiServerV2.catalogRefreshInterval      | String  | "60s"   | Frequency of updates to catalog following k8s updates                         |
 | thorasApiServerV2.cacheWindow                 | String  | "10s"   | Maximum staleness of data before querying k8s for updates                     |
 | thorasApiServerV2.additionalPvSecurityContext | Object  | {}      | Allows assigning additional securityContext objects to workloads that use PVs |
+| thorasApiServerV2.prometheus.enabled          | Boolean | true    | Enables a prometheus metric scrape point                                      |
 
 ## Thoras Dashboard
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -22,12 +22,11 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-      {{- with .Values.thorasApiServerV2.podAnnotations }}
-      annotations:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ .Values.thorasApiServerV2.containerPort | quote}}
+      {{- with .Values.thorasApiServerV2.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -22,12 +22,17 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.thorasApiServerV2.podAnnotations }}
       annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.thorasApiServerV2.prometheus.enabled }}
+      {{- if not .Values.thorasApiServerV2.podAnnotations }}
+      annotations:
+      {{- end }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ .Values.thorasApiServerV2.containerPort | quote}}
-      {{- with .Values.thorasApiServerV2.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.thorasApiServerV2.serviceAccount.name }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -122,6 +122,8 @@ thorasApiServerV2:
   catalogRefreshInterval: "60s"
   cacheWindow: "10s"
   additionalPvSecurityContext: {}
+  prometheus:
+    enabled: true
 
 thorasDashboard:
   enabled: true


### PR DESCRIPTION
# Why are we making this change?

The prometheus scrape point annotations should be available regardless of other annotations.
