### PR TITLE
Add support for service-specific labeling

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -72,7 +72,7 @@ helm install \
 | Key                                    | Type    | Default        | Description                                                                            |
 | -------------------------------------- | ------- | -------------- | -------------------------------------------------------------------------------------- |
 | thorasForecast.podAnnotations          | Object  | {}             | Pod Annotations for Thoras Forecast                                                    |
-| thorasForecast.labels                  | Object  | {}             | Pod Labels for Thoras Forecast                                                         |
+| thorasForecast.labels                  | Object  | {}             | Pod labels for Thoras Forecast                                                         |
 | thorasForecast.imageTag                | String  | .thorasVersion | Image tag for Thoras Forecast job                                                      |
 | thorasForecast.skipCache               | Boolean | false          | Directs the forecaster to skip to model cache                                          |
 | thorasForecast.worker.enabled          | Boolean | false          | Determines whether or not to spin up `thoras-forecast-worker` deployment (required if `thorasOperator.forecastQueue.enabled = true`) |
@@ -88,7 +88,7 @@ helm install \
 | Key                                  | Type    | Default | Description                                                  |
 | ------------------------------------ | ------- | ------- | ------------------------------------------------------------ |
 | thorasOperator.podAnnotations        | Object  | {}      | Pod Annotations for Thoras Operator                          |
-| thorasOperator.labels                | Object  | {}      | Pod Labels for Thoras Operator                               |
+| thorasOperator.labels                | Object  | {}      | Pod/service labels for Thoras Operator                       |
 | thorasOperator.limits.memory         | String  | 2000Mi  | Thoras Operator memory limit                                 |
 | thorasOperator.requests.cpu          | String  | 1000m   | Thoras Operator CPU request                                  |
 | thorasOperator.requests.memory       | String  | 1000Mi  | Thoras Operator memory request                               |
@@ -110,7 +110,7 @@ helm install \
 | metricsCollector.collector.name                                 | String  | thoras-collector | Thoras collector container name                                               |
 | metricsCollector.collector.logLevel                             | String  | Nil              | Logging level                                                                 |
 | metricsCollector.podAnnotations                                 | Object  | {}               | Pod Annotations for Thoras metrics collector                                  |
-| metricsCollector.labels                                         | Object  | {}               | Pod Labels for Thoras metrics      collector                                  |
+| metricsCollector.labels                                         | Object  | {}               | Pod/service labels for Thoras metrics collector                               |
 | metricsCollector.search.imageTag                                | String  | 8.12.1           | Elasticsearch image tag                                                       |
 | metricsCollector.search.name                                    | String  | elasticsearch    | Elasticsearch container name                                                  |
 | metricsCollector.search.containerPort                           | Number  | 9200             | Elasticsearch port                                                            |
@@ -128,7 +128,7 @@ helm install \
 | Key                                           | Type    | Default | Description                                                                   |
 | --------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------- |
 | thorasApiServerV2.podAnnotations              | Object  | {}      | Pod Annotations for Thoras API                                                |
-| thorasApiServerV2.labels                      | Object  | {}      | Pod labels for Thoras API                                                     |
+| thorasApiServerV2.labels                      | Object  | {}      | Pod/service labels for Thoras API                                             |
 | thorasApiServerV2.containerPort               | Number  | 8443    | Thoras API port                                                               |
 | thorasApiServerV2.port                        | Number  | 443     | Thoras API service port                                                       |
 | thorasApiServerV2.limits.memory               | String  | 2000Mi  | Thoras API memory limit                                                       |
@@ -152,7 +152,7 @@ helm install \
 | thorasDashboard.serviceAccount.name              | String  | thoras-dashboard | Service account name for Thoras Dashboard pod                            |
 | thorasDashboard.rbac.create                      | Bool    | true             | Creates cluster role for Thoras Dashboard pod                            |
 | thorasDashboard.podAnnotations                   | Object  | {}               | Pod Annotations for Thoras Dashboard                                     |
-| thorasDashboard.labels                           | Object  | {}               | Pod labels for Thoras      Dashboard                                     |
+| thorasDashboard.labels                           | Object  | {}               | Pod/service labels for Thoras      Dashboard                             |
 | thorasDashboard.containerPort                    | Number  | 3000             | Thoras Dashboard port                                                    |
 | thorasDashboard.port                             | Number  | 3000             | Thoras Dashboard service port                                            |
 | thorasDashboard.limits.memory                    | String  | 2000Mi           | Thoras Dashboard memory limit                                            |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -69,14 +69,16 @@ helm install \
 
 ## Thoras Forecast
 
