### PR TITLE
Don't run jobs from the API server when the worker is enabled

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -116,6 +116,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: SERVICE_RESTART_WORKLOAD_ON_CPU
             value: {{ .Values.thorasApiServerV2.restartWorkloadOnCpu | quote }}
+          - name: SERVICE_WORK_QUEUE_ENABLED
+            value: {{ not .Values.thorasWorker.enabled | quote }}
         ports:
         - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
         startupProbe:


### PR DESCRIPTION
## How does this help customers?

Improves system scalability by running jobs only from the dedicated worker service when it's enabled, allowing the worker and api service to be scaled separately.

## What's changing?

- Added `SERVICE_WORK_QUEUE_ENABLED` environment variable to API server v2 deployment
- Variable is set to the inverse of `thorasWorker.enabled` to disable job processing when worker is active

## How Tested

- Manual testing of deployment configuration

Disabled: `helm diff upgrade thoras ... --set thorasWorker.enabled=false`

```diff
thoras, thoras-api-server-v2, Deployment (apps) has changed:
...
            - name: SERVICE_RESTART_WORKLOAD_ON_CPU
              value: "false"
+           - name: SERVICE_WORK_QUEUE_ENABLED
+             value: "true"
          ports:
          - containerPort: 8080
...
```

Enabled: `helm diff upgrade thoras ... --set thorasWorker.enabled=true` (ignoring the other output):

```diff
thoras, thoras-operator, Deployment (apps) has changed:
...
            - name: SERVICE_THORAS_API_BASE_URL
              value: "http://thoras-api-server-v2.thoras.svc.cluster.local"
-           - name: SERVICE_REASONING_ENABLED
-             value: "false"
            - name: FORECAST_IMAGE_PULL_POLICY
              value: "IfNotPresent"
...
```

## Claude Prompts

- "Create a PR from the current branch using --head. Tag Reilly for review. Be brief/concise in the PR description."