### PR TITLE
Added v2 dashboard

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -19,8 +19,11 @@ spec:
         {{- with .Values.thorasDashboard.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.thorasDashboard.podAnnotations }}
       annotations:
+        {{- if not .Values.thorasDashboard.unittesting }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/dashboard/nginx-config-map.yaml") . | sha256sum }}
+        {{- end }}
+      {{- with .Values.thorasDashboard.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -77,6 +80,21 @@ spec:
           requests:
             cpu: {{ .Values.thorasDashboard.requests.cpu }}
             memory: {{ .Values.thorasDashboard.requests.memory }}
+      - image: {{ .Values.imageCredentials.registry }}/thoras-dashboard-v2:{{ default .Values.thorasVersion .Values.thorasDashboard.v2.imageTag }}
+        name: thoras-dashboard-v2
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        ports:
+        - containerPort: {{ .Values.thorasDashboard.v2.containerPort }}
+        resources:
+          limits:
+            memory: {{ .Values.thorasDashboard.limits.memory }}
+          requests:
+            cpu: {{ .Values.thorasDashboard.requests.cpu }}
+            memory: {{ .Values.thorasDashboard.requests.memory }}
+        volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/nginx.conf
+            subPath: dashboard-v2.nginx.conf
       - name: thoras-api-proxy
         image: {{ .Values.imageCredentials.registry }}/nginx:{{ .Values.thorasDashboard.nginx.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"

--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -29,11 +29,33 @@ data:
         }
 
         location / {
-          proxy_pass http://localhost:{{ .Values.thorasDashboard.containerPort }};
+          proxy_pass http://localhost:{{ ternary .Values.thorasDashboard.v2.containerPort .Values.thorasDashboard.containerPort .Values.thorasDashboard.v2.enabled }};
           proxy_set_header Host $host;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header X-Forwarded-Proto $scheme;       }
+      }
+    }
+  dashboard-v2.nginx.conf: |
+    events {
+      worker_connections 1024;
+    }
+    
+    http {
+      include       mime.types;
+
+      server {
+        listen       {{ .Values.thorasDashboard.v2.containerPort }};
+        server_name  localhost;
+
+        location / {
+          root   /usr/share/nginx/html;
+          index  index.html index.htm;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+          root   /usr/share/nginx/html;
         }
       }
     }

--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -40,7 +40,7 @@ data:
     events {
       worker_connections 1024;
     }
-    
+
     http {
       include       mime.types;
 

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -1,0 +1,132 @@
+Should default to v2 port:
+  1: |
+    apiVersion: v1
+    data:
+      dashboard-v2.nginx.conf: |
+        events {
+          worker_connections 1024;
+        }
+
+        http {
+          include       mime.types;
+
+          server {
+            listen       5173;
+            server_name  localhost;
+
+            location / {
+              root   /usr/share/nginx/html;
+              index  index.html index.htm;
+            }
+
+            error_page   500 502 503 504  /50x.html;
+            location = /50x.html {
+              root   /usr/share/nginx/html;
+            }
+          }
+        }
+      nginx.conf: |
+        events {
+          worker_connections 1024;
+        }
+
+        http {
+          server {
+            listen 80;
+
+            location /v1/ {
+              proxy_pass http://thoras-api-server-v2;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location /config.json {
+                default_type application/json;
+                return 200 '{ "api_base_url": "" }';
+            }
+
+            location / {
+              proxy_pass http://localhost:5173;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;       }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: thoras
+        helm.sh/chart: thoras-4.35.1
+      name: thoras-dashboard-nginx-config
+      namespace: NAMESPACE
+Should use the v1 port if v2 is disabled:
+  1: |
+    apiVersion: v1
+    data:
+      dashboard-v2.nginx.conf: |
+        events {
+          worker_connections 1024;
+        }
+
+        http {
+          include       mime.types;
+
+          server {
+            listen       5173;
+            server_name  localhost;
+
+            location / {
+              root   /usr/share/nginx/html;
+              index  index.html index.htm;
+            }
+
+            error_page   500 502 503 504  /50x.html;
+            location = /50x.html {
+              root   /usr/share/nginx/html;
+            }
+          }
+        }
+      nginx.conf: |
+        events {
+          worker_connections 1024;
+        }
+
+        http {
+          server {
+            listen 80;
+
+            location /v1/ {
+              proxy_pass http://thoras-api-server-v2;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location /config.json {
+                default_type application/json;
+                return 200 '{ "api_base_url": "" }';
+            }
+
+            location / {
+              proxy_pass http://localhost:3000;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;       }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: thoras
+        helm.sh/chart: thoras-4.35.1
+      name: thoras-dashboard-nginx-config
+      namespace: NAMESPACE

--- a/charts/thoras/tests/all_deployments_test.yaml
+++ b/charts/thoras/tests/all_deployments_test.yaml
@@ -12,6 +12,8 @@ set:
   thorasMonitorV2:
     enabled: true
     unittesting: true
+  thorasDashboard:
+    unittesting: true
   thorasReasoning:
     enabled: true
 tests:

--- a/charts/thoras/tests/dashboard_configmap_test.yaml
+++ b/charts/thoras/tests/dashboard_configmap_test.yaml
@@ -1,0 +1,19 @@
+suite: Dashboard
+templates:
+  - dashboard/nginx-config-map.yaml
+tests:
+  - it: Should default to v2 port
+    set:
+      thorasVersion: TEST
+    asserts:
+      - matchSnapshot:
+        path: data.nginx.conf
+  - it: Should use the v1 port if v2 is disabled
+    set:
+      thorasVersion: TEST
+      thorasDashboard:
+        v2:
+          enabled: false
+    asserts:
+      - matchSnapshot:
+        path: data.nginx.conf

--- a/charts/thoras/tests/dashboard_deployment_test.yaml
+++ b/charts/thoras/tests/dashboard_deployment_test.yaml
@@ -7,6 +7,7 @@ tests:
       thorasVersion: TEST
       thorasDashboard:
         replicas: 12
+        unittesting: true
     asserts:
       - isKind:
           of: Deployment
@@ -18,9 +19,12 @@ tests:
           value: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard:TEST
       - equal:
           path: spec.template.spec.containers[1].image
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard-v2:TEST
+      - equal:
+          path: spec.template.spec.containers[2].image
           value: us-east4-docker.pkg.dev/thoras-registry/platform/nginx:stable-alpine3.21
       - equal:
-          path: spec.template.spec.containers[1].volumeMounts[0]
+          path: spec.template.spec.containers[2].volumeMounts[0]
           value:
             name: nginx-config
             mountPath: /etc/nginx/nginx.conf
@@ -36,6 +40,8 @@ tests:
               name: thoras-dashboard-nginx-config
   - it: Should set tolerations if specified
     set:
+      thorasDashboard:
+        unittesting: true
       tolerations:
         - key: "example-key"
           operator: "Exists"
@@ -48,6 +54,9 @@ tests:
             operator: "Exists"
             effect: "NoSchedule"
   - it: Should not have tolerations if not specified
+    set:
+      thorasDashboard:
+        unittesting: true
     asserts:
       - notExists:
           path: spec.template.spec.tolerations

--- a/charts/thoras/tests/select_deployments_test.yaml
+++ b/charts/thoras/tests/select_deployments_test.yaml
@@ -14,6 +14,7 @@ set:
     replicas: 12
   thorasDashboard:
     replicas: 12
+    unittesting: true
   thorasApiServerV2:
     replicas: 12
 tests:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -135,6 +135,9 @@ thorasApiServerV2:
 
 thorasDashboard:
   enabled: true
+  v2:
+    enabled: true
+    containerPort: 5173
   serviceAccount:
     name: thoras-dashboard
     create: true


### PR DESCRIPTION
## Purpose of the Change

We are implementing this change to enable Thoras users to experience our newly enhanced dashboard.

## Changes Implemented

The V2 Thoras dashboard will be deployed by default. Users can revert to the V1 dashboard by modifying the following configuration:
```
thorasDashboard:
  v2:
    enabled: false
```