### PR TITLE
Align SLM compute requests with inference need

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -256,7 +256,7 @@ thorasSlmAgent:
     memory: 8192Mi
   requests:
     cpu: 1024m
-    memory: 1024Mi
+    memory: 4096Mi
 
 # K8s client max queries per second
 queriesPerSecond: "50"


### PR DESCRIPTION
# How does this help customers?

SLM will literally fail to initialize if there's not enough memory for inference available on the system. No relying on spiking is allowed, so we'll need to pre-allocate what we need

# What's changing?

Explicitly allocate what we need for inference

# Forget anything

[x] Do any feature flags need to be managed?
