### PR TITLE
Enable v2 monitor by default

### DIFF
--- a/charts/thoras/tests/monitor_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_deployment_test.yaml
@@ -38,16 +38,16 @@ tests:
           value: RELEASE-NAME
   - it: Should not create v2 monitor container when not enabled
     template: monitor/deployment.yaml
+    set:
+      thorasMonitorV2:
+        enabled: false
     asserts:
       - exists:
           path: $..spec.containers[?(@.name == 'thoras-monitor')]
       - notExists:
           path: $..spec.containers[?(@.name == 'thoras-monitor-v2')]
-  - it: Should create v2 monitor container when enabled
+  - it: Should create v2 monitor container when enabled (default)
     template: monitor/deployment.yaml
-    set:
-      thorasMonitorV2:
-        enabled: true
     asserts:
       - exists:
           path: $..spec.containers[?(@.name == 'thoras-monitor')]

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -168,7 +168,7 @@ thorasMonitor:
   config: |
 
 thorasMonitorV2:
-  enabled: false
+  enabled: true
 
 thorasForecast:
   skipCache: false


### PR DESCRIPTION
# Why are we making this change?

We should default enable the v2 monitor as we begin migrating functionality from the v1 monitor