### PR TITLE
Delete ASTs on uninstall

### DIFF
--- a/charts/thoras/templates/operator/pre-delete-hook.yaml
+++ b/charts/thoras/templates/operator/pre-delete-hook.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: thoras-pre-delete-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ .Release.Name }}
+      labels: {{- include "thoras.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Values.thorasOperator.serviceAccount.name }}
+      restartPolicy: OnFailure
+      containers:
+      - name: thoras-delete-asts
+        image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasOperator.imageTag }}
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command: ["/app/operator", "uninstall"]


### PR DESCRIPTION
## How does this help customers?

Prevents orphaned AST resources when uninstalling the Helm chart.

## What's changing?

Added pre-delete hook to clean up AST resources before chart uninstall.

## How Tested

Manual testing of chart install/uninstall cycle.

## Claude Prompts

N/A - direct implementation.