### PR TITLE
Add config to worker deployment

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "thoras.labels" . | nindent 4 }}
+  annotations:
+    {{- if not .Values.thorasMonitor.unittesting }}
+      checksum/configmap: {{ include (print $.Template.BasePath "/monitor/configmap.yaml") . | sha256sum }}
+    {{- end }}
 spec:
   replicas: {{ .Values.thorasWorker.replicas }}
   selector:
@@ -27,6 +31,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.thorasWorker.serviceAccount.name }}
+      volumes:
+      - name: monitor-config
+        configMap:
+          name: thoras-monitor-config
       initContainers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasWorker.imageTag }}
         name: wait-for-postgres
@@ -91,6 +99,11 @@ spec:
           requests:
             cpu: {{ .Values.thorasWorker.requests.cpu }}
             memory: {{ .Values.thorasWorker.requests.memory }}
+        volumeMounts:
+        - name: monitor-config
+          mountPath: /app/config.yaml
+          subPath: config.yaml
+          readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/tests/worker_deployment_test.yaml
+++ b/charts/thoras/tests/worker_deployment_test.yaml
@@ -4,6 +4,8 @@ templates:
 set:
   thorasWorker:
     enabled: true
+  thorasMonitor:
+    unittesting: true
 tests:
   - it: Should set tolerations if specified
     set:


### PR DESCRIPTION
# How does this help customers?

Allow the worker pods access to the monitor config 

# What's changing?

added monitor config to worker pods 
