### PR TITLE
Add feature flag to replace forecast-worker init container with readiness probe

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -40,6 +40,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.imageCredentials.secretRef }}
       {{- end }}
+      {{- if not .Values.featureFlags.enableForecastWorkerReadinessProbe }}
       initContainers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         name: wait-for-api-service
@@ -60,6 +61,7 @@ spec:
               exit 1
             fi
         resources: {}
+      {{- end }}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -109,6 +111,17 @@ spec:
         resources:
           limits: {{ .Values.thorasForecast.worker.limits | toYaml | nindent 12 }}
           requests: {{ .Values.thorasForecast.worker.requests | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.featureFlags.enableForecastWorkerReadinessProbe }}
+        readinessProbe:
+          exec:
+            command:
+              - curl
+              - -sf
+              - http://thoras-api-server-v2/health
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 48
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -287,6 +287,37 @@ tests:
             name: TRAINING_JITTER_MINUTES
             value: "30"
 
+  - it: Uses init container by default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-api-service
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: Replaces init container with readiness probe when enableForecastWorkerReadinessProbe is true
+    set:
+      featureFlags:
+        enableForecastWorkerReadinessProbe: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value:
+            - curl
+            - -sf
+            - http://thoras-api-server-v2/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 48
+
   - it: Should enable request and limit overrides
     set:
       thorasForecast:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,6 +65,7 @@ featureFlags:
   enableDeploymentMonitor: false
   enablePgLargeObjectStorage: false
   enableNoBlobApiServer: false
+  enableForecastWorkerReadinessProbe: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

The forecast-worker init container (`wait-for-api-service`) doesn't work with network policies applied via service mesh sidecars — sidecars aren't running during init containers. A new feature flag `featureFlags.enableForecastWorkerReadinessProbe` (default `false`) replaces the init container with a readiness probe on the main container when enabled.

## How Tested

Helm unit tests added and passing. Will be validated on test clusters with the flag enabled.