### PR TITLE
Add timescaleSnapshotPrimary flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -143,6 +143,7 @@ helm install \
 | thorasApiServerV2.slackErrorsEnabled          | Boolean | false      | Determines if error-level logs are sent to `slackWebHookUrl`                  |
 | thorasApiServerV2.logLevel                    | String  | Nil        | Logging level                                                                 |
 | thorasApiServerV2.timescalePrimary            | Boolean | true       | Use timescale as the primary data source, not elastic                         |
+| thorasApiServerV2.timescaleSnapshotPrimary    | Boolean | false      | Use the timescale snapshot repo as the primary data source                    |
 | thorasApiServerV2.queriesPerSecond            | String  | "50"       | Sets a maximum threshold for K8s API qps                                      |
 | thorasApiServerV2.catalogRefreshInterval      | String  | "60s"      | Frequency of updates to catalog following k8s updates                         |
 | thorasApiServerV2.cacheWindow                 | String  | "10s"      | Maximum staleness of data before querying k8s for updates                     |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -104,6 +104,8 @@ spec:
             value: "http://thoras-blob-api.thoras.svc.cluster.local"
           - name: SERVICE_TIMESCALE_PRIMARY
             value: {{ .Values.thorasApiServerV2.timescalePrimary | quote}}
+          - name: SERVICE_TIMESCALE_SNAPSHOT_PRIMARY
+            value: {{ .Values.thorasApiServerV2.timescaleSnapshotPrimary | quote}}
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasApiServerV2.queriesPerSecond | default .Values.queriesPerSecond | quote }}
           - name: SERVICE_CATALOG_REFRESH_INTERVAL

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -131,6 +131,7 @@ thorasApiServerV2:
   port: 80
   logLevel: "info"
   timescalePrimary: true
+  timescaleSnapshotPrimary: false
   catalogRefreshInterval: "60s"
   cacheWindow: "10s"
   additionalPvSecurityContext: {}


### PR DESCRIPTION
# How does this help customers?

The `timescaleSnapshotPrimary` feature flag enables testing out the updated repo in our test environments before releasing to customers.

# What's changing?

Adding a `timescaleSnapshotPrimary` flag (default `false`) that we can use to test the new repo in our test clusters,