### PR TITLE
Drop thorasMonitorV2.enabled flag

### DIFF
--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -101,14 +101,13 @@ spec:
           - name: API_BASE_URL
             value: "http://thoras-api-server-v2"
           - name: V2_MONITOR_ENABLED
-            value: {{ .Values.thorasMonitorV2.enabled | default false | quote }}
+            value: "true"
         resources:
           limits:
             memory: {{ .Values.thorasMonitor.limits.memory }}
           requests:
             cpu: {{ .Values.thorasMonitor.requests.cpu }}
             memory: {{ .Values.thorasMonitor.requests.memory }}
-      {{- if .Values.thorasMonitorV2.enabled }}
       - name: thoras-monitor-v2
         image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasMonitor.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -143,7 +142,6 @@ spec:
           requests:
             cpu: {{ .Values.thorasMonitor.requests.cpu }}
             memory: {{ .Values.thorasMonitor.requests.memory }}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/tests/all_deployments_test.yaml
+++ b/charts/thoras/tests/all_deployments_test.yaml
@@ -9,9 +9,6 @@ set:
   thorasMonitor:
     enabled: true
     unittesting: true
-  thorasMonitorV2:
-    enabled: true
-    unittesting: true
   thorasDashboard:
     unittesting: true
   thorasReasoning:

--- a/charts/thoras/tests/monitor_deployment_test.yaml
+++ b/charts/thoras/tests/monitor_deployment_test.yaml
@@ -36,23 +36,6 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
           value: RELEASE-NAME
-  - it: Should not create v2 monitor container when not enabled
-    template: monitor/deployment.yaml
-    set:
-      thorasMonitorV2:
-        enabled: false
-    asserts:
-      - exists:
-          path: $..spec.containers[?(@.name == 'thoras-monitor')]
-      - notExists:
-          path: $..spec.containers[?(@.name == 'thoras-monitor-v2')]
-  - it: Should create v2 monitor container when enabled (default)
-    template: monitor/deployment.yaml
-    asserts:
-      - exists:
-          path: $..spec.containers[?(@.name == 'thoras-monitor')]
-      - exists:
-          path: $..spec.containers[?(@.name == 'thoras-monitor-v2')]
   - it: Should set tolerations if specified
     template: monitor/deployment.yaml
     set:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -172,9 +172,6 @@ thorasMonitor:
   labels: {}
   config: |
 
-thorasMonitorV2:
-  enabled: true
-
 thorasForecast:
   skipCache: false
   requests:


### PR DESCRIPTION
# How does this help customers?

By always enabling the v2 monitor always, we enable removing features that the v1 monitor depends on, including Elasticsearch. By enabling the removal, we enable reducing the footprint of a thoras install.

# What's changing?

Removing the `thorasMonitorv2` flags. This flag previously governed whether the v2 monitor container would start in addition to the v1 monitor. We always want the v2 monitor to start so that there's no loss in monitor coverage.