### PR TITLE
Add reinvocationPolicy config for mutating webhooks

### DIFF
--- a/charts/thoras/templates/operator/webhooks.yaml
+++ b/charts/thoras/templates/operator/webhooks.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
 webhooks:
 - name: "pods.thoras.ai"
-  reinvocationPolicy: IfNeeded
+  reinvocationPolicy: {{ .Values.thorasOperator.webhooks.reinvocationPolicy.pods }}
   {{- with .Values.thorasOperator.webhooks.namespaceSelector }}
   namespaceSelector:
     {{- toYaml . | nindent 4 }}
@@ -28,6 +28,7 @@ webhooks:
   admissionReviewVersions:
     - v1
 - name: "scale.thoras.ai"
+  reinvocationPolicy: {{ .Values.thorasOperator.webhooks.reinvocationPolicy.scale }}
   {{- with .Values.thorasOperator.webhooks.namespaceSelector }}
   namespaceSelector:
     {{- toYaml . | nindent 4 }}

--- a/charts/thoras/templates/operator/webhooks.yaml
+++ b/charts/thoras/templates/operator/webhooks.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
 webhooks:
 - name: "pods.thoras.ai"
+  reinvocationPolicy: IfNeeded
   {{- with .Values.thorasOperator.webhooks.namespaceSelector }}
   namespaceSelector:
     {{- toYaml . | nindent 4 }}

--- a/charts/thoras/tests/operator_webhooks_test.yaml
+++ b/charts/thoras/tests/operator_webhooks_test.yaml
@@ -25,3 +25,26 @@ tests:
           path: webhooks[0].namespaceSelector
       - notExists:
           path: webhooks[1].namespaceSelector
+
+  - it: Should set reinvocationPolicy to IfNeeded on pods webhook and Never on scale webhook by default
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: webhooks[0].reinvocationPolicy
+          value: IfNeeded
+      - equal:
+          path: webhooks[1].reinvocationPolicy
+          value: Never
+
+  - it: Should allow overriding reinvocationPolicy on both webhooks
+    documentIndex: 0
+    set:
+      thorasOperator.webhooks.reinvocationPolicy.pods: Never
+      thorasOperator.webhooks.reinvocationPolicy.scale: IfNeeded
+    asserts:
+      - equal:
+          path: webhooks[0].reinvocationPolicy
+          value: Never
+      - equal:
+          path: webhooks[1].reinvocationPolicy
+          value: IfNeeded

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -141,6 +141,9 @@ thorasOperator:
           values:
             - kube-system
             - kube-node-lease
+    reinvocationPolicy:
+      pods: IfNeeded
+      scale: Never
   extraEgressRules: []
 
 metricsCollector:


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Allows operators to configure `reinvocationPolicy` on the pods and scale mutating webhooks. The pods webhook defaults to `IfNeeded` to ensure mutations are applied correctly when other webhooks also mutate pods.

## What's changing?

- Add `reinvocationPolicy` field to both `pods.thoras.ai` and `scale.thoras.ai` webhooks
- Default: `pods` → `IfNeeded`, `scale` → `Never`
- Configurable via `thorasOperator.webhooks.reinvocationPolicy.{pods,scale}` in values

## How Tested

Added 2 unit tests covering default values and override behavior.