### PR TITLE
Add enableForecastQueueStats feature flag

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -136,6 +136,8 @@ spec:
           - name: SERVICE_WATCH_NAMESPACES
             value: {{ join "," . | quote }}
           {{- end }}
+          - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
+            value: {{ .Values.featureFlags.enableForecastQueueStats | ternary "true" "false" | quote }}
           - name: SERVICE_MIN_LOOKBACK_TO_SCALE
             value: {{ .Values.thorasForecast.minLookbackToScale | quote }}
           - name: DATABASE_HOST

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -226,6 +226,8 @@ spec:
             value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
             value: {{ .Values.featureFlags.enableDeploymentMonitor | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
+            value: {{ not .Values.featureFlags.enableForecastQueueStats | ternary "true" "false" | quote }}
           - name: SERVICE_POD_NAME
             valueFrom:
               fieldRef:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1175,6 +1175,8 @@ Default matches snapshot:
                   value: "50"
                 - name: SERVICE_PORT
                   value: "9101"
+                - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
+                  value: "false"
                 - name: SERVICE_MIN_LOOKBACK_TO_SCALE
                   value: 3h
                 - name: DATABASE_HOST
@@ -1533,6 +1535,8 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
                   value: "false"
+                - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
+                  value: "true"
                 - name: SERVICE_POD_NAME
                   valueFrom:
                     fieldRef:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -64,6 +64,7 @@ featureFlags:
   enablePgLargeObjectStorage: false
   enableNoBlobApiServer: false
   enableForecastWorkerReadinessProbe: false
+  enableForecastQueueStats: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
## What's changing and why?

Wires up the `ENABLE_FORECAST_QUEUE_STATS` flag from thoras-ai/platform#4063, which migrates forecast queue metrics publishing from the worker to the operator (so metrics remain available when the DB is degraded).

- `featureFlags.enableForecastQueueStats: false` (default keeps current behavior — worker publishes)
- Operator gets the flag directly; worker gets the inverse (prevents double-publishing)