### PR TITLE
Give operator role the ability to restart/patch deployments

### DIFF
--- a/charts/thoras/templates/component-clusterrole.yaml
+++ b/charts/thoras/templates/component-clusterrole.yaml
@@ -50,3 +50,9 @@ rules:
   - cronjobs
   verbs:
   - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - patch


### PR DESCRIPTION
# Why are we making this change?

The operator recently started restarting deployments/etc. when a VPA target moved from `autonomous` to `recommendation`. This is done in the reconciler but it didn't have the correct permissions.