### PR TITLE
Update third-party images

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -109,11 +109,11 @@ helm install \
 | metricsCollector.collector.logLevel                             | String  | Nil              | Logging level                                                                 |
 | metricsCollector.podAnnotations                                 | Object  | {}               | Pod Annotations for Thoras metrics collector                                  |
 | metricsCollector.labels                                         | Object  | {}               | Pod/service labels for Thoras metrics collector                               |
-| metricsCollector.search.imageTag                                | String  | 8.12.1           | Elasticsearch image tag                                                       |
+| metricsCollector.search.imageTag                                | String  | 8.19.2           | Elasticsearch image tag                                                       |
 | metricsCollector.search.name                                    | String  | elasticsearch    | Elasticsearch container name                                                  |
 | metricsCollector.search.containerPort                           | Number  | 9200             | Elasticsearch port                                                            |
 | metricsCollector.timescale.image                                | String  | timescaledb      | Timescale image                                                               |
-| metricsCollector.timescale.imageTag                             | String  | 2.21.0-pg16      | Timescale image tag                                                           |
+| metricsCollector.timescale.imageTag                             | String  | 2.21.3-pg16      | Timescale image tag                                                           |
 | metricsCollector.timescale.name                                 | String  | timescale        | Timescale container name                                                      |
 | metricsCollector.timescale.containerPort                        | Number  | 5432             | Timescale port                                                                |
 | metricsCollector.blobService.port                               | Number  | 80               | Blob service external port                                                    |

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -14,7 +14,7 @@ Default containers should match snapshots:
           secretKeyRef:
             key: password
             name: thoras-elastic-password
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.18.3
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.19.2
     imagePullPolicy: IfNotPresent
     name: elasticsearch
     ports:

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -13,10 +13,10 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[0].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.18.3
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/elasticsearch:8.19.2
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.21.0-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.21.3-pg16
   - it: Default containers should match snapshots
     set:
       thorasVersion: dev

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -72,7 +72,7 @@ metricsCollector:
       cpu: "200m"
       memory: "32Mi"
   search:
-    imageTag: "8.18.3"
+    imageTag: "8.19.2"
     name: elasticsearch
     containerPort: 9200
     limits:
@@ -92,7 +92,7 @@ metricsCollector:
       memory: "32Mi"
   timescale:
     image: "timescaledb"
-    imageTag: "2.21.0-pg16"
+    imageTag: "2.21.3-pg16"
     name: timescale
     containerPort: 5432
     limits:


### PR DESCRIPTION
# How does this help customers?

Updating our third-party images keeps on top of security updates.

# What's changing?

Updating the elastic and timescale image tags.