### PR TITLE
Add RBAC rule to the operator ClusterRole granting patch

### DIFF
--- a/charts/thoras/templates/operator/rbac.yaml
+++ b/charts/thoras/templates/operator/rbac.yaml
@@ -43,6 +43,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - pods/resize
+  verbs:
+  - patch
+- apiGroups:
   - apps
   - argoproj.io
   resources:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1359,6 +1359,12 @@ Default matches snapshot:
         verbs:
           - '*'
       - apiGroups:
+          - ""
+        resources:
+          - pods/resize
+        verbs:
+          - patch
+      - apiGroups:
           - apps
           - argoproj.io
         resources:


### PR DESCRIPTION
on pods/resize (core API group)

Relates to https://github.com/thoras-ai/platform/issues/3446

# What's changing and why?

Adds a single RBAC rule to the operator ClusterRole granting `patch`
on `pods/resize` (core API group). The existing wildcard rules only
cover read access to all resources and write access to `*/scale` and
`*/status` subresources. `pods/resize` is a distinct sub-resource that
must be listed explicitly.

The is necessary for moving resizing from the api server to the operator.