### PR TITLE
Add forecast worker liveness probe

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -104,6 +104,10 @@ spec:
           - name: METRICS_PORT
             value: {{ .Values.thorasForecast.prometheus.port | quote }}
           {{- end }}
+          {{- if .Values.featureFlags.enableForecastWorkerLivenessProbe }}
+          - name: WORKER_HEARTBEAT_FILE
+            value: /var/run/thoras/worker-heartbeat
+          {{- end }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         {{- if .Values.thorasForecast.worker.resources }}
         resources: {{ .Values.thorasForecast.worker.resources | toYaml | nindent 10 }}

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -123,6 +123,25 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 48
         {{- end }}
+        {{- if .Values.featureFlags.enableForecastWorkerLivenessProbe }}
+        livenessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - "test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat) )) -lt 300"
+          initialDelaySeconds: 120
+          periodSeconds: 60
+          failureThreshold: 5
+        volumeMounts:
+          - name: worker-state
+            mountPath: /var/run/thoras
+        {{- end }}
+      {{- if .Values.featureFlags.enableForecastWorkerLivenessProbe }}
+      volumes:
+        - name: worker-state
+          emptyDir: {}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -66,6 +66,7 @@ featureFlags:
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastWorkerReadinessProbe: false
+  enableForecastWorkerLivenessProbe: false
   enableForecastQueueStats: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)


### PR DESCRIPTION
# What's changing and why?

Adds a liveness probe for the forecast worker behind the `enableForecastWorkerLivenessProbe` feature flag. The probe checks a heartbeat file's mtime — if the worker hasn't updated it in 5 minutes, the pod is restarted. Defaults to disabled.