### PR TITLE
Give the API service up to 5 minutes to start

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -120,6 +120,12 @@ spec:
             value: {{ .Values.thorasApiServerV2.restartWorkloadOnCpu | quote }}
         ports:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
+        startupProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.thorasApiServerV2.containerPort }}
+          failureThreshold: 30
+          periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
# Why are we making this change?

When a cluster has a large number of ASTs, it can take a couple minutes to load the initial catalog from k8s. Adding a [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) gives the API service long enough to load the catalog.

# What's changing?
