### PR TITLE
Don't use the fully qualified service URL, just the intra-namespace URL

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -36,12 +36,12 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         name: wait-for-api-service
         env:
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2.thoras.svc.cluster.local/health"
+          - name: API_HEALTH_URL
+            value: "http://thoras-api-server-v2/health"
         command: ["/bin/sh", "-c"]
         args:
           - |
-            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_BASE_URL}
+            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
             if [ $? -ne 0 ]; then
               echo "Failed to connect to API service"
               exit 1

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -29,12 +29,12 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         name: wait-for-api-service
         env:
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2.thoras.svc.cluster.local/health"
+          - name: API_HEALTH_URL
+            value: "http://thoras-api-server-v2/health"
         command: ["/bin/sh", "-c"]
         args:
           - |
-            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_BASE_URL}
+            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
             if [ $? -ne 0 ]; then
               echo "Failed to connect to API service"
               exit 1

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -37,12 +37,12 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasMonitor.imageTag }}
         name: wait-for-api-service
         env:
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2.thoras.svc.cluster.local/health"
+          - name: API_HEALTH_URL
+            value: "http://thoras-api-server-v2/health"
         command: ["/bin/sh", "-c"]
         args:
           - |
-            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_BASE_URL}
+            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
             if [ $? -ne 0 ]; then
               echo "Failed to connect to API service"
               exit 1

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -43,12 +43,12 @@ spec:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasOperator.imageTag }}
         name: wait-for-api-service
         env:
-          - name: API_BASE_URL
-            value: "http://thoras-api-server-v2.thoras.svc.cluster.local/health"
+          - name: API_HEALTH_URL
+            value: "http://thoras-api-server-v2/health"
         command: ["/bin/sh", "-c"]
         args:
           - |
-            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_BASE_URL}
+            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
             if [ $? -ne 0 ]; then
               echo "Failed to connect to API service"
               exit 1


### PR DESCRIPTION
# Why are we making this change?

The init containers don't need to reference the fully qualified URL for the service but can instead use the intra-namespace URL.
