### PR TITLE
Update TimescaleDB image to official timescaledb image

### DIFF
--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -6,7 +6,7 @@ Default containers should match snapshots:
           secretKeyRef:
             key: password
             name: thoras-timescale-password
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb-ha:pg16.10-ts2.21.3
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.21.3-pg16
     imagePullPolicy: IfNotPresent
     name: timescaledb
     ports:

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb-ha:pg16.10-ts2.21.3
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.21.3-pg16
   - it: Default containers should match snapshots
     chart:
       version: "4.50.0"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -83,8 +83,8 @@ metricsCollector:
       cpu: "16m"
       memory: "32Mi"
   timescale:
-    image: "timescaledb-ha"
-    imageTag: "pg16.10-ts2.21.3"
+    image: "timescaledb"
+    imageTag: "2.21.3-pg16"
     name: timescale
     containerPort: 5432
     limits:


### PR DESCRIPTION
## How does this help customers?

This change updates the TimescaleDB image reference to use the official `timescaledb` image instead of the HA variant (`timescaledb-ha`), with the tag format changed from `pg16.10-ts2.21.3` to `2.21.3-pg16`. This ensures customers benefit from better image support, stability, and alignment with TimescaleDB's standard distribution.

## What's changing?

- Changed `metricsCollector.timescale.image` from `timescaledb-ha` to `timescaledb`
- Updated `metricsCollector.timescale.imageTag` from `pg16.10-ts2.21.3` to `2.21.3-pg16`

## How Tested

- Helm template rendering verified to ensure correct image reference
- Chart linting passes
- CI/CD pipeline tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)