### PR TITLE
Add pprof endpoint configuration

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -118,6 +118,7 @@ helm install \
 | metricsCollector.timescale.containerPort                        | Number  | 5432             | Timescale port                                                                |
 | metricsCollector.blobService.port                               | Number  | 80               | Blob service external port                                                    |
 | metricsCollector.blobService.containerPort                      | Number  | 8080             | Blob service internal port                                                    |
+| metricsCollector.blobService.pprof.enabled                      | Boolean | false            | Enable pprof endpoint.                                                        |
 | metricsCollector.slackErrorsEnabled                             | Boolean | false            | Determines if error-level logs are sent to `slackWebHookUrl`                  |
 | metricsCollector.init.imageTag                                  | String  | latest           | Image tag for metrics collector init container                                |
 | metricsCollector.additionalPvSecurityContext                    | Object  | {}               | Allows assigning additional securityContext objects to workloads that use PVs |
@@ -143,6 +144,7 @@ helm install \
 | thorasApiServerV2.additionalPvSecurityContext | Object  | {}         | Allows assigning additional securityContext objects to workloads that use PVs |
 | thorasApiServerV2.prometheus.enabled          | Boolean | true       | Enables a prometheus metric scrape point                                      |
 | thorasApiServerV2.restartWorkloadOnCpu        | Boolean | false      | Enables restarting vertical workloads for CPU forecasts                       |
+| thorasApiServerV2.pprof.enabled               | Boolean | false      | Enable pprof endpoint.                                                        |
 
 ## Thoras Worker
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -123,6 +123,8 @@ spec:
             value: {{ .Values.thorasApiServerV2.restartWorkloadOnCpu | quote }}
           - name: SERVICE_WORK_QUEUE_ENABLED
             value: {{ not .Values.thorasWorker.enabled | quote }}
+          - name: SERVICE_ENABLE_PPROF
+            value: {{ .Values.thorasApiServerV2.pprof.enabled | quote }}
         volumeMounts:
           - name: monitor-config
             mountPath: /app/config.yaml

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -205,6 +205,8 @@ spec:
             value: {{ default .Values.logLevel .Values.thorasApiServerV2.logLevel }}
           - name: SERVICE_STORAGE_FILE_PATH
             value: "/var/lib/share"
+          - name: SERVICE_ENABLE_PPROF
+            value: {{ .Values.metricsCollector.blobService.pprof.enabled | quote }}
         resources:
           limits:
             memory: {{ .Values.metricsCollector.blobService.limits.memory }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -93,6 +93,8 @@ metricsCollector:
       cpu: "400m"
       memory: "1280Mi"
   blobService:
+    pprof:
+      enabled: false
     containerPort: 8080
     port: 80
     limits:
@@ -125,6 +127,8 @@ thorasApiServerV2:
   prometheus:
     enabled: true
   restartWorkloadOnCpu: false
+  pprof:
+    enabled: false
 
 thorasWorker:
   enabled: true


### PR DESCRIPTION
## How does this help customers?

Enables profiling Go services for performance debugging and optimization when needed.

## What's changing?

- Environment variable SERVICE_ENABLE_PPROF controls pprof endpoint exposure; defaults to `false`

## How Tested

- Confirmed environment variables passed to containers