### PR TITLE
Support external TimescaleDB via DSN

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -175,6 +175,18 @@ All components support `<component>.useGlobalAffinity` (default: `true`) and `<c
 | thorasOperator.prometheus.enabled  | Boolean | true            | Enables a prometheus metric exporter                         |
 | thorasOperator.prometheus.port     | Number  | 9101            | Port for the prometheus metric exporter                      |
 
+## External TimescaleDB
+
+When set, the chart skips deploying the in-cluster TimescaleDB and configures
+all components to use an external database instead. The TimescaleDB extension
+must be pre-installed and managed externally.
+
+| Key                             | Type   | Default | Description                                                                                           |
+| ------------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------- |
+| externalTimescale.dsn           | String | ""      | Full postgres DSN including database name, e.g. `postgres://user:pass@host:5432/tsdb?sslmode=require` |
+| externalTimescale.secretRefName | String | ""      | Name of a pre-existing Secret containing the DSN (alternative to `dsn`)                               |
+| externalTimescale.secretRefKey  | String | ""      | Key within the Secret that holds the DSN                                                              |
+
 ## Thoras Metrics Collector
 
 | Key                                                             | Type    | Default          | Description                                                  |

--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -92,6 +92,15 @@ Global environment variables (proxy settings + user-defined env) injected into a
 Returns a YAML list of global env var entries (proxy + user-defined), or empty string.
 Indent the output at the call site: {{- include "thoras.globalEnv" . | indent 10 }}
 */}}
+{{/*
+True when the chart should use an external TimescaleDB instead of deploying one.
+*/}}
+{{- define "thoras.externalTimescaleEnabled" -}}
+{{- if or .Values.externalTimescale.dsn .Values.externalTimescale.secretRefName -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "thoras.globalEnv" -}}
 {{- $out := list -}}
 {{- with .Values.proxy.httpProxy -}}

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -63,10 +63,19 @@ spec:
           - name: DATABASE_HOST
             valueFrom:
               secretKeyRef:
+              {{- if .Values.externalTimescale.secretRefName }}
+                name: {{ .Values.externalTimescale.secretRefName }}
+                key: {{ .Values.externalTimescale.secretRefKey }}
+              {{- else }}
                 name: thoras-timescale-password
                 key: host
+              {{- end }}
           - name: DATABASE_URL
+          {{- if include "thoras.externalTimescaleEnabled" . }}
+            value: "$(DATABASE_HOST)"
+          {{- else }}
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
+          {{- end }}
           - name: EXTENSION_VERSION
             value: "{{ .Values.metricsCollector.timescale.extensionVersion }}"
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
@@ -76,7 +85,7 @@ spec:
             retries=0
             max_retries=48
             until [ $retries -ge $max_retries ]; do
-              if pg_isready -q -d ${DATABASE_HOST}/thoras; then
+              if pg_isready -q -d ${DATABASE_URL}; then
                 break
               else
                 echo "postgres not ready"
@@ -88,6 +97,7 @@ spec:
               echo "Failed to connect to database after $max_retries retries"
               exit 1
             fi
+        {{- if not (include "thoras.externalTimescaleEnabled" .) }}
 
             # Update the timescale extension first
             # Validate version format (only allow alphanumeric, dots, and hyphens)
@@ -96,6 +106,7 @@ spec:
               exit 1
             fi
             /usr/bin/psql $DATABASE_URL -c "ALTER EXTENSION timescaledb UPDATE TO '$EXTENSION_VERSION';"
+        {{- end }}
 
             # run any migrations, accounting for upgrade/downgrade scenarios
             ./scripts/migrate_database.sh
@@ -114,12 +125,21 @@ spec:
           - name: DATABASE_HOST
             valueFrom:
               secretKeyRef:
+              {{- if .Values.externalTimescale.secretRefName }}
+                name: {{ .Values.externalTimescale.secretRefName }}
+                key: {{ .Values.externalTimescale.secretRefKey }}
+              {{- else }}
                 name: thoras-timescale-password
                 key: host
