### PR TITLE
default to timescale data store

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -122,7 +122,7 @@ thorasApiServerV2:
     memory: 100Mi
   port: 80
   logLevel: "info"
-  timescalePrimary: false
+  timescalePrimary: true
   catalogRefreshInterval: "60s"
   cacheWindow: "10s"
   additionalPvSecurityContext: {}


### PR DESCRIPTION
# Why are we making this change?
Timescale should be the default data store.

# What's changing?
Flipping `timescalePrimary` default value to true