### PR TITLE
Prefer forecast interval to cron in AST specs

### DIFF
--- a/charts/thoras/templates/api-server-v2/ast.yaml
+++ b/charts/thoras/templates/api-server-v2/ast.yaml
@@ -10,8 +10,8 @@ spec:
   horizontal:
     mode: recommendation
   model:
-    forecast_blocks: 20m0s
-    forecast_cron: '*/15 * * * *'
+    forecast_blocks: 20m
+    forecast_interval: 15m
     mode: balanced
   scaleTargetRef:
     kind: Deployment

--- a/charts/thoras/templates/dashboard/ast.yaml
+++ b/charts/thoras/templates/dashboard/ast.yaml
@@ -10,8 +10,8 @@ spec:
   horizontal:
     mode: recommendation
   model:
-    forecast_blocks: 20m0s
-    forecast_cron: '*/15 * * * *'
+    forecast_blocks: 20m
+    forecast_interval: 15m
     mode: balanced
   scaleTargetRef:
     kind: Deployment

--- a/charts/thoras/templates/monitor/ast.yaml
+++ b/charts/thoras/templates/monitor/ast.yaml
@@ -11,8 +11,8 @@ spec:
   horizontal:
     mode: recommendation
   model:
-    forecast_blocks: 20m0s
-    forecast_cron: '*/15 * * * *'
+    forecast_blocks: 20m
+    forecast_interval: 15m
     mode: balanced
   scaleTargetRef:
     kind: Deployment

--- a/charts/thoras/templates/operator/ast.yaml
+++ b/charts/thoras/templates/operator/ast.yaml
@@ -10,8 +10,8 @@ spec:
   horizontal:
     mode: recommendation
   model:
-    forecast_blocks: 20m0s
-    forecast_cron: '*/15 * * * *'
+    forecast_blocks: 20m
+    forecast_interval: '15m'
     mode: balanced
   scaleTargetRef:
     kind: Deployment


### PR DESCRIPTION
# What's changing and why?

Switches AST model config from `forecast_cron` (cron expression) to `forecast_interval` (duration) across all component AST templates. Also normalizes `forecast_blocks` from `20m0s` to `20m`.

Note: the database still has an override. I need to learn more about how this is currently in use.

## How Tested

Verified templates render correctly with `helm template`.