+              {{- end }}
           - name: SERVICE_PORT
             value: {{ .Values.thorasApiServerV2.containerPort | quote }}
           - name: SERVICE_POSTGRESQL_DSN
+          {{- if include "thoras.externalTimescaleEnabled" . }}
+            value: "$(DATABASE_HOST)"
+          {{- else }}
             value: "$(DATABASE_HOST)/thoras"
+          {{- end }}
           - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/templates/collector/ast.yaml
+++ b/charts/thoras/templates/collector/ast.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.featureFlags.thorasManageThoras.enabled }}
+{{- if and (.Values.featureFlags.thorasManageThoras.enabled) (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .))) }}
 apiVersion: thoras.ai/v1
 kind: AIScaleTarget
 metadata:
@@ -26,11 +26,13 @@ spec:
         limit:
           ratio: 3
       name: 'blob-api'
+    {{- if not (include "thoras.externalTimescaleEnabled" .) }}
     - cpu:
         lowerbound: 1m
       memory:
         lowerbound: 1Mi
       name: 'timescaledb'
+    {{- end }}
     update_policy:
       update_mode: {{ .Values.featureFlags.thorasManageThoras.db.updateMode | default .Values.featureFlags.thorasManageThoras.updateMode | default "recreate" }}
     mode: {{ .Values.featureFlags.thorasManageThoras.mode | default "recommendation" }}

--- a/charts/thoras/templates/collector/configmap.yaml
+++ b/charts/thoras/templates/collector/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metricsCollector.timescale.config.enabled }}
+{{- if and .Values.metricsCollector.timescale.config.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .)) }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -20,9 +21,9 @@ spec:
         {{- with include "thoras.componentLabels" (dict "root" $ "component" .Values.metricsCollector.labels) }}
         {{- . | trim | nindent 8 }}
         {{- end }}
-      {{- if or .Values.podAnnotations .Values.metricsCollector.timescale.config.enabled .Values.metricsCollector.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.metricsCollector.podAnnotations (and .Values.metricsCollector.timescale.config.enabled (not (include "thoras.externalTimescaleEnabled" .))) }}
       annotations:
