### PR TITLE
Add migration flag to operator

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -184,6 +184,8 @@ spec:
           - name: SERVICE_FIELD_MANAGER
             value: {{ .Values.flux.fieldManager | quote }}
           {{- end }}
+          - name: SERVICE_ENABLE_MIGRATION_ON_START
+            value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1197,6 +1197,8 @@ Default matches snapshot:
                     secretKeyRef:
                       key: clusterKey
                       name: thoras-cloud-sync
+                - name: SERVICE_ENABLE_MIGRATION_ON_START
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-operator


### PR DESCRIPTION
# What's changing and why?

Exposes `SERVICE_ENABLE_MIGRATION_ON_START` as a configurable feature flag (`featureFlags.enableMigrationOnStartup`) on the operator deployment, so migrations can be toggled without a code change.