### PR TITLE
Enable feature flags by default

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -178,6 +178,9 @@ thorasDashboard:
     annotations: {}
   extras:
     show_savings: true
+    cost_analysis: true
+    cost_simulator: true
+    rolling_savings: true
 
 thorasMonitor:
   enabled: false


### PR DESCRIPTION
# How does this help customers?

We want customers to get these features by default, not have to opt into them

# What's changing?

Default to enabling the following dashboard features:

* Cost analysis dashboard
* Cost simulator
* Waste average-over-last-24h (versus real-time, moment-to-moment)
