### PR TITLE
feat: migrate db before starting

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -65,6 +65,9 @@ spec:
               echo "Failed to connect to database after $max_retries retries"
               exit 1
             fi
+
+            # run any migrations, accounting for upgrade/downgrade scenarios
+            ./scripts/migrate_database.sh
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -62,6 +62,9 @@ spec:
               echo "Failed to connect to database after $max_retries retries"
               exit 1
             fi
+
+            # run any migrations, accounting for upgrade/downgrade scenarios
+            ./scripts/migrate_database.sh
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasWorker.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"


### PR DESCRIPTION
## How does this help customers?

Prevents database inconsistency issues during deployments by ensuring migrations run before services start.

## What's changing?

- Added database migration script execution to init containers in both api-server-v2 and worker deployments
- Migration runs after database connectivity check but before main container starts

## How Tested

- Manual testing of deployment process
- Verified migration script executes correctly in init container context

## Claude Prompts

User requested: "create a PR from current branch onto main; keep terse and to the point"

🤖 Generated with [Claude Code](https://claude.ai/code)