### PR TITLE
Add DATABASE_URL to worker and api-server

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -47,6 +47,8 @@ spec:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: host
+          - name: DATABASE_URL
+            value: "$(DATABASE_HOST)/thoras?sslmode=disable"
         command: ["/bin/sh", "-c"]
         args:
           - |

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -44,6 +44,8 @@ spec:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: host
+          - name: DATABASE_URL
+            value: "$(DATABASE_HOST)/thoras?sslmode=disable"
         command: ["/bin/sh", "-c"]
         args:
           - |


### PR DESCRIPTION
# How does this help customers?

Fixing a missing env var in the api-server and worker deployment.

# What's changing?

Adding the `DATABASE_URL` to the worker and api-server init containers.
