### PR TITLE
Add feature flags to dashboard values

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -165,6 +165,7 @@ helm install \
 | thorasDashboard.logLevel                         | String  | Nil              | Logging level                                                            |
 | thorasDashboard.v2.enabled                       | Bool    | true             | Use v2 dashboard                                                         |
 | thorasDashboard.v2.containerPort                 | Number  | 5173             | V2 Dashboard port                                                        |
+| thorasDashboard.extras                           | Object  | {}               | Additional values to be injected into the Thoras Dashboard config        |
 
 ## Thoras Monitor
 

--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -25,7 +25,7 @@ data:
 
         location /config.json {
             default_type application/json;
-            return 200 '{ "api_base_url": "", "cluster_name": "{{ .Values.cluster.name }}" }';
+            return 200 '{ "api_base_url": "", "extras": {{ toJson (merge (dict "cluster_name" .Values.cluster.name) .Values.thorasDashboard.extras) }} }';
         }
 
         location / {

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -52,7 +52,7 @@ Should default to v2 port:
 
             location /config.json {
                 default_type application/json;
-                return 200 '{ "api_base_url": "", "cluster_name": "phantom-assassin" }';
+                return 200 '{ "api_base_url": "", "extras": {"cluster_name":"phantom-assassin"} }';
             }
 
             location / {
@@ -126,11 +126,85 @@ Should use the v1 port if v2 is disabled:
 
             location /config.json {
                 default_type application/json;
-                return 200 '{ "api_base_url": "", "cluster_name": "phantom-assassin" }';
+                return 200 '{ "api_base_url": "", "extras": {"cluster_name":"phantom-assassin"} }';
             }
 
             location / {
               proxy_pass http://localhost:3000;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;       }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: thoras
+        helm.sh/chart: thoras-4.36.0
+      name: thoras-dashboard-nginx-config
+      namespace: NAMESPACE
+should set extras in config.json:
+  1: |
+    apiVersion: v1
+    data:
+      dashboard-v2.nginx.conf: |
+        events {
+          worker_connections 1024;
+        }
+
+        http {
+          include       mime.types;
+
+          server {
+            listen       5173;
+            server_name  localhost;
+
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+
+            location / {
+              try_files $uri /index.html;
+            }
+
+            location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|otf|ttf|map)$ {
+              expires 1y;
+              access_log off;
+              add_header Cache-Control "public";
+            }
+
+            error_page   500 502 503 504  /50x.html;
+            location = /50x.html {
+              root   /usr/share/nginx/html;
+            }
+          }
+        }
+      nginx.conf: |
+        events {
+          worker_connections 1024;
+        }
+
+        http {
+          server {
+            listen 80;
+
+            location /v1/ {
+              proxy_pass http://thoras-api-server-v2;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location /config.json {
+                default_type application/json;
+                return 200 '{ "api_base_url": "", "extras": {"cluster_name":"phantom-assassin","feature":true,"foo":"bar"} }';
+            }
+
+            location / {
+              proxy_pass http://localhost:5173;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/charts/thoras/tests/dashboard_configmap_test.yaml
+++ b/charts/thoras/tests/dashboard_configmap_test.yaml
@@ -21,3 +21,13 @@ tests:
     asserts:
       - matchSnapshot:
         path: data.nginx.conf
+  - it: should set extras in config.json
+    set:
+      thorasDashboard:
+        extras:
+          cluster_name: phantom-assassin
+          foo: bar
+          feature: true
+    asserts:
+      - matchSnapshot:
+        path: data.nginx.conf

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -155,6 +155,7 @@ thorasDashboard:
   service:
     type: ClusterIP
     annotations: {}
+  extras: {}
 
 thorasMonitor:
   enabled: false


### PR DESCRIPTION
# Why are we making this change?

The addition of new feature flags to the dashboard should not necessitate a complete helm release.

# What's changing?

Added `thorasDashboard.extras` value that will be used to add feature flags to the dashboard dynamically. 
