### PR TITLE
Enable thoras worker by default

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -148,7 +148,7 @@ helm install \
 
 | Key                              | Type    | Default       | Description                                                  |
 | -------------------------------- | ------- | ------------- | ------------------------------------------------------------ |
-| thorasWorker.enabled             | Boolean | false         | Enables the Thoras worker                                    |
+| thorasWorker.enabled             | Boolean | true          | Enables the Thoras worker                                    |
 | thorasWorker.serviceAccount.name | String  | thoras-worker | Service account name for Thoras worker pod                   |
 | thorasWorker.podAnnotations      | Object  | {}            | Pod Annotations for Thoras worker                            |
 | thorasWorker.labels              | Object  | {}            | Pod/service labels for Thoras worker                         |

--- a/charts/thoras/tests/all_deployments_test.yaml
+++ b/charts/thoras/tests/all_deployments_test.yaml
@@ -9,8 +9,6 @@ set:
   thorasMonitor:
     enabled: true
     unittesting: true
-  thorasWorker:
-    enabled: true
   thorasDashboard:
     unittesting: true
   thorasReasoning:

--- a/charts/thoras/tests/secrets_test.yaml
+++ b/charts/thoras/tests/secrets_test.yaml
@@ -33,8 +33,6 @@ tests:
       - forecast-worker/service-account.yaml
       - worker/service-account.yaml
     set:
-      thorasWorker:
-        enabled: true
       imageCredentials:
         secretRef: "frou-frou"
     documentIndex: 0
@@ -57,8 +55,6 @@ tests:
         enabled: true
       thorasReasoning:
         enabled: true
-      thorasWorker:
-        enabled: true
     asserts:
       - equal:
           path: $..spec.containers[0].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name
@@ -79,8 +75,6 @@ tests:
         enabled: true
       thorasReasoning:
         enabled: true
-      thorasWorker:
-        enabled: true
     asserts:
       - equal:
           path: $..spec.containers[-1].env[?(@.name =~ /SLACK_WEBHOOK_URL$/)].valueFrom.secretKeyRef.name
@@ -96,8 +90,6 @@ tests:
     set:
       cluster:
         name: "test_dev"
-      thorasWorker:
-        enabled: true
     asserts:
       - equal:
           path: $..spec.containers[0].env[?(@.name =~ /SERVICE_CLUSTER_NAME$/)].value

--- a/charts/thoras/tests/select_deployments_test.yaml
+++ b/charts/thoras/tests/select_deployments_test.yaml
@@ -20,7 +20,6 @@ set:
   thorasApiServerV2:
     replicas: 12
   thorasWorker:
-    enabled: true
     replicas: 12
 tests:
   - it: Image registry should be correct

--- a/charts/thoras/tests/worker_deployment_test.yaml
+++ b/charts/thoras/tests/worker_deployment_test.yaml
@@ -2,8 +2,6 @@ suite: Worker Deployment
 templates:
   - worker/deployment.yaml
 set:
-  thorasWorker:
-    enabled: true
   thorasMonitor:
     unittesting: true
 tests:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -127,7 +127,7 @@ thorasApiServerV2:
   restartWorkloadOnCpu: false
 
 thorasWorker:
-  enabled: false
+  enabled: true
   serviceAccount:
     name: thoras-worker
   podAnnotations: {}


### PR DESCRIPTION
## How does this help customers?

Customers get the worker component enabled by default, reducing configuration overhead for new deployments.

## What's changing?

- Changed `thorasWorker.enabled` default from `false` to `true` in values.yaml
- Updated README.md documentation to reflect new default
- Removed explicit `thorasWorker.enabled: true` from test files since it's now the default

## How Tested

Updated all existing helm unit tests to work with the new default. Tests pass without requiring explicit worker enablement.

## Claude Prompts

User: "Create a PR for the current branch using --head, tag Mudit for review. Be super concise in PR description."

/cc @muditmathur11