### PR TITLE
Remove feature flag for scaling when not sufficient data

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -83,7 +83,6 @@ The following flags are considered temporary and gate access to specific behavio
 | Key                                              | Type    | Default | Description                                                     |
 | ------------------------------------------------ | ------- | ------- | --------------------------------------------------------------- |
 | featureFlags.enableNodeDetailsCollector          | Boolean | true    | Collection of node detail snapshots                             |
-| featureFlags.enableSkipScalingOnInsufficientData | Boolean | true    | Workloads are scaled only if they more than three hours of data |
 | featureFlags.enableCheckDatabaseHealth           | Boolean | false   | If true, pings the database in the health endpoint              |
 | featureFlags.enableMigrationOnStartup            | Boolean | false   | If true, the main container handles migrations                  |
 | featureFlags.enableCostSavingsSettingsRefresh    | Boolean | true    | If true, refreshes the costs savings settings periodically      |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -166,8 +166,6 @@ spec:
             value: {{ .Values.costRefreshBatching.maxConcurrency | quote }}
           - name: SERVICE_ENABLE_VIEW_CACHE_QUERY_LIVE_JOIN
             value: {{ .Values.thorasApiServerV2.enableViewCacheQueryLiveJoin | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_SKIP_SCALING_ON_INSUFFICIENT_DATA
-            value: {{ .Values.featureFlags.enableSkipScalingOnInsufficientData | ternary "true" "false" | quote }}
           - name: SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME
             value: "{{ .Values.thorasForecast.podEligibilityMinRunningTime }}"
           - name: SERVICE_MIN_LOOKBACK_TO_SCALE

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -136,8 +136,6 @@ spec:
           - name: SERVICE_WATCH_NAMESPACES
             value: {{ join "," . | quote }}
           {{- end }}
-          - name: SERVICE_ENABLE_SKIP_SCALING_ON_INSUFFICIENT_DATA
-            value: {{ .Values.featureFlags.enableSkipScalingOnInsufficientData | ternary "true" "false" | quote }}
           - name: SERVICE_MIN_LOOKBACK_TO_SCALE
             value: {{ .Values.thorasForecast.minLookbackToScale | quote }}
           - name: DATABASE_HOST

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -75,8 +75,6 @@ Default matches snapshot:
                   value: "5"
                 - name: SERVICE_ENABLE_VIEW_CACHE_QUERY_LIVE_JOIN
                   value: "true"
-                - name: SERVICE_ENABLE_SKIP_SCALING_ON_INSUFFICIENT_DATA
-                  value: "true"
                 - name: SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME
                   value: 2m
                 - name: SERVICE_MIN_LOOKBACK_TO_SCALE
@@ -1177,8 +1175,6 @@ Default matches snapshot:
                   value: "50"
                 - name: SERVICE_PORT
                   value: "9101"
-                - name: SERVICE_ENABLE_SKIP_SCALING_ON_INSUFFICIENT_DATA
-                  value: "true"
                 - name: SERVICE_MIN_LOOKBACK_TO_SCALE
                   value: 3h
                 - name: DATABASE_HOST

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -42,7 +42,6 @@ proxy:
 
 featureFlags:
   enableNodeDetailsCollector: true
-  enableSkipScalingOnInsufficientData: true
   thorasManageThoras:
     enabled: false
     # Recommendation Mode by default


### PR DESCRIPTION
# What's changing and why?

Removes the `enableSkipScalingOnInsufficientData` feature flag — the behavior is now the default and the flag is no longer needed. Drops the env var from the API server and operator deployments.