### PR TITLE
pass platform version to monitor

### DIFF
--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -102,6 +102,8 @@ spec:
             value: {{ .Values.thorasWorker.enableActiveSuggestionWorker | ternary "true" "false" | quote }}
           - name: SERVICE_CHART_VERSION
             value: {{ .Chart.Version | quote }}
+          - name: SERVICE_PLATFORM_VERSION
+            value: {{ .Values.thorasVersion | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         {{- if .Values.thorasMonitor.resources }}
         resources: {{ .Values.thorasMonitor.resources | toYaml | nindent 10 }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -950,6 +950,8 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_CHART_VERSION
                   value: 4.7.0
+                - name: SERVICE_PLATFORM_VERSION
+                  value: TEST
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-monitor


### PR DESCRIPTION
Closes https://github.com/thoras-ai/platform/issues/4132

# What's changing and why?
Setting monitor thorasVersion, which is consistant with other services.