### PR TITLE
Add SERVICE_POD_LOG_LABEL

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -96,6 +96,8 @@ spec:
             value: "{{ .Values.thorasApiServerV2.slackErrorsEnabled | default .Values.slackErrorsEnabled }}"
           - name: "SERVICE_LOG_LEVEL"
             value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
+          - name: SERVICE_POD_LOG_LABEL
+            value: {{ (printf "app.kubernetes.io/name=%s" .Chart.Name) | quote }}
           - name: "SERVICE_PROMETHEUS_API_URL"
             value: {{ .Values.thorasReasoning.connectors.prometheus.baseUrl }}
           - name: SERVICE_CLUSTER_NAME

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -19,3 +19,8 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.tolerations
+  - it: Ensure SERVICE_POD_LOG_LABEL is correct
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_POD_LOG_LABEL')].value
+          value: "app.kubernetes.io/name=thoras"


### PR DESCRIPTION
# Why are we making this change?
SERVICE_POD_LOG_LABEL is used to dynamically retrieve Thoras service names.

# What's changing?
Added environment variable SERVICE_POD_LOG_LABEL which defaults to "app.kubernetes.io/name=thoras"