### PR TITLE
set enableDeploymentMonitor default to true

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1534,7 +1534,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_MIGRATION_ON_START
                   value: "false"
                 - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "true"
                 - name: SERVICE_POD_NAME

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -60,7 +60,7 @@ featureFlags:
   enableCostSavingsSettingsRefresh: true
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false
-  enableDeploymentMonitor: false
+  enableDeploymentMonitor: true
   enablePgLargeObjectStorage: false
   enableNoBlobApiServer: false
   enableForecastWorkerReadinessProbe: false


### PR DESCRIPTION
# What's changing and why?
Use the new and improved deployment monitor by default.