### PR TITLE
Remove forecast rescuer feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -87,7 +87,6 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableCheckDatabaseHealth           | Boolean | false   | If true, pings the database in the health endpoint              |
 | featureFlags.enableMigrationOnStartup            | Boolean | false   | If true, the main container handles migrations                  |
 | featureFlags.enableCostSavingsSettingsRefresh    | Boolean | true    | If true, refreshes the costs savings settings periodically      |
-| featureFlags.enableForecastRescuer               | Boolean | true    | If true, enables rescuing stalled forecast jobs                 |
 | featureFlags.enablePgLargeObjectStorage          | Boolean | false   | If true, enables storing blobs as postgres large objects        |
 
 ## Affinity Configuration

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -200,8 +200,6 @@ spec:
             value: {{ .Values.featureFlags.enableCheckDatabaseHealth | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_COST_SAVINGS_SETTINGS_REFRESH
             value: {{ .Values.featureFlags.enableCostSavingsSettingsRefresh | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_FORECAST_RESCUER
-            value: {{ .Values.featureFlags.enableForecastRescuer | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
             value: {{ .Values.featureFlags.enableMonitorActiveSuggestionFromCRD | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MIGRATION_ON_START

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1531,8 +1531,6 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_ENABLE_COST_SAVINGS_SETTINGS_REFRESH
                   value: "true"
-                - name: SERVICE_ENABLE_FORECAST_RESCUER
-                  value: "true"
                 - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
                   value: "false"
                 - name: SERVICE_ENABLE_MIGRATION_ON_START

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -59,7 +59,6 @@ featureFlags:
   enableCheckDatabaseHealth: false
   enableMigrationOnStartup: false
   enableCostSavingsSettingsRefresh: true
-  enableForecastRescuer: true
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false
   enableDeploymentMonitor: false


### PR DESCRIPTION
# What's changing and why?

The `enableForecastRescuer` feature flag has been permanently enabled and is no longer needed. This removes it from values, the worker deployment, tests, and docs.