### PR TITLE
Pass chart version to various components

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -125,6 +125,8 @@ spec:
             value: {{ not .Values.thorasWorker.enabled | quote }}
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.thorasApiServerV2.pprof.enabled | quote }}
+          - name: SERVICE_CHART_VERSION
+            value: {{ .Chart.Version | quote }}
           {{- with .Values.rbac.namespaces }}
           - name: SERVICE_WATCH_NAMESPACES
             value: {{ join "," . | quote }}

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -77,6 +77,8 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_THORAS_API_BASE_URL
             value: "http://thoras-api-server-v2"
+          - name: SERVICE_CHART_VERSION
+            value: {{ .Chart.Version | quote }}
         resources:
           limits:
             memory: {{ .Values.thorasMonitor.limits.memory }}

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -98,6 +98,8 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasWorker.queriesPerSecond | default .Values.queriesPerSecond | quote }}
+          - name: SERVICE_CHART_VERSION
+            value: {{ .Chart.Version | quote }}
           {{- with .Values.rbac.namespaces }}
           - name: SERVICE_WATCH_NAMESPACES
             value: {{ join "," . | quote }}


### PR DESCRIPTION
# How does this help customers?

By knowing the chart version from different messages, such as the monitor, we can better understand the context of a customers deployment when investigating a problem.

# What's changing?

Adding `SERVICE_CHART_VERSION` to the API service, the worker, and the monitor.
