### PR TITLE
feat: add RETRAIN_OVERRIDE_HOURS environment variable to forecast worker

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -61,6 +61,10 @@ spec:
           - name: RETRAIN_STEADY_STATE_HOURS
             value: {{ (max (float64 (printf "%v" .)) 1.0) | quote }}
             {{- end }}
+            {{- with .Values.thorasForecast.worker.retrainOverrideHours }}
+          - name: RETRAIN_OVERRIDE_HOURS
+            value: {{ (float64 (printf "%v" .)) | quote }}
+            {{- end }}
         resources:
           requests:
             cpu: {{ .Values.thorasForecast.worker.requests.cpu }}

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -117,3 +117,61 @@ tests:
           content:
             name: RETRAIN_STEADY_STATE_HOURS
             value: "1"
+
+  - it: sets RETRAIN_OVERRIDE_HOURS when value is an integer
+    set:
+      thorasForecast:
+        worker:
+          retrainOverrideHours: 10
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RETRAIN_OVERRIDE_HOURS
+            value: "10"
+
+  - it: sets RETRAIN_OVERRIDE_HOURS when value is a float
+    set:
+      thorasForecast:
+        worker:
+          retrainOverrideHours: 10.0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RETRAIN_OVERRIDE_HOURS
+            value: "10"
+
+  - it: omits RETRAIN_OVERRIDE_HOURS when value is null
+    set:
+      thorasForecast:
+        worker:
+          retrainOverrideHours: null
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RETRAIN_OVERRIDE_HOURS
+
+  - it: omits RETRAIN_OVERRIDE_HOURS when value is empty string
+    set:
+      thorasForecast:
+        worker:
+          retrainOverrideHours: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RETRAIN_OVERRIDE_HOURS
+
+  - it: does not clamp RETRAIN_OVERRIDE_HOURS when below 1.0
+    set:
+      thorasForecast:
+        worker:
+          retrainOverrideHours: 0.1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RETRAIN_OVERRIDE_HOURS
+            value: "0.1"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -187,6 +187,7 @@ thorasForecast:
     pollingInterval: 15
     podAnnotations: {}
     retrainSteadyStateHours: ""
+    retrainOverrideHours: ""
     labels: {}
     limits:
       memory: 2Gi


### PR DESCRIPTION
# Why are we making this change?
Expose the “break glass” override via Helm so operators can set/clear it per deployment without code changes.

# What's changing?
New chart value:
- thorasForecast.worker.retrainOverrideHours (optional)
   - Accepts integers/floats (e.g., 10, 10.0, 0.5)
   - null or "" omits the env var entirely
   - No clamp at the chart level (unlike thorasForecast.worker.retrainSteadyStateHours)

# Testing
Unit tests written + passing for all bullet points above

Also checked this all manually with helm template ...