### PR TITLE
Give operator ability to patch more than just deployments

### DIFF
--- a/charts/thoras/templates/api-server-v2/rbac.yaml
+++ b/charts/thoras/templates/api-server-v2/rbac.yaml
@@ -51,6 +51,7 @@ rules:
   - '*'
 - apiGroups:
   - apps
+  - argoproj.io
   resources:
   - '*'
   verbs:

--- a/charts/thoras/templates/api-server-v2/rbac.yaml
+++ b/charts/thoras/templates/api-server-v2/rbac.yaml
@@ -52,7 +52,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
+  - '*'
   verbs:
   - patch
 ---

--- a/charts/thoras/templates/component-clusterrole.yaml
+++ b/charts/thoras/templates/component-clusterrole.yaml
@@ -53,6 +53,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
+  - '*'
   verbs:
   - patch

--- a/charts/thoras/templates/component-clusterrole.yaml
+++ b/charts/thoras/templates/component-clusterrole.yaml
@@ -52,6 +52,7 @@ rules:
   - '*'
 - apiGroups:
   - apps
+  - argoproj.io
   resources:
   - '*'
   verbs:

--- a/charts/thoras/templates/dashboard/rbac.yaml
+++ b/charts/thoras/templates/dashboard/rbac.yaml
@@ -53,12 +53,6 @@ rules:
   - jobs
   verbs:
   - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/thoras/tests/__snapshot__/api_service_deployment_rbac_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/api_service_deployment_rbac_test.yaml.snap
@@ -54,7 +54,7 @@ Default matches snapshot:
       - apiGroups:
           - apps
         resources:
-          - deployments
+          - '*'
         verbs:
           - patch
   3: |

--- a/charts/thoras/tests/__snapshot__/api_service_deployment_rbac_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/api_service_deployment_rbac_test.yaml.snap
@@ -53,6 +53,7 @@ Default matches snapshot:
           - '*'
       - apiGroups:
           - apps
+          - argoproj.io
         resources:
           - '*'
         verbs:


### PR DESCRIPTION
# Why are we making this change?

We support workloads other than `deployments`, including `stateful` sets. The operator and API service layer both should have privileges to `patch`, necessary for triggering workload restarts.

# What's changing?

- opening up the RBAC roles for the operator and the API service layer to have permission to patch `*`, not just `deployments`
- removing the dashboard's ability to patch deployments since this is no longer necessary