### PR TITLE
Enable storing blobs as postgres large objects

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -97,7 +97,7 @@ Default matches snapshot:
                       key: clusterKey
                       name: thoras-cloud-sync
                 - name: SERVICE_ENABLE_PG_LARGE_OBJECT_STORAGE
-                  value: "false"
+                  value: "true"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -61,7 +61,7 @@ featureFlags:
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false
   enableDeploymentMonitor: false
-  enablePgLargeObjectStorage: false
+  enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastWorkerReadinessProbe: false
   enableForecastQueueStats: false


### PR DESCRIPTION
## What's changing and why?

Enables the `enablePgLargeObjectStorage` feature flag by default so blobs are stored as Postgres large objects.