-| Key                      | Type    | Default        | Description                                   |
-| ------------------------ | ------- | -------------- | --------------------------------------------- |
-| thorasForecast.imageTag  | String  | .thorasVersion | Image tag for Thoras Forecast job             |
-| thorasForecast.skipCache | Boolean | false          | Directs the forecaster to skip to model cache |
-| thorasForecast.worker.enabled | Boolean | false          | Determines whether or not to spin up `thoras-forecast-worker` deployment (required if `thorasOperator.forecastQueue.enabled = true`) |
-| thorasForecast.worker.replicas  | Number  | 1 | Number of `thoras-forecast-worker` replicas to use             |
-| thorasForecast.worker.pollingInterval  | Number  | 15 | Polling interval to check for work for `thoras-forecast-workers`      |
-| thorasForecast.worker.forecastTimeout  | Number  | 600 | Maximum time (in seconds) spent on a single forecast by the `thoras-forecast-worker`   |
+| Key                                    | Type    | Default        | Description                                                                            |
+| -------------------------------------- | ------- | -------------- | -------------------------------------------------------------------------------------- |
+| thorasForecast.podAnnotations          | Object  | {}             | Pod Annotations for Thoras Forecast                                                    |
+| thorasForecast.labels                  | Object  | {}             | Pod Labels for Thoras Forecast                                                         |
+| thorasForecast.imageTag                | String  | .thorasVersion | Image tag for Thoras Forecast job                                                      |
+| thorasForecast.skipCache               | Boolean | false          | Directs the forecaster to skip to model cache                                          |
+| thorasForecast.worker.enabled          | Boolean | false          | Determines whether or not to spin up `thoras-forecast-worker` deployment (required if `thorasOperator.forecastQueue.enabled = true`) |
+| thorasForecast.worker.replicas         | Number  | 1              | Number of `thoras-forecast-worker` replicas to use                                     |
+| thorasForecast.worker.pollingInterval  | Number  | 15             | Polling interval to check for work for `thoras-forecast-workers`                       |
+| thorasForecast.worker.forecastTimeout  | Number  | 600            | Maximum time (in seconds) spent on a single forecast by the `thoras-forecast-worker`   |
 
 
 
@@ -86,6 +88,7 @@ helm install \
 | Key                                  | Type    | Default | Description                                                  |
 | ------------------------------------ | ------- | ------- | ------------------------------------------------------------ |
 | thorasOperator.podAnnotations        | Object  | {}      | Pod Annotations for Thoras Operator                          |
+| thorasOperator.labels                | Object  | {}      | Pod Labels for Thoras Operator                               |
 | thorasOperator.limits.memory         | String  | 2000Mi  | Thoras Operator memory limit                                 |
 | thorasOperator.requests.cpu          | String  | 1000m   | Thoras Operator CPU request                                  |
 | thorasOperator.requests.memory       | String  | 1000Mi  | Thoras Operator memory request                               |
@@ -107,6 +110,7 @@ helm install \
 | metricsCollector.collector.name                                 | String  | thoras-collector | Thoras collector container name                                               |
 | metricsCollector.collector.logLevel                             | String  | Nil              | Logging level                                                                 |
 | metricsCollector.podAnnotations                                 | Object  | {}               | Pod Annotations for Thoras metrics collector                                  |
+| metricsCollector.labels                                         | Object  | {}               | Pod Labels for Thoras metrics      collector                                  |
 | metricsCollector.search.imageTag                                | String  | 8.12.1           | Elasticsearch image tag                                                       |
 | metricsCollector.search.name                                    | String  | elasticsearch    | Elasticsearch container name                                                  |
 | metricsCollector.search.containerPort                           | Number  | 9200             | Elasticsearch port                                                            |
@@ -123,7 +127,8 @@ helm install \
 
 | Key                                           | Type    | Default | Description                                                                   |
 | --------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------- |
-| thorasApiServerV2.podAnnotations              | Object  | {}      | Pod Annotations for Thoras Thoras API                                         |
+| thorasApiServerV2.podAnnotations              | Object  | {}      | Pod Annotations for Thoras API                                                |
+| thorasApiServerV2.labels                      | Object  | {}      | Pod labels for Thoras API                                                     |
 | thorasApiServerV2.containerPort               | Number  | 8443    | Thoras API port                                                               |
 | thorasApiServerV2.port                        | Number  | 443     | Thoras API service port                                                       |
 | thorasApiServerV2.limits.memory               | String  | 2000Mi  | Thoras API memory limit                                                       |
@@ -147,6 +152,7 @@ helm install \
 | thorasDashboard.serviceAccount.name              | String  | thoras-dashboard | Service account name for Thoras Dashboard pod                            |
 | thorasDashboard.rbac.create                      | Bool    | true             | Creates cluster role for Thoras Dashboard pod                            |
 | thorasDashboard.podAnnotations                   | Object  | {}               | Pod Annotations for Thoras Dashboard                                     |
