### PR TITLE
Drop timescale slightly to fix on smaller nodes

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -95,7 +95,7 @@ metricsCollector:
       memory: "8192Mi"
     requests:
       cpu: "400m"
-      memory: "1536Mi"
+      memory: "1280Mi"
   blobService:
     containerPort: 8080
     port: 80


### PR DESCRIPTION
# Why are we making this change?

Our nodes in our internal clusters can't service a pod that takes >3Gi of memory. Bumping timescale up to 1.5Gi took us over the limit so I'm dropping this down slightly.

# What's changing?
