### PR TITLE
Add restart on cpu flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -139,6 +139,7 @@ helm install \
 | thorasApiServerV2.cacheWindow                 | String  | "10s"   | Maximum staleness of data before querying k8s for updates                     |
 | thorasApiServerV2.additionalPvSecurityContext | Object  | {}      | Allows assigning additional securityContext objects to workloads that use PVs |
 | thorasApiServerV2.prometheus.enabled          | Boolean | true    | Enables a prometheus metric scrape point                                      |
+| thorasApiServerV2.restartWorkloadOnCpu        | Boolean | false   | Enables restarting vertical workloads for CPU forecasts                       |
 
 ## Thoras Dashboard
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -116,6 +116,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: SERVICE_RESTART_WORKLOAD_ON_CPU
+            value: {{ .Values.thorasApiServerV2.restartWorkloadOnCpu | quote }}
         ports:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
         livenessProbe:

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -24,3 +24,11 @@ tests:
       - equal:
           path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_POD_LOG_LABEL')].value
           value: "app.kubernetes.io/name=thoras"
+  - it: Ensure SERVICE_RESTART_WORKLOAD_ON_CPU is correct
+    set:
+      thorasApiServerV2:
+        restartWorkloadOnCpu: true
+    asserts:
+      - equal:
+          path: $.spec.template.spec.containers[0].env[?(@.name == 'SERVICE_RESTART_WORKLOAD_ON_CPU')].value
+          value: "true"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -128,6 +128,7 @@ thorasApiServerV2:
   additionalPvSecurityContext: {}
   prometheus:
     enabled: true
+  restartWorkloadOnCpu: false
 
 thorasDashboard:
   enabled: true


### PR DESCRIPTION
# Why are we making this change?

Restarting vertical workloads based solely on CPU metrics can lead to frequent and unnecessary restarts.

# What's changing?

A feature flag has been introduced to enable users to restart vertical workloads based on CPU forecasts. By default, this feature is disabled. 