### PR TITLE
Expose prometheus metrics port on operator

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -129,7 +129,10 @@ spec:
             subPath: tls.key
             readOnly: true
         ports:
-          - containerPort: 9443
+          - name: https-web-hooks
+            containerPort: 9443
+          - name: http-metrics
+            containerPort: {{ .Values.thorasOperator.prometheus.port }}
         resources:
           limits:
             memory: {{ .Values.thorasOperator.limits.memory }}

--- a/charts/thoras/templates/operator/service.yaml
+++ b/charts/thoras/templates/operator/service.yaml
@@ -11,9 +11,13 @@ metadata:
     {{- end }}
 spec:
   ports:
-  - name: https
+  - name: https-web-hooks
     port: 443
     protocol: TCP
     targetPort: 9443
+  - name: http-metrics
+    port: {{ .Values.thorasOperator.prometheus.port }}
+    protocol: TCP
+    targetPort: {{ .Values.thorasOperator.prometheus.port }}
   selector:
     app: thoras-operator


### PR DESCRIPTION
# Why are we making this change?

The prometheus metrics service on the operator should be exposed so service monitors can target it.