### PR TITLE
Fix forecast worker liveness probe syntax error

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -133,7 +133,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - "test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat) )) -lt 300"
+              - "test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat 2>/dev/null || echo 0) )) -lt 300"
           initialDelaySeconds: 120
           periodSeconds: 60
           failureThreshold: 5


### PR DESCRIPTION
# What's changing and why?

Liveness probe fails with a shell syntax error when the heartbeat file doesn't exist — `stat` returns empty stdout, breaking the arithmetic. Add `2>/dev/null || echo 0` fallback so a missing file correctly fails the probe instead of erroring.

Addresses an error when the file doesn't exist yet:

```
stat: cannot statx '/var/run/thoras/worker-heartbeat': No such file or directory
/home/runner/work/_temp/e8cbae13-71d1-4a28-b5fd-42e445f2f395.sh: line 1: 1776871767 -  : syntax error: operand expected (error token is "-  ")
```