+| thorasDashboard.labels                           | Object  | {}               | Pod labels for Thoras      Dashboard                                     |
 | thorasDashboard.containerPort                    | Number  | 3000             | Thoras Dashboard port                                                    |
 | thorasDashboard.port                             | Number  | 3000             | Thoras Dashboard service port                                            |
 | thorasDashboard.limits.memory                    | String  | 2000Mi           | Thoras Dashboard memory limit                                            |
@@ -167,6 +173,7 @@ helm install \
 | -------------------------------- | ------- | ------- | ------------------------------------------------------------ |
 | thorasMonitor.enabled            | Bool    | false   | Enable Thoras monitoring                                     |
 | thorasMonitor.podAnnotations     | Object  | {}      | Pod Annotations for Thoras monitor                           |
+| thorasMonitor.labels             | Object  | {}      | Pod labels for Thoras monitor                                |
 | thorasMonitor.slackErrorsEnabled | Boolean | false   | Determines if error-level logs are sent to `slackWebHookUrl` |
 | thorasMonitor.config             | String  | ""      | Thoras Monitor configuration yaml                            |
 | thorasMonitor.logLevel           | String  | Nil     | Logging level                                                |
@@ -176,6 +183,8 @@ helm install \
 | Key                            | Type    | Default        | Description                                                            |
 | ------------------------------ | ------- | -------------- | ---------------------------------------------------------------------- |
 | thorasAgent.enabled            | Bool    | false          | Enable the Thoras Agent (opt-in, for now)                              |
+| thorasAgent.podAnnotations     | Object  | {}             | Pod Annotations for Thoras Agent                                       |
+| thorasAgent.labels             | Object  | {}             | Pod labels for Thoras Agent                                            |
 | thorasAgent.imageTag           | String  | .thorasVersion | Image tag for Thoras Agent daemon set                                  |
 | thorasAgent.slackErrorsEnabled | Boolean | false          | Determines if error-level logs are sent to `slackWebHookUrl`           |
 | thorasAgent.frequency          | Integer | 15             | Frequency, in seconds, of agent polling for service map communications |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -71,11 +71,11 @@ helm install \
 
 | Key                                    | Type    | Default        | Description                                                                            |
 | -------------------------------------- | ------- | -------------- | -------------------------------------------------------------------------------------- |
-| thorasForecast.podAnnotations          | Object  | {}             | Pod Annotations for Thoras Forecast                                                    |
-| thorasForecast.labels                  | Object  | {}             | Pod labels for Thoras Forecast                                                         |
 | thorasForecast.imageTag                | String  | .thorasVersion | Image tag for Thoras Forecast job                                                      |
 | thorasForecast.skipCache               | Boolean | false          | Directs the forecaster to skip to model cache                                          |
 | thorasForecast.worker.enabled          | Boolean | false          | Determines whether or not to spin up `thoras-forecast-worker` deployment (required if `thorasOperator.forecastQueue.enabled = true`) |
+| thorasForecast.worker.podAnnotations   | Object  | {}             | Pod Annotations for Thoras Forecast                                                    |
+| thorasForecast.worker.labels           | Object  | {}             | Pod labels for Thoras Forecast                                                         |
 | thorasForecast.worker.replicas         | Number  | 1              | Number of `thoras-forecast-worker` replicas to use                                     |
 | thorasForecast.worker.pollingInterval  | Number  | 15             | Polling interval to check for work for `thoras-forecast-workers`                       |
 | thorasForecast.worker.forecastTimeout  | Number  | 600            | Maximum time (in seconds) spent on a single forecast by the `thoras-forecast-worker`   |

--- a/charts/thoras/templates/agent/daemonset.yaml
+++ b/charts/thoras/templates/agent/daemonset.yaml
@@ -21,6 +21,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.thorasAgent.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.thorasAgent.containerPort | quote}}

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.thorasApiServerV2.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.thorasApiServerV2.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/api-server-v2/service.yaml
+++ b/charts/thoras/templates/api-server-v2/service.yaml
@@ -4,6 +4,10 @@ kind: Service
 metadata:
   name: thoras-api-server-v2
   namespace: {{ .Release.Namespace }}
