### PR TITLE
Set OMP_NUM_THREADS=1

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             value: "http://thoras-api-server-v2"
           - name: FORECAST_TIMEOUT
             value: "{{ default 600 .Values.thorasForecast.worker.forecastTimeout }}"
+          - name: OMP_NUM_THREADS
+            value: "1"
         resources:
           requests:
             cpu: {{ .Values.thorasForecast.worker.requests.cpu }}

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -57,3 +57,5 @@ tests:
               value: "http://thoras-api-server-v2"
             - name: FORECAST_TIMEOUT
               value: "600"
+            - name: OMP_NUM_THREADS
+              value: "1"


### PR DESCRIPTION
# Why are we making this change?

Some models will multithread automatically and bypass the cpu limit causing k8s to throttle the forecaster


# What's changing?
set OMP_NUM_THREADS=1 by default 