### PR TITLE
Switch reading of data from elastic to timescale

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -134,7 +134,7 @@ helm install \
 | thorasApiServerV2.requests.memory             | String  | 1000Mi  | Thoras API memory request                                                     |
 | thorasApiServerV2.slackErrorsEnabled          | Boolean | false   | Determines if error-level logs are sent to `slackWebHookUrl`                  |
 | thorasApiServerV2.logLevel                    | String  | Nil     | Logging level                                                                 |
-| thorasApiServerV2.timescalePrimary            | Boolean | false   | Use timescale as the primary data source, not elastic                         |
+| thorasApiServerV2.timescalePrimary            | Boolean | true    | Use timescale as the primary data source, not elastic                         |
 | thorasApiServerV2.queriesPerSecond            | String  | "50"    | Sets a maximum threshold for K8s API qps                                      |
 | thorasApiServerV2.catalogRefreshInterval      | String  | "60s"   | Frequency of updates to catalog following k8s updates                         |
 | thorasApiServerV2.cacheWindow                 | String  | "10s"   | Maximum staleness of data before querying k8s for updates                     |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -125,7 +125,7 @@ thorasApiServerV2:
     memory: 100Mi
   port: 80
   logLevel: "info"
-  timescalePrimary: false
+  timescalePrimary: true
   catalogRefreshInterval: "60s"
   cacheWindow: "10s"
   additionalPvSecurityContext: {}


### PR DESCRIPTION
# Why are we making this change?

In order to turn off elasticsearch, we need to start reading all values from timescale instead.

# What's changing?

Switching the default `timescalePrimary` from `false` to `true`. We'll continue writing values to both, but with this flag enabled, we'll start reading everything from timescale as the primary source of truth instead of Elastic.