### PR TITLE
Switch to timescaledb-ha images

### DIFF
--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -6,7 +6,7 @@ Default containers should match snapshots:
           secretKeyRef:
             key: password
             name: thoras-timescale-password
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.21.3-pg16
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb-ha:pg16.10-ts2.21.3
     imagePullPolicy: IfNotPresent
     name: timescaledb
     ports:

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.21.3-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb-ha:pg16.10-ts2.21.3
   - it: Default containers should match snapshots
     chart:
       version: "4.50.0"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -83,8 +83,8 @@ metricsCollector:
       cpu: "16m"
       memory: "32Mi"
   timescale:
-    image: "timescaledb"
-    imageTag: "2.21.3-pg16"
+    image: "timescaledb-ha"
+    imageTag: "pg16.10-ts2.21.3"
     name: timescale
     containerPort: 5432
     limits:


### PR DESCRIPTION
## How does this help customers?

This change increases our access to various functions in the [Timescale Toolkit](https://docs.tigerdata.com/self-hosted/latest/tooling/install-toolkit/) which will be useful in future features.

## What's changing?

- Updated TimescaleDB image from `timescaledb:2.21.3-pg16` to `timescaledb-ha:pg16.10-ts2.21.3`
- Maintained same PostgreSQL version (16) and TimescaleDB functionality

## How Tested

- We've been running with HA images in our `dev` and test cluster for a while now.

🤖 Generated with [Claude Code](https://claude.ai/code)