### PR TITLE
Expose prometheus metric exporter on operator

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -96,6 +96,8 @@ helm install \
 | thorasOperator.logLevel              | String  | Nil     | Logging level                                                |
 | thorasOperator.queriesPerSecond      | String  | "50"    | Sets a maximum threshold for K8s API qps                     |
 | thorasOperator.forecastQueue.enabled | Boolean | false   | Determines if forecasts will be queued by the operator       |
+| thorasOperator.prometheus.enabled    | Boolean | true    | Enables a prometheus metric exporter                         |
+| thorasOperator.prometheus.port       | Number  | 9101    | Port for the prometheus metric exporter                      |
 
 ## Thoras Metrics Collector
 

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -20,9 +20,17 @@ spec:
         {{- with .Values.thorasOperator.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.thorasOperator.podAnnotations }}
+      {{- with .Values.thorasOperator.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.thorasOperator.prometheus.enabled }}
+      {{- if not .Values.thorasOperator.podAnnotations }}
+      annotations:
+      {{- end }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ .Values.thorasOperator.prometheus.port | quote}}
       {{- end }}
       name: thoras-operator
     spec:
@@ -106,6 +114,8 @@ spec:
             value: {{ .Values.thorasOperator.forecastQueue.enabled | quote }}
           - name: SERVICE_FORECAST_TOLERATIONS
             value: {{ .Values.tolerations | toJson | quote }}
+          - name: SERVICE_PORT
+            value: {{ .Values.thorasOperator.prometheus.port | quote }}
         command: [
           "/app/operator"
         ]

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -48,6 +48,9 @@ thorasOperator:
     memory: 100Mi
   forecastQueue:
     enabled: true
+  prometheus:
+    enabled: true
+    port: 9101
 
 metricsCollector:
   persistence:


### PR DESCRIPTION
# Why are we making this change?

We need to register the prometheus exporter on the operator so that the prometheus server starts to ingest metrics from it.
