### PR TITLE
Remove outdated collector parameter

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -138,7 +138,7 @@ spec:
             # run any migrations, accounting for upgrade/downgrade scenarios
             ./scripts/migrate_database.sh
 
-            ./metrics-collector collect -c 60s
+            ./metrics-collector collect
         env:
           - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -50,7 +50,7 @@ Default containers should match snapshots:
         # run any migrations, accounting for upgrade/downgrade scenarios
         ./scripts/migrate_database.sh
 
-        ./metrics-collector collect -c 60s
+        ./metrics-collector collect
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
# How does this help customers?

To start, the collector must no longer use the `-c` parameter.

# What's changing?

Dropping the out-dated `-c` parameter. Future PR to remove the collector altogether.