### PR TITLE
Add PDB for api server

### DIFF
--- a/charts/thoras/templates/api-server-v2/pdb.yaml
+++ b/charts/thoras/templates/api-server-v2/pdb.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: thoras-api-server-v2
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: thoras-api-server-v2


### PR DESCRIPTION
# How does this help customers?

Ensure maximum api availability in the event of voluntary disruptions like:
  - Karpenter / Cluster autoscaler scale-downs
  - Manual pod evictions
  - Node drains for maintenance
  
On top of making the app more resilient, this should help tighten up monitoring chatter

# What's changing?

Add PDB for our api server. Always ensure there's at least one replica available