### PR TITLE
Always enable thoras worker

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -151,7 +151,6 @@ helm install \
 
 | Key                                    | Type    | Default       | Description                                                      |
 | -------------------------------------- | ------- | ------------- | ---------------------------------------------------------------- |
-| thorasWorker.enabled                   | Boolean | true          | Enables the Thoras worker                                        |
 | thorasWorker.serviceAccount.name       | String  | thoras-worker | Service account name for Thoras worker pod                       |
 | thorasWorker.podAnnotations            | Object  | {}            | Pod Annotations for Thoras worker                                |
 | thorasWorker.labels                    | Object  | {}            | Pod/service labels for Thoras worker                             |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -123,8 +123,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: SERVICE_RESTART_WORKLOAD_ON_CPU
             value: {{ .Values.thorasApiServerV2.restartWorkloadOnCpu | quote }}
-          - name: SERVICE_WORK_QUEUE_ENABLED
-            value: {{ not .Values.thorasWorker.enabled | quote }}
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.thorasApiServerV2.pprof.enabled | quote }}
           - name: SERVICE_CHART_VERSION

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.thorasWorker.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -127,4 +126,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}

--- a/charts/thoras/templates/worker/rbac.yaml
+++ b/charts/thoras/templates/worker/rbac.yaml
@@ -49,14 +49,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- if .Values.thorasWorker.enabled }}
-  {{- if .Values.rbac.namespaces}}
-    {{- range $idx, $namespace := .Values.rbac.namespaces }}
-      {{- template "thoras.worker.roles" ($ | deepCopy | merge (dict "rbacNamespace" $namespace) ) }}
-    {{- end}}
-  {{- else }}
-    {{- template "thoras.worker.roles" $ }}
-  {{- end }}
+{{- if .Values.rbac.namespaces}}
+  {{- range $idx, $namespace := .Values.rbac.namespaces }}
+    {{- template "thoras.worker.roles" ($ | deepCopy | merge (dict "rbacNamespace" $namespace) ) }}
+  {{- end}}
+{{- else }}
+  {{- template "thoras.worker.roles" $ }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -88,4 +87,3 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.thorasWorker.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/charts/thoras/templates/worker/service-account.yaml
+++ b/charts/thoras/templates/worker/service-account.yaml
@@ -1,4 +1,3 @@
-{{- if $.Values.thorasWorker.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -13,5 +12,3 @@ imagePullSecrets:
 {{- else }}
   - name: thoras-secret-registry
 {{- end }}
-
-{{- end}}


### PR DESCRIPTION
## How does this help customers?

Simplifies deployment by removing the optional toggle for the thoras worker component, ensuring consistent platform behavior.

## What's changing?

- Removed `thorasWorker.enabled` configuration flag
- Removed `SERVICE_WORK_QUEUE_ENABLED` env var from API server (fallback logic)

## How Tested

Helm unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)