### PR TITLE
Forecasts via API should use the forecast queue

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -144,6 +144,7 @@ helm install \
 | thorasApiServerV2.cacheWindow                 | String  | "10s"   | Maximum staleness of data before querying k8s for updates                     |
 | thorasApiServerV2.additionalPvSecurityContext | Object  | {}      | Allows assigning additional securityContext objects to workloads that use PVs |
 | thorasApiServerV2.prometheus.enabled          | Boolean | true    | Enables a prometheus metric scrape point                                      |
+| thorasApiServerV2.forecastQueue.enabled       | Boolean | false   | Determines if forecasts requests should use the queue                         |
 
 ## Thoras Dashboard
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -110,6 +110,8 @@ spec:
             value: {{ .Values.thorasApiServerV2.catalogRefreshInterval | quote }}
           - name: SERVICE_CACHE_WINDOW
             value: {{ .Values.thorasApiServerV2.cacheWindow | quote }}
+          - name: SERVICE_ENQUEUE_FORECASTS
+            value: {{ .Values.thorasApiServerV2.forecastQueue.enabled | quote }}
           - name: SERVICE_THORAS_NAMESPACE
             valueFrom:
               fieldRef:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -125,6 +125,8 @@ thorasApiServerV2:
   port: 80
   logLevel: "info"
   timescalePrimary: false
+  forecastQueue:
+    enabled: true
   catalogRefreshInterval: "60s"
   cacheWindow: "10s"
   additionalPvSecurityContext: {}


### PR DESCRIPTION
# Why are we making this change?

Forecast requests made via the API (typically from a UI request) should use the forecast queue, when enabled.