+{{- with .Values.thorasApiServerV2.labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   ports:
   - port: {{ .Values.thorasApiServerV2.port }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -2,6 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
   name: metrics-collector
   namespace: {{ .Release.Namespace }}
 spec:
@@ -19,6 +24,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.metricsCollector.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.metricsCollector.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/collector/service.yaml
+++ b/charts/thoras/templates/collector/service.yaml
@@ -17,6 +17,10 @@ kind: Service
 metadata:
   name: timescale
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.metricsCollector.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: {{ .Values.metricsCollector.timescale.containerPort }}
@@ -30,6 +34,10 @@ kind: Service
 metadata:
   name: thoras-blob-api
   namespace: {{ .Release.Namespace }}
+{{- with .Values.metricsCollector.labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   ports:
   - port: {{ .Values.metricsCollector.blobService.port }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.thorasDashboard.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.thorasDashboard.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/dashboard/service.yaml
+++ b/charts/thoras/templates/dashboard/service.yaml
@@ -8,6 +8,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 8 }}
   {{- end }}
+  {{- with .Values.thorasDashboard.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if (or (eq .Values.thorasDashboard.service.type "ClusterIP") (empty .Values.thorasDashboard.service.type)) }}
   type: ClusterIP

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.thorasForecast.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- with .Values.thorasForecast.podAnnotations }}
           {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -23,11 +23,11 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.thorasForecast.labels }}
+        {{- with .Values.thorasForecast.worker.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.thorasForecast.worker.podAnnotations }}
       annotations:
-        {{- with .Values.thorasForecast.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.thorasMonitor.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- if not .Values.thorasMonitor.unittesting }}
         checksum/configmap: {{ include (print $.Template.BasePath "/monitor/configmap.yaml") . | sha256sum }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -23,7 +23,10 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-      {{- with .Values.thorasOperator.podAnnotations }}
+        {{- with .Values.thorasOperator.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.thorasOperator.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/thoras/templates/operator/service.yaml
+++ b/charts/thoras/templates/operator/service.yaml
@@ -4,6 +4,10 @@ kind: Service
 metadata:
   name: thoras-webhooks
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.thorasOperator.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 443

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.thorasAgent.labels }}
+        {{- with .Values.thorasReasoning.api.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.thorasReasoning.api.podAnnotations }}

--- a/charts/thoras/templates/reasoning-api/deployment.yaml
+++ b/charts/thoras/templates/reasoning-api/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.thorasAgent.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.thorasReasoning.api.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/reasoning-api/service.yaml
+++ b/charts/thoras/templates/reasoning-api/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: thoras-reasoning-api
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.thorasReasoning.labels }}
+  {{- with .Values.thorasReasoning.api.labels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/thoras/templates/reasoning-api/service.yaml
+++ b/charts/thoras/templates/reasoning-api/service.yaml
@@ -5,6 +5,10 @@ kind: Service
 metadata:
   name: thoras-reasoning-api
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.thorasReasoning.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: {{ .Values.thorasReasoning.api.port }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -40,6 +40,7 @@ thorasOperator:
   # Operator is a singleton -- don't change this :)
   replicas: 1
   podAnnotations: {}
+  labels: {}
   limits:
     memory: 2000Mi
   requests:
@@ -58,6 +59,7 @@ metricsCollector:
       fileSystemId: ""
     pvcStorageRequestSize: "3Gi"
   podAnnotations: {}
+  labels: {}
   collector:
     name: thoras-collector
     limits:
@@ -110,6 +112,7 @@ thorasApiServerV2:
     name: thoras-api
   containerPort: 8080
   podAnnotations: {}
+  labels: {}
   replicas: 1
   limits:
     memory: 2000Mi
@@ -133,6 +136,7 @@ thorasDashboard:
   rbac:
     create: true
   podAnnotations: {}
+  labels: {}
   containerPort: 3000
   nginxContainerPort: 80
   nginx:
@@ -157,6 +161,7 @@ thorasMonitor:
     cpu: "16m"
     memory: "64Mi"
   podAnnotations: {}
+  labels: {}
   config: |
 
 thorasMonitorV2:
@@ -164,6 +169,8 @@ thorasMonitorV2:
 
 thorasForecast:
   skipCache: false
+  podAnnotations: {}
+  labels: {}
   requests:
     cpu: "256m"
     memory: "256Mi"
@@ -190,9 +197,12 @@ thorasAgent:
   frequency: 15
   containerPort: 9101
   podAnnotations: {}
+  labels: {}
 
 thorasReasoning:
   enabled: false
+  podAnnotations: {}
+  labels: {}
   connectors:
     prometheus:
       baseUrl: "http://localhost"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -169,8 +169,6 @@ thorasMonitorV2:
 
 thorasForecast:
   skipCache: false
-  podAnnotations: {}
-  labels: {}
   requests:
     cpu: "256m"
     memory: "256Mi"
@@ -182,6 +180,7 @@ thorasForecast:
     replicas: 1
     pollingInterval: 15
     podAnnotations: {}
+    labels: {}
     limits:
       memory: 2Gi
       cpu: 2
@@ -201,13 +200,12 @@ thorasAgent:
 
 thorasReasoning:
   enabled: false
-  podAnnotations: {}
-  labels: {}
   connectors:
     prometheus:
       baseUrl: "http://localhost"
   api:
     podAnnotations: {}
+    labels: {}
     containerPort: 8080
     port: 80
     limits:


### PR DESCRIPTION
# Why are we making this change?

Customers would like to specify per-service labels to drive monitoring, etc.

