### PR TITLE
Increase timescale default requests

### DIFF
--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -13,10 +13,10 @@ Default containers should match snapshots:
       - containerPort: 5432
     resources:
       limits:
-        memory: 8192Mi
+        memory: 16384Mi
       requests:
         cpu: 400m
-        memory: 1280Mi
+        memory: 3072Mi
   2: |
     args:
       - |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -91,7 +91,7 @@ metricsCollector:
       memory: "8192Mi"
     requests:
       cpu: "400m"
-      memory: "1280Mi"
+      memory: "3072Mi"
   blobService:
     pprof:
       enabled: false

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -88,7 +88,7 @@ metricsCollector:
     name: timescale
     containerPort: 5432
     limits:
-      memory: "8192Mi"
+      memory: "16384Mi"
     requests:
       cpu: "400m"
       memory: "3072Mi"


### PR DESCRIPTION
# How does this help customers?

With elastic no longer necessary, we need to commit more resources to timescale to avoid OOMs.

```
POD                                 NAME               CPU(cores)   MEMORY(bytes)
metrics-collector-c88d8c796-945wr   thoras-blob-api    20m          158Mi
metrics-collector-c88d8c796-945wr   thoras-collector   0m           12Mi
metrics-collector-c88d8c796-945wr   timescaledb        692m         5012Mi
```

# What's changing?

Increasing timescale's request to 3gb