### PR TITLE
Update third-party images

### DIFF
--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -14,7 +14,7 @@ Default containers should match snapshots:
           secretKeyRef:
             key: password
             name: thoras-elastic-password
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.18.2
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.18.3
     imagePullPolicy: IfNotPresent
     name: elasticsearch
     ports:

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -13,10 +13,10 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[0].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.18.2
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.18.3
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.20.2-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.21.0-pg16
   - it: Default containers should match snapshots
     set:
       thorasVersion: dev

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -69,7 +69,7 @@ metricsCollector:
       cpu: "200m"
       memory: "32Mi"
   search:
-    imageTag: "8.18.2"
+    imageTag: "8.18.3"
     name: elasticsearch
     containerPort: 9200
     limits:
@@ -81,14 +81,14 @@ metricsCollector:
     ttl: 30
     schedule: "00 00 * * *"
   init:
-    imageTag: "3.22.0"
+    imageTag: "3.22.1"
     limits:
       memory: "8192Mi"
     requests:
       cpu: "16m"
       memory: "32Mi"
   timescale:
-    imageTag: "2.20.2-pg16"
+    imageTag: "2.21.0-pg16"
     name: timescale
     containerPort: 5432
     limits:


### PR DESCRIPTION
# Why are we making this change?

We need to keep third-party dependencies up-to-date to avoid security issues.