### PR TITLE
Remove unused MODEL_IMAGE environment variable

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -74,8 +74,6 @@ spec:
             value: {{ .Values.thorasForecast.requests.memory | quote }}
           - name: "SERVICE_FORECAST_RESOURCE_LIMITS_MEMORY"
             value: {{ .Values.thorasForecast.limits.memory | quote }}
-          - name: "MODEL_IMAGE"
-            value: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
           - name: THORAS_NS
             valueFrom:
               fieldRef:


### PR DESCRIPTION
## How does this help customers?

Removes unused environment variable that was cluttering the deployment configuration and potentially causing confusion during troubleshooting.

## What's changing?

- Removed `MODEL_IMAGE` environment variable from operator deployment template
- Variable was not being used by the application and was redundant

## How Tested

- Template renders correctly without the variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)