### PR TITLE
Add name to service ports

### DIFF
--- a/charts/thoras/templates/api-server-v2/service.yaml
+++ b/charts/thoras/templates/api-server-v2/service.yaml
@@ -10,7 +10,8 @@ metadata:
 {{- end }}
 spec:
   ports:
-  - port: {{ .Values.thorasApiServerV2.port }}
+  - name: http
+    port: {{ .Values.thorasApiServerV2.port }}
     protocol: TCP
     targetPort: {{ .Values.thorasApiServerV2.containerPort }}
   selector:

--- a/charts/thoras/templates/collector/service.yaml
+++ b/charts/thoras/templates/collector/service.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - port: {{ .Values.metricsCollector.search.containerPort }}
+  - name: http
+    port: {{ .Values.metricsCollector.search.containerPort }}
     protocol: TCP
     targetPort: {{ .Values.metricsCollector.search.containerPort }}
   selector:
@@ -23,7 +24,8 @@ metadata:
   {{- end }}
 spec:
   ports:
-  - port: {{ .Values.metricsCollector.timescale.containerPort }}
+  - name: postgres
+    port: {{ .Values.metricsCollector.timescale.containerPort }}
     protocol: TCP
     targetPort: {{ .Values.metricsCollector.timescale.containerPort }}
   selector:
@@ -40,7 +42,8 @@ metadata:
 {{- end }}
 spec:
   ports:
-  - port: {{ .Values.metricsCollector.blobService.port }}
+  - name: http
+    port: {{ .Values.metricsCollector.blobService.port }}
     protocol: TCP
     targetPort: {{ .Values.metricsCollector.blobService.containerPort }}
   selector:

--- a/charts/thoras/templates/dashboard/service.yaml
+++ b/charts/thoras/templates/dashboard/service.yaml
@@ -35,7 +35,8 @@ spec:
 {{ toYaml .Values.thorasDashboard.service.externalIPs | indent 4 }}
 {{- end }}
   ports:
-  - port: {{ .Values.thorasDashboard.port }}
+  - name: http
+    port: {{ .Values.thorasDashboard.port }}
     protocol: TCP
     targetPort: {{ .Values.thorasDashboard.nginxContainerPort }}
   selector:

--- a/charts/thoras/templates/operator/service.yaml
+++ b/charts/thoras/templates/operator/service.yaml
@@ -10,7 +10,8 @@ metadata:
   {{- end }}
 spec:
   ports:
-  - port: 443
+  - name: https
+    port: 443
     protocol: TCP
     targetPort: 9443
   selector:

--- a/charts/thoras/templates/reasoning-api/service.yaml
+++ b/charts/thoras/templates/reasoning-api/service.yaml
@@ -11,7 +11,8 @@ metadata:
   {{- end }}
 spec:
   ports:
-  - port: {{ .Values.thorasReasoning.api.port }}
+  - name: http
+    port: {{ .Values.thorasReasoning.api.port }}
     protocol: TCP
     targetPort: {{ .Values.thorasReasoning.api.containerPort }}
   selector:

--- a/charts/thoras/tests/__snapshot__/dashboard_service_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_service_test.yaml.snap
@@ -7,7 +7,8 @@ Default matches snapshot:
       namespace: NAMESPACE
     spec:
       ports:
-        - port: 80
+        - name: http
+          port: 80
           protocol: TCP
           targetPort: 80
       selector:


### PR DESCRIPTION
# Why are we making this change?

Add `name` to service ports to allow service monitor targeting.