### PR TITLE
Increase timescaledb memory request

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -95,7 +95,7 @@ metricsCollector:
       memory: "8192Mi"
     requests:
       cpu: "400m"
-      memory: "128Mi"
+      memory: "1536Mi"
   blobService:
     containerPort: 8080
     port: 80


### PR DESCRIPTION
# Why are we making this change?

We initially gave timescale a request of 128Mi. However, empirical evidence suggests this should be much higher so that we can fit our indices in memory which impacts query performance. 

# What's changing?

Increasing timescale's memory request from 128Mi to 1536Mi (1.5 Gi)
