### PR TITLE
Add worker service account

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -152,17 +152,18 @@ helm install \
 
 ## Thoras Worker
 
-| Key                             | Type    | Default | Description                                                  |
-| ------------------------------- | ------- | ------- | ------------------------------------------------------------ |
-| thorasWorker.enabled            | Boolean | false   | Enables the Thoras worker                                    |
-| thorasWorker.podAnnotations     | Object  | {}      | Pod Annotations for Thoras worker                            |
-| thorasWorker.labels             | Object  | {}      | Pod/service labels for Thoras worker                         |
-| thorasWorker.limits.memory      | String  | 2000Mi  | Thoras API memory limit                                      |
-| thorasWorker.requests.cpu       | String  | 1000Mi  | Thoras API CPU request                                       |
-| thorasWorker.requests.memory    | String  | 1000Mi  | Thoras API memory request                                    |
-| thorasWorker.slackErrorsEnabled | Boolean | false   | Determines if error-level logs are sent to `slackWebHookUrl` |
-| thorasWorker.logLevel           | String  | Nil     | Logging level                                                |
-| thorasWorker.queriesPerSecond   | String  | "50"    | Sets a maximum threshold for K8s API qps                     |
+| Key                              | Type    | Default       | Description                                                  |
+| -------------------------------- | ------- | ------------- | ------------------------------------------------------------ |
+| thorasWorker.enabled             | Boolean | false         | Enables the Thoras worker                                    |
+| thorasWorker.serviceAccount.name | String  | thoras-worker | Service account name for Thoras worker pod                   |
+| thorasWorker.podAnnotations      | Object  | {}            | Pod Annotations for Thoras worker                            |
+| thorasWorker.labels              | Object  | {}            | Pod/service labels for Thoras worker                         |
+| thorasWorker.limits.memory       | String  | 2000Mi        | Thoras API memory limit                                      |
+| thorasWorker.requests.cpu        | String  | 1000Mi        | Thoras API CPU request                                       |
+| thorasWorker.requests.memory     | String  | 1000Mi        | Thoras API memory request                                    |
+| thorasWorker.slackErrorsEnabled  | Boolean | false         | Determines if error-level logs are sent to `slackWebHookUrl` |
+| thorasWorker.logLevel            | String  | Nil           | Logging level                                                |
+| thorasWorker.queriesPerSecond    | String  | "50"          | Sets a maximum threshold for K8s API qps                     |
 
 ## Thoras Dashboard
 

--- a/charts/thoras/templates/worker/service-account.yaml
+++ b/charts/thoras/templates/worker/service-account.yaml
@@ -1,0 +1,17 @@
+{{- if $.Values.thorasWorker.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "thoras.labels" . | nindent 4 }}
+  name: {{ .Values.thorasWorker.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+imagePullSecrets:
+{{- if .Values.imageCredentials.secretRef }}
+  - name: {{ .Values.imageCredentials.secretRef }}
+{{- else }}
+  - name: thoras-secret-registry
+{{- end }}
+
+{{- end}}


### PR DESCRIPTION
# How does this help customers?

In order to run, the worker needs a service account

# What's changing?

Adding a service worker for the `thoras-worker`