### PR TITLE
Parameterize timescaledb's image

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -112,6 +112,10 @@ helm install \
 | metricsCollector.search.imageTag                                | String  | 8.12.1           | Elasticsearch image tag                                                       |
 | metricsCollector.search.name                                    | String  | elasticsearch    | Elasticsearch container name                                                  |
 | metricsCollector.search.containerPort                           | Number  | 9200             | Elasticsearch port                                                            |
+| metricsCollector.timescale.image                                | String  | timescaledb      | Timescale image                                                               |
+| metricsCollector.timescale.imageTag                             | String  | 2.21.0-pg16      | Timescale image tag                                                           |
+| metricsCollector.timescale.name                                 | String  | timescale        | Timescale container name                                                      |
+| metricsCollector.timescale.containerPort                        | Number  | 5432             | Timescale port                                                                |
 | metricsCollector.blobService.port                               | Number  | 80               | Blob service external port                                                    |
 | metricsCollector.blobService.containerPort                      | Number  | 8080             | Blob service internal port                                                    |
 | metricsCollector.purge.ttl                                      | String  | 30d              | How long to keep metrics data in Elasticsearch                                |

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      - image: {{ .Values.imageCredentials.registry }}/timescaledb:{{ .Values.metricsCollector.timescale.imageTag }}
+      - image: {{ .Values.imageCredentials.registry }}/{{ .Values.metricsCollector.timescale.image }}:{{ .Values.metricsCollector.timescale.imageTag }}
         name: timescaledb
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         ports:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -91,6 +91,7 @@ metricsCollector:
       cpu: "16m"
       memory: "32Mi"
   timescale:
+    image: "timescaledb"
     imageTag: "2.21.0-pg16"
     name: timescale
     containerPort: 5432


### PR DESCRIPTION
# How does this help customers?

Switching from the [timescaledb](https://hub.docker.com/r/timescale/timescaledb) images to [timescaledb-ha](https://hub.docker.com/r/timescale/timescaledb-ha) images gives us access to the Timescale Toolkit and functions that will help us aggregate and compute data for queries, such as [time_weight](https://docs.tigerdata.com/api/latest/hyperfunctions/time-weighted-calculations/time_weight/). Parameterizing this value allows us to test the `-ha` images without impacting customers until we're satisfied.

# What's changing?

Parameterizing `metricsCollector.timescale.image`