### PR TITLE
Remove unused collector environment variable

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -178,10 +178,6 @@ spec:
             ./metrics-collector init
             ./metrics-collector collect -c 60s
         env:
-          - name: THORAS_NS
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: "ELASTICSEARCH_URL"
             valueFrom:
               secretKeyRef:
@@ -211,8 +207,6 @@ spec:
                 name: thoras-timescale-password
                 key: host
           - name: DATABASE_URL
-            value: "$(DATABASE_HOST)/thoras?sslmode=disable"
-          - name: SERVICE_POSTGRESQL_DSN
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
           - name: "POSTGRES_PASSWORD"
             valueFrom:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -62,10 +62,6 @@ Default containers should match snapshots:
       - /bin/sh
       - -c
     env:
-      - name: THORAS_NS
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
       - name: ELASTICSEARCH_URL
         valueFrom:
           secretKeyRef:
@@ -90,8 +86,6 @@ Default containers should match snapshots:
             key: host
             name: thoras-timescale-password
       - name: DATABASE_URL
-        value: $(DATABASE_HOST)/thoras?sslmode=disable
-      - name: SERVICE_POSTGRESQL_DSN
         value: $(DATABASE_HOST)/thoras?sslmode=disable
       - name: POSTGRES_PASSWORD
         valueFrom:


### PR DESCRIPTION
# Why are we making this change?

The collector no longer talks directly to postgres and doesn't need the DSN.
