### PR TITLE
Remove unused THORAS_VERSION

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -172,8 +172,6 @@ spec:
                 key: password
           - name: SERVICE_COLLECTION_PARALLELIZATION
             value: "{{ .Values.metricsCollector.collector.parallelization | default 20}}"
-          - name: SERVICE_THORAS_VERSION
-            value: "{{ .Values.metricsCollector.collector.imageTag | default .Values.thorasVersion }}"
           - name: SERVICE_CHART_VERSION
             value: "{{ .Chart.Version }}"
         resources:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -66,8 +66,6 @@ spec:
                 name: thoras-slack
                 key: webhookUrl
             {{- end }}
-          - name: "THORAS_VERSION"
-            value: {{ .Chart.Version | replace "+" "_" }}
           - name: "SERVICE_FORECAST_RESOURCE_REQUESTS_CPU"
             value: {{ .Values.thorasForecast.requests.cpu | quote }}
           - name: "SERVICE_FORECAST_RESOURCE_LIMITS_CPU"

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -82,8 +82,6 @@ Default containers should match snapshots:
             name: thoras-timescale-password
       - name: SERVICE_COLLECTION_PARALLELIZATION
         value: "20"
-      - name: SERVICE_THORAS_VERSION
-        value: dev
       - name: SERVICE_CHART_VERSION
         value: 4.50.0
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev


### PR DESCRIPTION
# How does this help customers?

Removing unused environment variables simplifies our chart and reduces the chance for errors.

# What's changing?

The `THORAS_VERSION` environment variable is no longer in use by the collector or operator and no longer needed.