### PR TITLE
Pass watch namespaces to API server and worker

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -125,6 +125,10 @@ spec:
             value: {{ not .Values.thorasWorker.enabled | quote }}
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.thorasApiServerV2.pprof.enabled | quote }}
+          {{- with .Values.rbac.namespaces }}
+          - name: SERVICE_WATCH_NAMESPACES
+            value: {{ join "," . | quote }}
+          {{- end }}
         volumeMounts:
           - name: monitor-config
             mountPath: /app/config.yaml

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasWorker.queriesPerSecond | default .Values.queriesPerSecond | quote }}
+          {{- with .Values.rbac.namespaces }}
+          - name: SERVICE_WATCH_NAMESPACES
+            value: {{ join "," . | quote }}
+          {{- end }}
         resources:
           limits:
             memory: {{ .Values.thorasWorker.limits.memory }}


### PR DESCRIPTION
## How does this help customers?
Enables restricting Thoras monitoring to specific namespaces, reducing resource usage and improving security.

## What's changing?
Added SERVICE_WATCH_NAMESPACES environment variable to API server v2 and worker deployments from `.Values.rbac.namespaces`

## How Tested
Verified template rendering with different namespace configurations.