### PR TITLE
Revert timescalePrimary defaulting to true

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -122,7 +122,7 @@ thorasApiServerV2:
     memory: 100Mi
   port: 80
   logLevel: "info"
-  timescalePrimary: true
+  timescalePrimary: false
   catalogRefreshInterval: "60s"
   cacheWindow: "10s"
   additionalPvSecurityContext: {}


### PR DESCRIPTION
# Why are we making this change?

We're not confident of using timescale as the primary read for many ASTs. Reverting this to give us a chance to stress test it locally in our cluster and possibly with a customer trying this out.