### PR TITLE
Default to timescale snapshots

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -137,7 +137,7 @@ helm install \
 | thorasApiServerV2.requests.memory             | String  | 1000Mi     | Thoras API memory request                                                     |
 | thorasApiServerV2.slackErrorsEnabled          | Boolean | false      | Determines if error-level logs are sent to `slackWebHookUrl`                  |
 | thorasApiServerV2.logLevel                    | String  | Nil        | Logging level                                                                 |
-| thorasApiServerV2.timescaleSnapshotsPrimary   | Boolean | false      | Use the timescale snapshot repo as the primary data source                    |
+| thorasApiServerV2.timescaleSnapshotsPrimary   | Boolean | true       | Use the timescale snapshot repo as the primary data source                    |
 | thorasApiServerV2.queriesPerSecond            | String  | "50"       | Sets a maximum threshold for K8s API qps                                      |
 | thorasApiServerV2.catalogRefreshInterval      | String  | "60s"      | Frequency of updates to catalog following k8s updates                         |
 | thorasApiServerV2.cacheWindow                 | String  | "10s"      | Maximum staleness of data before querying k8s for updates                     |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -120,7 +120,7 @@ thorasApiServerV2:
     memory: 100Mi
   port: 80
   logLevel: "info"
-  timescaleSnapshotsPrimary: false
+  timescaleSnapshotsPrimary: true
   catalogRefreshInterval: "60s"
   cacheWindow: "10s"
   additionalPvSecurityContext: {}


### PR DESCRIPTION
## How does this help customers?

Improves performance by defaulting to the more efficient timescale snapshot data source, reducing query latency and resource usage.

## What's changing?

- Changed `timescaleSnapshotsPrimary` default from `false` to `true` in values.yaml and README.md

## How Tested

- Updated documentation reflects the new default value
- Existing tests validate the configuration option functionality