### PR TITLE
Update subject ServiceAccount in thoras-worker rbac

### DIFF
--- a/charts/thoras/templates/worker/rbac.yaml
+++ b/charts/thoras/templates/worker/rbac.yaml
@@ -28,6 +28,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.thorasApiServerV2.serviceAccount.name }}
+  name: {{ .Values.thorasWorker.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
# How does this help customers?

The `thoras-worker` needs permission to access `thoras.api` objects in order to monitor various components of the thoras install.

# What's changing?

The ClusterRoleBinding for the `thoras-worker` is updated from `thoras-api` to `thoras-worker`