### PR TITLE
Ensure empty string for slack webhook URL

### DIFF
--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -2,7 +2,7 @@
 ---
 apiVersion: v1
 data:
-  webhookUrl: {{ .Values.slackWebhookUrl | b64enc }}
+  webhookUrl: "{{ .Values.slackWebhookUrl | b64enc }}"
 kind: Secret
 metadata:
   name: thoras-slack

--- a/charts/thoras/templates/monitor/secret.yaml
+++ b/charts/thoras/templates/monitor/secret.yaml
@@ -2,7 +2,7 @@
 ---
 apiVersion: v1
 data:
-  webhookUrl: "{{ .Values.slackWebhookUrl | b64enc }}"
+  webhookUrl: {{ .Values.slackWebhookUrl | b64enc | quote }}
 kind: Secret
 metadata:
   name: thoras-slack


### PR DESCRIPTION
# Why are we making this change?

We want to make sure there's an empty string as the value of this secret no matter what. Also this is best practice

# What's changing?

Wrap value in quotes