### PR TITLE
Give api proxy container pod resources

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -71,6 +71,12 @@ spec:
           - name: nginx-config
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+        resources:
+          limits:
+            memory: {{ .Values.thorasDashboard.limits.memory }}
+          requests:
+            cpu: {{ .Values.thorasDashboard.requests.cpu }}
+            memory: {{ .Values.thorasDashboard.requests.memory }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
# How does this help customers?

Customers need to be able to right-size the dashboard pods so they can run optimally. Additionally, if someone enrolls Thoras into the dashboard, it will show up with a warning because of no resource settings

# What's changing?

For simplicity, use the same settings for the dashboard container for the api proxy container.
