### PR TITLE
Add readiness probe to API service

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -118,7 +118,7 @@ spec:
                 fieldPath: metadata.namespace
         ports:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
-        readinessProbe:
+        livenessProbe:
           httpGet:
             path: /health
             port: {{ .Values.thorasApiServerV2.containerPort }}

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -118,6 +118,10 @@ spec:
                 fieldPath: metadata.namespace
         ports:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.thorasApiServerV2.containerPort }}
         resources:
           limits:
             memory: {{ .Values.thorasApiServerV2.limits.memory }}


### PR DESCRIPTION
# Why are we making this change?

We have a `/health` endpoint on the service layer and just needed to add a `readinessProbe` section to use it.
