### PR TITLE
Enable unified AST utilization monitor

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1505,7 +1505,7 @@ Default matches snapshot:
                 - name: SERVICE_COST_REFRESH_MAX_CONCURRENCY
                   value: "5"
                 - name: SERVICE_ENABLE_UNIFIED_AST_UTILIZATION_MONITOR
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
                   value: "false"
                 - name: SERVICE_ENABLE_CLOUD_SYNC_WORKER

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -287,7 +287,7 @@ thorasWorker:
   enableAstViewCacheStateReconcilerWorker: true
   enableMetricIntegrityWorker: false
   enableActiveSuggestionWorker: true
-  enableUnifiedAstUtilizationMonitor: false
+  enableUnifiedAstUtilizationMonitor: true
   # Set to true to apply global affinity rules to this component
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)


### PR DESCRIPTION
# What's changing and why?

Enables `enableUnifiedAstUtilizationMonitor` for all customers by flipping the default from `false` to `true`.