### PR TITLE
Allow passing cluster name into config.json

### DIFF
--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -25,7 +25,7 @@ data:
 
         location /config.json {
             default_type application/json;
-            return 200 '{ "api_base_url": "" }';
+            return 200 '{ "api_base_url": "", "cluster_name": "{{ .Values.cluster.name }}" }';
         }
 
         location / {

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -52,7 +52,7 @@ Should default to v2 port:
 
             location /config.json {
                 default_type application/json;
-                return 200 '{ "api_base_url": "" }';
+                return 200 '{ "api_base_url": "", "cluster_name": "phantom-assassin" }';
             }
 
             location / {
@@ -126,7 +126,7 @@ Should use the v1 port if v2 is disabled:
 
             location /config.json {
                 default_type application/json;
-                return 200 '{ "api_base_url": "" }';
+                return 200 '{ "api_base_url": "", "cluster_name": "phantom-assassin" }';
             }
 
             location / {

--- a/charts/thoras/tests/dashboard_configmap_test.yaml
+++ b/charts/thoras/tests/dashboard_configmap_test.yaml
@@ -3,20 +3,21 @@ templates:
   - dashboard/nginx-config-map.yaml
 chart:
   version: "4.36.0"
+set:
+  thorasVersion: TEST
+  cluster:
+    name: phantom-assassin
 tests:
   - it: Should default to v2 port
     set:
-      thorasVersion: TEST
     asserts:
       - matchSnapshot:
         path: data.nginx.conf
   - it: Should use the v1 port if v2 is disabled
     set:
-      thorasVersion: TEST
       thorasDashboard:
         v2:
           enabled: false
-
     asserts:
       - matchSnapshot:
         path: data.nginx.conf


### PR DESCRIPTION
# Why are we making this change?

See [#1532](https://github.com/thoras-ai/platform/pull/1532) for the why

# What's changing?

Pass in the cluster name from the helm chart into the config.json of the dashboard