### PR TITLE
add feature flag enableUpdateScaleModeApi to api server

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -222,6 +222,8 @@ spec:
           {{- end }}
           - name: SERVICE_ENABLE_PG_LARGE_OBJECT_STORAGE
             value: {{ .Values.featureFlags.enablePgLargeObjectStorage | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_UPDATE_SCALE_MODE_API
+            value: {{ .Values.featureFlags.enableUpdateScaleModeApi | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         volumeMounts:
           - name: monitor-config

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -98,6 +98,8 @@ Default matches snapshot:
                       name: thoras-cloud-sync
                 - name: SERVICE_ENABLE_PG_LARGE_OBJECT_STORAGE
                   value: "true"
+                - name: SERVICE_ENABLE_UPDATE_SCALE_MODE_API
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:


### PR DESCRIPTION
# What's changing and why?
The API server needs access to this feature flag for gating scale mode configuration via API route.