### PR TITLE
Add 'karpenter/dont-disrupt' annotations

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -19,14 +19,12 @@ spec:
         {{- with .Values.thorasApiServerV2.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.thorasApiServerV2.podAnnotations }}
       annotations:
+        karpenter.sh/do-not-disrupt: "true"
+      {{- with .Values.thorasApiServerV2.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.thorasApiServerV2.prometheus.enabled }}
-      {{- if not .Values.thorasApiServerV2.podAnnotations }}
-      annotations:
-      {{- end }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ .Values.thorasApiServerV2.containerPort | quote}}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -21,8 +21,9 @@ spec:
         {{- with .Values.metricsCollector.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.metricsCollector.podAnnotations }}
       annotations:
+        karpenter.sh/do-not-disrupt: "true"
+      {{- with .Values.metricsCollector.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -21,6 +21,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        karpenter.sh/do-not-disrupt: "true"
         {{- if not .Values.thorasMonitor.unittesting }}
         checksum/configmap: {{ include (print $.Template.BasePath "/monitor/configmap.yaml") . | sha256sum }}
         {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -20,14 +20,12 @@ spec:
         {{- with .Values.thorasOperator.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.thorasOperator.podAnnotations }}
       annotations:
+        karpenter.sh/do-not-disrupt: "true"
+      {{- with .Values.thorasOperator.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.thorasOperator.prometheus.enabled }}
-      {{- if not .Values.thorasOperator.podAnnotations }}
-      annotations:
-      {{- end }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ .Values.thorasOperator.prometheus.port | quote }}


### PR DESCRIPTION
# Why are we making this change?

Some of our core services shouldn't be disrupted by karpenter because it creates churn and windows where auto scaling can be affected.

# What's changing?

Adding `karpenter.sh/do-not-disrupt: "true"` annotations to our metrics collector, API server, monitor, and operator.