-        {{- if .Values.metricsCollector.timescale.config.enabled }}
+        {{- if and .Values.metricsCollector.timescale.config.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
         checksum/configmap: {{ include (print $.Template.BasePath "/collector/configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- with include "thoras.podAnnotations" (dict "root" $ "component" .Values.metricsCollector.podAnnotations) }}
@@ -44,12 +45,12 @@ spec:
       - name: {{ .Values.imageCredentials.secretRef }}
       {{- end }}
       volumes:
-      {{- if .Values.metricsCollector.timescale.config.enabled }}
+      {{- if and .Values.metricsCollector.timescale.config.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
         - name: timescale-config
           configMap:
             name: thoras-timescale-config
       {{- end }}
-      {{- if .Values.metricsCollector.persistence.enabled }}
+      {{- if and .Values.metricsCollector.persistence.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
         - name: elastic-search-data
           persistentVolumeClaim:
             claimName:  elastic-search-data
@@ -72,7 +73,11 @@ spec:
         {{- else }}
         args:
           - |
+        {{- if include "thoras.externalTimescaleEnabled" . }}
+            mkdir -p /var/lib/share/blobs
+        {{- else }}
             mkdir -p /var/lib/share/postgresql /var/lib/share/blobs
+        {{- end }}
         {{- end }}
         {{- if .Values.metricsCollector.init.resources }}
         resources: {{ .Values.metricsCollector.init.resources | toYaml | nindent 10 }}
@@ -83,12 +88,12 @@ spec:
         {{- end }}
         volumeMounts:
           - mountPath: /var/lib/share
-      {{- if .Values.metricsCollector.persistence.enabled }}
+      {{- if and .Values.metricsCollector.persistence.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
             name: elastic-search-data
       {{- else }}
             name: timescale-data
       {{- end }}
-      {{- if .Values.metricsCollector.timescale.walRecovery.enabled }}
+      {{- if and .Values.metricsCollector.timescale.walRecovery.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
       - name: reset-wal-on-startup
         image: {{ .Values.imageCredentials.registry }}/{{ .Values.metricsCollector.timescale.image }}:{{ .Values.metricsCollector.timescale.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -126,6 +131,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
+      {{- if not (include "thoras.externalTimescaleEnabled" .) }}
       - image: {{ .Values.imageCredentials.registry }}/{{ .Values.metricsCollector.timescale.image }}:{{ .Values.metricsCollector.timescale.imageTag }}
         name: timescaledb
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -171,6 +177,7 @@ spec:
       {{- else }}
             name: timescale-data
       {{- end }}
+      {{- end }}
       {{- if not .Values.featureFlags.enableNoBlobApiServer }}
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.metricsCollector.blobService.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -182,6 +189,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+        {{- if not (include "thoras.externalTimescaleEnabled" .) }}
             # wait for postgres to be available
             retries=0
             max_retries=48
@@ -208,16 +216,32 @@ spec:
             # ensure the postgres user has the correct password
             echo "setting password"
             psql -U postgres -h localhost -c "ALTER USER postgres WITH PASSWORD '${POSTGRES_PASSWORD}'";
+        {{- end }}
 
             ./blob-service
         env:
           - name: SERVICE_CLUSTER_NAME
             value: "{{ .Values.cluster.name }}"
+        {{- if include "thoras.externalTimescaleEnabled" . }}
+          - name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.externalTimescale.secretRefName }}
+                name: {{ .Values.externalTimescale.secretRefName }}
+                key: {{ .Values.externalTimescale.secretRefKey }}
+              {{- else }}
+                name: thoras-timescale-password
+                key: host
+              {{- end }}
+          - name: SERVICE_POSTGRESQL_DSN
+            value: "$(DATABASE_HOST)"
+        {{- else }}
           - name: "POSTGRES_PASSWORD"
             valueFrom:
               secretKeyRef:
                 name: thoras-timescale-password
                 key: password
+        {{- end }}
           - name: SERVICE_CHART_VERSION
             value: {{ .Chart.Version | quote }}
           - name: SERVICE_PLATFORM_VERSION
@@ -252,7 +276,7 @@ spec:
         {{- end }}
         volumeMounts:
           - mountPath: /var/lib/share
-      {{- if .Values.metricsCollector.persistence.enabled }}
+      {{- if and .Values.metricsCollector.persistence.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
             name: elastic-search-data
       {{- else }}
             name: timescale-data
@@ -283,3 +307,4 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+{{- end }}

--- a/charts/thoras/templates/collector/pvc.yaml
+++ b/charts/thoras/templates/collector/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metricsCollector.persistence.enabled }}
+{{- if and .Values.metricsCollector.persistence.enabled (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .)))}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/thoras/templates/collector/secret.yaml
+++ b/charts/thoras/templates/collector/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalTimescale.secretRefName }}
 ---
 {{- $newPgPassword := randAlphaNum 16 }}
 apiVersion: v1
@@ -5,8 +6,13 @@ kind: Secret
 metadata:
   name: thoras-timescale-password
 data:
+  {{- if include "thoras.externalTimescaleEnabled" . }}
+  host: {{ .Values.externalTimescale.dsn | b64enc | quote }}
+  {{- else }}
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "thoras-timescale-password") }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   {{- $pgPassword := (get $secretData "password") | default ((.Values.metricsCollector.timescale.password | default $newPgPassword) | b64enc) }}
   password: {{ $pgPassword | quote }}
   host: {{ (printf "postgres://postgres:%s@%s:%d" ($pgPassword | b64dec) .Values.metricsCollector.timescale.name (.Values.metricsCollector.timescale.containerPort | int)) | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/thoras/templates/collector/service-account.yaml
+++ b/charts/thoras/templates/collector/service-account.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .)) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,4 +12,5 @@ imagePullSecrets:
   - name: {{ .Values.imageCredentials.secretRef }}
 {{- else }}
   - name: thoras-secret-registry
+{{- end }}
 {{- end }}

--- a/charts/thoras/templates/collector/service.yaml
+++ b/charts/thoras/templates/collector/service.yaml
@@ -1,3 +1,4 @@
+{{- if not (include "thoras.externalTimescaleEnabled" .) }}
 ---
 apiVersion: v1
 kind: Service
@@ -18,6 +19,7 @@ spec:
     targetPort: {{ .Values.metricsCollector.timescale.containerPort }}
   selector:
     app: metrics-collector
+{{- end }}
 {{- if not .Values.featureFlags.enableNoBlobApiServer }}
 ---
 apiVersion: v1

--- a/charts/thoras/templates/collector/storageclass.yaml
+++ b/charts/thoras/templates/collector/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metricsCollector.persistence.enabled .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId }}
+{{- if and .Values.metricsCollector.persistence.enabled .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .))) }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -143,10 +143,19 @@ spec:
           - name: DATABASE_HOST
             valueFrom:
               secretKeyRef:
+              {{- if .Values.externalTimescale.secretRefName }}
+                name: {{ .Values.externalTimescale.secretRefName }}
+                key: {{ .Values.externalTimescale.secretRefKey }}
+              {{- else }}
                 name: thoras-timescale-password
                 key: host
+              {{- end }}
           - name: SERVICE_POSTGRESQL_DSN
+          {{- if include "thoras.externalTimescaleEnabled" . }}
+            value: "$(DATABASE_HOST)"
+          {{- else }}
             value: "$(DATABASE_HOST)/thoras"
+          {{- end }}
           - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
             value: {{ .Values.featureFlags.enablePrometheusMetricScraping | quote }}
           - name: SERVICE_ENABLE_CLOUD_SYNC

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -61,10 +61,19 @@ spec:
           - name: DATABASE_HOST
             valueFrom:
               secretKeyRef:
+              {{- if .Values.externalTimescale.secretRefName }}
+                name: {{ .Values.externalTimescale.secretRefName }}
+                key: {{ .Values.externalTimescale.secretRefKey }}
+              {{- else }}
                 name: thoras-timescale-password
                 key: host
+              {{- end }}
           - name: DATABASE_URL
+          {{- if include "thoras.externalTimescaleEnabled" . }}
+            value: "$(DATABASE_HOST)"
+          {{- else }}
             value: "$(DATABASE_HOST)/thoras?sslmode=disable"
+          {{- end }}
           - name: EXTENSION_VERSION
             value: "{{ .Values.metricsCollector.timescale.extensionVersion }}"
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
@@ -74,7 +83,7 @@ spec:
             retries=0
             max_retries=48
             until [ $retries -ge $max_retries ]; do
-              if pg_isready -q -d ${DATABASE_HOST}/thoras; then
+              if pg_isready -q -d ${DATABASE_URL}; then
                 break
               else
                 echo "postgres not ready"
@@ -86,6 +95,7 @@ spec:
               echo "Failed to connect to database after $max_retries retries"
               exit 1
             fi
+        {{- if not (include "thoras.externalTimescaleEnabled" .) }}
 
             # Update the timescale extension first
             # Validate version format (only allow alphanumeric, dots, and hyphens)
@@ -94,6 +104,7 @@ spec:
               exit 1
             fi
             /usr/bin/psql $DATABASE_URL -c "ALTER EXTENSION timescaledb UPDATE TO '$EXTENSION_VERSION';"
+        {{- end }}
 
             # run any migrations, accounting for upgrade/downgrade scenarios
             ./scripts/migrate_database.sh
@@ -112,10 +123,19 @@ spec:
           - name: DATABASE_HOST
             valueFrom:
               secretKeyRef:
+              {{- if .Values.externalTimescale.secretRefName }}
+                name: {{ .Values.externalTimescale.secretRefName }}
+                key: {{ .Values.externalTimescale.secretRefKey }}
+              {{- else }}
                 name: thoras-timescale-password
                 key: host
+              {{- end }}
           - name: SERVICE_POSTGRESQL_DSN
+          {{- if include "thoras.externalTimescaleEnabled" . }}
+            value: "$(DATABASE_HOST)"
+          {{- else }}
             value: "$(DATABASE_HOST)/thoras"
+          {{- end }}
           - name: SERVICE_SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -141,7 +141,7 @@ Default matches snapshot:
                   retries=0
                   max_retries=48
                   until [ $retries -ge $max_retries ]; do
-                    if pg_isready -q -d ${DATABASE_HOST}/thoras; then
+                    if pg_isready -q -d ${DATABASE_URL}; then
                       break
                     else
                       echo "postgres not ready"
@@ -1571,7 +1571,7 @@ Default matches snapshot:
                   retries=0
                   max_retries=48
                   until [ $retries -ge $max_retries ]; do
-                    if pg_isready -q -d ${DATABASE_HOST}/thoras; then
+                    if pg_isready -q -d ${DATABASE_URL}; then
                       break
                     else
                       echo "postgres not ready"

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -92,7 +92,7 @@ tests:
             name: timescale-config
             mountPath: /etc/postgresql.conf
             subPath: custom.conf
-  - it: Should always create timescale container
+  - it: Should create timescale container in default mode
     template: collector/deployment.yaml
     asserts:
       - contains:

--- a/charts/thoras/tests/external_timescale_test.yaml
+++ b/charts/thoras/tests/external_timescale_test.yaml
@@ -1,0 +1,301 @@
+suite: External TimescaleDB
+tests:
+  # --- Collector Deployment ---
+
+  - it: Should not include timescaledb container when external host is set
+    templates:
+      - collector/deployment.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+    asserts:
+      - isKind:
+          of: Deployment
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: timescaledb
+          any: true
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: thoras-blob-api
+          any: true
+
+  - it: Should give blob-service DATABASE_HOST and SERVICE_POSTGRESQL_DSN in external mode
+    templates:
+      - collector/deployment.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-blob-api')].env
+          content:
+            name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: thoras-timescale-password
+                key: host
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-blob-api')].env
+          content:
+            name: SERVICE_POSTGRESQL_DSN
+            value: "$(DATABASE_HOST)"
+
+  - it: Should not include POSTGRES_PASSWORD env on blob-service in external mode
+    templates:
+      - collector/deployment.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-blob-api')].env
+          content:
+            name: POSTGRES_PASSWORD
+          any: true
+
+  - it: Blob-service should skip localhost bootstrap script in external mode
+    templates:
+      - collector/deployment.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[?(@.name == 'thoras-blob-api')].args[0]
+          pattern: "pg_isready -h localhost"
+
+  - it: Should not include WAL recovery init container in external mode
+    templates:
+      - collector/deployment.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+      metricsCollector:
+        timescale:
+          walRecovery:
+            enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: reset-wal-on-startup
+          any: true
+
+  - it: Should only create blobs dir in fix-dir-ownership in external mode
+    templates:
+      - collector/deployment.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name == 'fix-dir-ownership')].args[0]
+          pattern: "mkdir -p /var/lib/share/blobs"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[?(@.name == 'fix-dir-ownership')].args[0]
+          pattern: "/var/lib/share/postgresql"
+
+  - it: Should use secretRef for blob-service DATABASE_HOST when secretRefName is set
+    templates:
+      - collector/deployment.yaml
+    set:
+      externalTimescale:
+        secretRefName: "my-db-secret"
+        secretRefKey: "dsn"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-blob-api')].env
+          content:
+            name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: dsn
+
+  # --- Collector Service ---
+
+  - it: Should not create timescale Service in external mode
+    templates:
+      - collector/service.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: thoras-blob-api
+
+  - it: Should create both Services in default mode
+    templates:
+      - collector/service.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  # --- Collector Secret ---
+
+  - it: Should store external host in secret when host is set
+    templates:
+      - collector/secret.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: thoras-timescale-password
+
+  - it: Should not create secret when secretRefName is set
+    templates:
+      - collector/secret.yaml
+    set:
+      externalTimescale:
+        secretRefName: "my-db-secret"
+        secretRefKey: "dsn"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- ConfigMap, PVC, StorageClass ---
+
+  - it: Should not create configmap in external mode even if config enabled
+    templates:
+      - collector/configmap.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+      metricsCollector:
+        timescale:
+          config:
+            enabled: true
+            content: "shared_buffers = 256MB"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create PVC in external mode when blob server is enabled
+    templates:
+      - collector/pvc.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+      metricsCollector:
+        persistence:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: Should not create PVC when external timescale and blob server both disabled
+    templates:
+      - collector/pvc.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+      featureFlags:
+        enableNoBlobApiServer: true
+      metricsCollector:
+        persistence:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create StorageClass when external timescale and blob server both disabled
+    templates:
+      - collector/storageclass.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+      featureFlags:
+        enableNoBlobApiServer: true
+      metricsCollector:
+        persistence:
+          enabled: true
+          createEFSStorageClass:
+            fileSystemId: "fs-12345"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- Consumer Deployments with secretRef ---
+
+  - it: Operator should use external secretRef for DATABASE_HOST
+    templates:
+      - operator/deployment.yaml
+    set:
+      externalTimescale:
+        secretRefName: "my-db-secret"
+        secretRefKey: "dsn"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-operator')].env
+          content:
+            name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: dsn
+
+  - it: API server should use external secretRef for DATABASE_HOST
+    templates:
+      - api-server-v2/deployment.yaml
+    set:
+      externalTimescale:
+        secretRefName: "my-db-secret"
+        secretRefKey: "dsn"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-api-server-v2')].env
+          content:
+            name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: dsn
+
+  - it: Worker should use external secretRef for DATABASE_HOST
+    templates:
+      - worker/deployment.yaml
+    set:
+      externalTimescale:
+        secretRefName: "my-db-secret"
+        secretRefKey: "dsn"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-worker')].env
+          content:
+            name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: dsn
+
+  # --- AST ---
+
+  - it: Should not include timescaledb in AST vertical containers in external mode
+    templates:
+      - collector/ast.yaml
+    set:
+      externalTimescale:
+        dsn: "postgres://user:pass@ext-db:5432/tsdb"
+      featureFlags:
+        thorasManageThoras:
+          enabled: true
+    asserts:
+      - notContains:
+          path: spec.vertical.containers
+          content:
+            name: timescaledb
+          any: true

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -93,6 +93,20 @@ cloudSync:
   clusterKeySecretRefName: ""
   clusterKeySecretRefKey: ""
 
+# External TimescaleDB configuration. When set, the chart skips deploying the
+# in-cluster TimescaleDB and configures all components to use the external
+# database instead. The TimescaleDB extension must be pre-installed and managed
+# externally.
+externalTimescale:
+  # Full postgres DSN including the database name,
+  # e.g. "postgres://user:password@host:5432/tsdb?sslmode=require"
+  dsn: ""
+
+  # Or reference a pre-existing Secret containing the DSN.
+  # The secret key must contain the full postgres DSN including the database name.
+  secretRefName: ""
+  secretRefKey: ""
+
 rbac:
   namespaces: []
 


### PR DESCRIPTION
## How this helps the customer
Customers can use a cloud-managed TimescaleDB (e.g. TigerDB) instead of running one in-cluster.

## What's changing
New `externalTimescale.dsn` / `externalTimescale.secretRefName` values. When set, the in-cluster TimescaleDB container, Service, ConfigMap, PVC, and StorageClass are skipped. All components use the provided DSN directly (the DSN must include the database name).

## Testing
- New test suite: `tests/external_timescale_test.yaml`