### PR TITLE
Add age to AST output

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.vertical.mode
       name: Vertical
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
# Why are we making this change?

Add the `Age` column to the kubectl output

# What's changing?

```
NAME       MODEL      HORIZONTAL   VERTICAL         AGE
frontend   balanced   auto         recommendation   37d
```