### PR TITLE
feat: add network policy support for all components

### DIFF
--- a/charts/thoras/templates/api-server-v2/network-policy.yaml
+++ b/charts/thoras/templates/api-server-v2/network-policy.yaml
@@ -22,7 +22,9 @@ spec:
   # Allow all egress to pods within the same namespace
   - to:
     - podSelector: {}
-  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here).
+  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
+  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
   - ports:
     - port: 443
       protocol: TCP

--- a/charts/thoras/templates/api-server-v2/network-policy.yaml
+++ b/charts/thoras/templates/api-server-v2/network-policy.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-api-server-v2
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: thoras-api-server-v2
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow all ingress from pods within the same namespace
+  - from:
+    - podSelector: {}
+  egress:
+  # Allow all egress to pods within the same namespace
+  - to:
+    - podSelector: {}
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- with .Values.thorasApiServerV2.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-api-server-v2
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: thoras-api-server-v2
+  ingress:
+  # Allow all ingress from endpoints within the same namespace
+  - fromEndpoints:
+    - {}
+  egress:
+  # Allow all egress to endpoints within the same namespace
+  - toEndpoints:
+    - {}
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  - toEntities:
+    - kube-apiserver
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  {{- with .Values.thorasApiServerV2.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/thoras/templates/collector/network-policy.yaml
+++ b/charts/thoras/templates/collector/network-policy.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: metrics-collector
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow all ingress from pods within the same namespace
+  - from:
+    - podSelector: {}
+  egress:
+  # Allow all egress to pods within the same namespace
+  - to:
+    - podSelector: {}
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- with .Values.metricsCollector.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: metrics-collector
+  ingress:
+  # Allow all ingress from endpoints within the same namespace
+  - fromEndpoints:
+    - {}
+  egress:
+  # Allow all egress to endpoints within the same namespace
+  - toEndpoints:
+    - {}
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  {{- with .Values.metricsCollector.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/thoras/templates/dashboard/network-policy.yaml
+++ b/charts/thoras/templates/dashboard/network-policy.yaml
@@ -1,0 +1,88 @@
+{{- if and .Values.networkPolicy.enabled .Values.thorasDashboard.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: thoras-dashboard
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow all ingress from pods within the same namespace
+  - from:
+    - podSelector: {}
+  # Allow ingress from users and ingress controllers on the dashboard port
+  - ports:
+    - port: 8080
+      protocol: TCP
+  egress:
+  # Allow all egress to pods within the same namespace
+  - to:
+    - podSelector: {}
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- with .Values.thorasDashboard.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: thoras-dashboard
+  ingress:
+  # Allow all ingress from endpoints within the same namespace
+  - fromEndpoints:
+    - {}
+  # Allow ingress from users and ingress controllers on the dashboard port
+  - fromEntities:
+    - all
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+  egress:
+  # Allow all egress to endpoints within the same namespace
+  - toEndpoints:
+    - {}
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  {{- with .Values.thorasDashboard.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/thoras/templates/forecast-worker/network-policy.yaml
+++ b/charts/thoras/templates/forecast-worker/network-policy.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-forecast-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: thoras-forecast-worker
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow all ingress from pods within the same namespace
+  - from:
+    - podSelector: {}
+  egress:
+  # Allow all egress to pods within the same namespace
+  - to:
+    - podSelector: {}
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- with .Values.thorasForecast.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-forecast-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: thoras-forecast-worker
+  ingress:
+  # Allow all ingress from endpoints within the same namespace
+  - fromEndpoints:
+    - {}
+  egress:
+  # Allow all egress to endpoints within the same namespace
+  - toEndpoints:
+    - {}
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  {{- with .Values.thorasForecast.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/thoras/templates/monitor/network-policy.yaml
+++ b/charts/thoras/templates/monitor/network-policy.yaml
@@ -1,0 +1,77 @@
+{{- if and .Values.networkPolicy.enabled .Values.thorasMonitor.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: thoras-monitor
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow all ingress from pods within the same namespace
+  - from:
+    - podSelector: {}
+  egress:
+  # Allow all egress to pods within the same namespace
+  - to:
+    - podSelector: {}
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- with .Values.thorasMonitor.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: thoras-monitor
+  ingress:
+  # Allow all ingress from endpoints within the same namespace
+  - fromEndpoints:
+    - {}
+  egress:
+  # Allow all egress to endpoints within the same namespace
+  - toEndpoints:
+    - {}
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  {{- with .Values.thorasMonitor.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/thoras/templates/operator/network-policy.yaml
+++ b/charts/thoras/templates/operator/network-policy.yaml
@@ -18,7 +18,9 @@ spec:
   # Allow all ingress from pods within the same namespace
   - from:
     - podSelector: {}
-  # Allow webhook callbacks from the Kubernetes API server
+  # Allow webhook callbacks from the Kubernetes API server.
+  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
+  # ingress from any source on this port. Use the cilium flavor for precise scoping.
   - ports:
     - port: 9443
       protocol: TCP
@@ -26,7 +28,9 @@ spec:
   # Allow all egress to pods within the same namespace
   - to:
     - podSelector: {}
-  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here).
+  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
+  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
   - ports:
     - port: 443
       protocol: TCP

--- a/charts/thoras/templates/operator/network-policy.yaml
+++ b/charts/thoras/templates/operator/network-policy.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: thoras-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow all ingress from pods within the same namespace
+  - from:
+    - podSelector: {}
+  # Allow webhook callbacks from the Kubernetes API server
+  - ports:
+    - port: 9443
+      protocol: TCP
+  egress:
+  # Allow all egress to pods within the same namespace
+  - to:
+    - podSelector: {}
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- with .Values.thorasOperator.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: thoras-operator
+  ingress:
+  # Allow all ingress from endpoints within the same namespace
+  - fromEndpoints:
+    - {}
+  # Allow webhook callbacks from the Kubernetes API server
+  - fromEntities:
+    - kube-apiserver
+  egress:
+  # Allow all egress to endpoints within the same namespace
+  - toEndpoints:
+    - {}
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  - toEntities:
+    - kube-apiserver
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  {{- with .Values.thorasOperator.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-network-policy.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-network-policy.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-certgen
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Weight -10 ensures this policy exists before the certgen-create job (weight -5) runs.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: webhook-certgen
+  policyTypes:
+  - Egress
+  egress:
+  # Allow access to the Kubernetes API server to read/write secrets and patch webhooks.
+  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
+  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-certgen
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Weight -10 ensures this policy exists before the certgen-create job (weight -5) runs.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: webhook-certgen
+  egress:
+  # Allow access to the Kubernetes API server to read/write secrets and patch webhooks
+  - toEntities:
+    - kube-apiserver
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+{{- end }}
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
@@ -62,7 +62,6 @@ metadata:
     app.kubernetes.io/component: webhook-certgen
 spec:
   ttlSecondsAfterFinished: 300
-  backoffLimit: 10
   template:
     metadata:
       name: thoras-tls-certsgen-patch-validating

--- a/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
@@ -62,6 +62,7 @@ metadata:
     app.kubernetes.io/component: webhook-certgen
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 10
   template:
     metadata:
       name: thoras-tls-certsgen-patch-validating

--- a/charts/thoras/templates/worker/network-policy.yaml
+++ b/charts/thoras/templates/worker/network-policy.yaml
@@ -22,7 +22,9 @@ spec:
   # Allow all egress to pods within the same namespace
   - to:
     - podSelector: {}
-  # Allow access to the Kubernetes API server
+  # Allow access to the Kubernetes API server.
+  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
+  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
   - ports:
     - port: 443
       protocol: TCP

--- a/charts/thoras/templates/worker/network-policy.yaml
+++ b/charts/thoras/templates/worker/network-policy.yaml
@@ -1,0 +1,86 @@
+{{- if and .Values.networkPolicy.enabled .Values.thorasWorker.enabled }}
+{{- if eq .Values.networkPolicy.flavor "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: thoras-worker
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow all ingress from pods within the same namespace
+  - from:
+    - podSelector: {}
+  egress:
+  # Allow all egress to pods within the same namespace
+  - to:
+    - podSelector: {}
+  # Allow access to the Kubernetes API server
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- with .Values.thorasWorker.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else if eq .Values.networkPolicy.flavor "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .) | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: thoras-worker
+  ingress:
+  # Allow all ingress from endpoints within the same namespace
+  - fromEndpoints:
+    - {}
+  egress:
+  # Allow all egress to endpoints within the same namespace
+  - toEndpoints:
+    - {}
+  # Allow access to the Kubernetes API server
+  - toEntities:
+    - kube-apiserver
+  # Allow DNS resolution
+  - toEndpoints:
+    - matchLabels:
+        k8s:k8s-app: kube-dns
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  {{- with .Values.thorasWorker.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/thoras/tests/network_policy_test.yaml
+++ b/charts/thoras/tests/network_policy_test.yaml
@@ -1,0 +1,227 @@
+suite: Network Policy
+set:
+  networkPolicy:
+    enabled: true
+    flavor: kubernetes
+  thorasMonitor:
+    enabled: true
+tests:
+  # --- Rendering guards ---
+
+  - it: Does not render when networkPolicy is disabled
+    set:
+      networkPolicy:
+        enabled: false
+    templates:
+      - api-server-v2/network-policy.yaml
+      - collector/network-policy.yaml
+      - forecast-worker/network-policy.yaml
+      - operator/network-policy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Does not render dashboard policy when dashboard is disabled
+    template: dashboard/network-policy.yaml
+    set:
+      thorasDashboard:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Does not render monitor policy when monitor is disabled
+    template: monitor/network-policy.yaml
+    set:
+      thorasMonitor:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Does not render worker policy when worker is disabled
+    template: worker/network-policy.yaml
+    set:
+      thorasWorker:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- Kubernetes flavor ---
+
+  - it: Renders NetworkPolicy kind for kubernetes flavor
+    templates:
+      - api-server-v2/network-policy.yaml
+      - collector/network-policy.yaml
+      - forecast-worker/network-policy.yaml
+      - operator/network-policy.yaml
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+
+  - it: Operator kubernetes policy targets the correct pod selector
+    template: operator/network-policy.yaml
+    asserts:
+      - equal:
+          path: spec.podSelector.matchLabels.app
+          value: thoras-operator
+
+  - it: Operator kubernetes policy allows webhook ingress on port 9443
+    template: operator/network-policy.yaml
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            ports:
+            - port: 9443
+              protocol: TCP
+
+  - it: Operator kubernetes policy allows API server egress on ports 443 and 6443
+    template: operator/network-policy.yaml
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            ports:
+            - port: 443
+              protocol: TCP
+            - port: 6443
+              protocol: TCP
+
+  - it: Dashboard kubernetes policy allows external ingress on port 8080
+    template: dashboard/network-policy.yaml
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            ports:
+            - port: 8080
+              protocol: TCP
+
+  - it: All kubernetes policies allow DNS egress via kube-dns
+    templates:
+      - api-server-v2/network-policy.yaml
+      - collector/network-policy.yaml
+      - forecast-worker/network-policy.yaml
+      - operator/network-policy.yaml
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+            ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+
+  # --- Cilium flavor ---
+
+  - it: Renders CiliumNetworkPolicy kind for cilium flavor
+    templates:
+      - api-server-v2/network-policy.yaml
+      - collector/network-policy.yaml
+      - forecast-worker/network-policy.yaml
+      - operator/network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+    asserts:
+      - isKind:
+          of: CiliumNetworkPolicy
+      - equal:
+          path: apiVersion
+          value: cilium.io/v2
+
+  - it: Operator cilium policy allows kube-apiserver ingress for webhook callbacks
+    template: operator/network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            fromEntities:
+            - kube-apiserver
+
+  - it: Operator cilium policy allows kube-apiserver egress
+    template: operator/network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            toEntities:
+            - kube-apiserver
+
+  - it: All cilium policies allow DNS egress via kube-dns endpoint
+    templates:
+      - api-server-v2/network-policy.yaml
+      - collector/network-policy.yaml
+      - forecast-worker/network-policy.yaml
+      - operator/network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            toEndpoints:
+            - matchLabels:
+                k8s:k8s-app: kube-dns
+                k8s:io.kubernetes.pod.namespace: kube-system
+            toPorts:
+            - ports:
+              - port: "53"
+                protocol: ANY
+              rules:
+                dns:
+                - matchPattern: "*"
+
+  # --- extraEgressRules ---
+
+  - it: Injects extraEgressRules into the kubernetes egress list
+    template: api-server-v2/network-policy.yaml
+    set:
+      thorasApiServerV2:
+        extraEgressRules:
+          - ports:
+            - port: 9200
+              protocol: TCP
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            ports:
+            - port: 9200
+              protocol: TCP
+
+  - it: Injects extraEgressRules into the cilium egress list
+    template: collector/network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+      metricsCollector:
+        extraEgressRules:
+          - toFQDNs:
+            - matchName: "my-database.example.com"
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            toFQDNs:
+            - matchName: "my-database.example.com"

--- a/charts/thoras/tests/network_policy_test.yaml
+++ b/charts/thoras/tests/network_policy_test.yaml
@@ -17,6 +17,7 @@ tests:
       - collector/network-policy.yaml
       - forecast-worker/network-policy.yaml
       - operator/network-policy.yaml
+      - operator/webhooks-certgen-network-policy.yaml
     asserts:
       - hasDocuments:
           count: 0
@@ -225,3 +226,90 @@ tests:
           content:
             toFQDNs:
             - matchName: "my-database.example.com"
+
+  # --- Certgen network policy ---
+
+  - it: Certgen kubernetes policy targets the webhook-certgen component selector
+    template: operator/webhooks-certgen-network-policy.yaml
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: webhook-certgen
+
+  - it: Certgen kubernetes policy allows API server egress on ports 443 and 6443
+    template: operator/webhooks-certgen-network-policy.yaml
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            ports:
+            - port: 443
+              protocol: TCP
+            - port: 6443
+              protocol: TCP
+
+  - it: Certgen kubernetes policy allows DNS egress via kube-dns
+    template: operator/webhooks-certgen-network-policy.yaml
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+            ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+
+  - it: Certgen cilium policy targets the webhook-certgen component selector
+    template: operator/webhooks-certgen-network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+    asserts:
+      - isKind:
+          of: CiliumNetworkPolicy
+      - equal:
+          path: spec.endpointSelector.matchLabels["app.kubernetes.io/component"]
+          value: webhook-certgen
+
+  - it: Certgen cilium policy allows kube-apiserver egress
+    template: operator/webhooks-certgen-network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            toEntities:
+            - kube-apiserver
+
+  - it: Certgen cilium policy allows DNS egress via kube-dns endpoint
+    template: operator/webhooks-certgen-network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            toEndpoints:
+            - matchLabels:
+                k8s:k8s-app: kube-dns
+                k8s:io.kubernetes.pod.namespace: kube-system
+            toPorts:
+            - ports:
+              - port: "53"
+                protocol: ANY
+              rules:
+                dns:
+                - matchPattern: "*"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -21,6 +21,12 @@ resourceQuota:
   cronjobs: 200
   jobs: 200
 
+networkPolicy:
+  enabled: false
+  # flavor: "kubernetes" uses standard NetworkPolicy (networking.k8s.io/v1)
+  # flavor: "cilium" uses CiliumNetworkPolicy (cilium.io/v2)
+  flavor: kubernetes
+
 imagePullPolicy: "IfNotPresent"
 
 logLevel: info
@@ -135,6 +141,7 @@ thorasOperator:
           values:
             - kube-system
             - kube-node-lease
+  extraEgressRules: []
 
 metricsCollector:
   persistence:
@@ -201,6 +208,7 @@ metricsCollector:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  extraEgressRules: []
 
 thorasApiServerV2:
   rbac:
@@ -233,6 +241,7 @@ thorasApiServerV2:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  extraEgressRules: []
 
 thorasWorker:
   enabled: true
@@ -267,6 +276,7 @@ thorasWorker:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  extraEgressRules: []
 
 thorasDashboard:
   enabled: true
@@ -326,6 +336,7 @@ thorasDashboard:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  extraEgressRules: []
 
 thorasMonitor:
   enabled: false
@@ -348,6 +359,7 @@ thorasMonitor:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  extraEgressRules: []
 
 thorasForecast:
   serviceAccount:
@@ -397,6 +409,7 @@ thorasForecast:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  extraEgressRules: []
 
 # K8s client max queries per second
 queriesPerSecond: "50"


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Enables customers to enforce network-level traffic controls for all Thoras platform components, supporting both standard Kubernetes NetworkPolicy and Cilium. This helps teams meet compliance and security requirements in locked-down clusters.

## What's changing?

- Add `NetworkPolicy` / `CiliumNetworkPolicy` templates for all components (api-server-v2, collector, dashboard, forecast-worker, monitor, operator, worker)
- New `networkPolicy.enabled` and `networkPolicy.flavor` values (disabled by default)
- Helm unit tests covering both Kubernetes and Cilium flavors

## How Tested

Added 227-line test suite covering both flavors for all components. Policies are disabled by default so no impact to existing installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>