### PR TITLE
feat: add USE_AST_METRICS_SERIES env var to forecast worker

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -146,6 +146,7 @@ All components support `<component>.useGlobalAffinity` (default: `true`) and `<c
 | thorasForecast.skipCache               | Boolean  | false                  | Directs the forecaster to skip to model cache                                                  |
 | thorasForecast.ignoreNewPods           | Boolean  | true                   | Directs forecaster to adjust CPU and memory metrics temporarily for new pods                   |
 | thorasForecast.enableDecoupledTraining | Boolean  | true                   | Enables async training mode where forecasts report "needs_training" instead of training inline |
+| thorasForecast.useAstMetricsSeries     | Boolean  | false                  | Enables catalog-free training data fetching via the AST metrics series endpoint               |
 | thorasForecast.worker.podAnnotations   | Object   | {}                     | Pod Annotations for Thoras Forecast                                                            |
 | thorasForecast.worker.labels           | Object   | {}                     | Pod labels for Thoras Forecast                                                                 |
 | thorasForecast.worker.replicas         | Number   | 1                      | Number of `thoras-forecast-worker` replicas to use                                             |

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -98,6 +98,8 @@ spec:
             value: {{ .Values.thorasForecast.worker.maxTimeseriesMetricCacheSizeMb | quote }}
           - name: ENABLE_DECOUPLED_TRAINING
             value: {{ .Values.thorasForecast.enableDecoupledTraining | ternary "true" "false" | quote }}
+          - name: USE_AST_METRICS_SERIES
+            value: {{ .Values.thorasForecast.useAstMetricsSeries | ternary "true" "false" | quote }}
           - name: TRAINING_JITTER_MINUTES
             value: {{ .Values.thorasForecast.trainingJitterMinutes | quote }}
           {{- if .Values.thorasForecast.prometheus.enabled }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -821,6 +821,8 @@ Default matches snapshot:
                   value: "1000"
                 - name: ENABLE_DECOUPLED_TRAINING
                   value: "true"
+                - name: USE_AST_METRICS_SERIES
+                  value: "false"
                 - name: TRAINING_JITTER_MINUTES
                   value: "0"
                 - name: METRICS_PORT

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -287,6 +287,25 @@ tests:
             name: TRAINING_JITTER_MINUTES
             value: "30"
 
+  - it: renders USE_AST_METRICS_SERIES as false by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
+          content:
+            name: USE_AST_METRICS_SERIES
+            value: "false"
+
+  - it: renders USE_AST_METRICS_SERIES as true when useAstMetricsSeries is true
+    set:
+      thorasForecast:
+        useAstMetricsSeries: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
+          content:
+            name: USE_AST_METRICS_SERIES
+            value: "true"
+
   - it: Uses init container by default
     asserts:
       - equal:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -389,6 +389,7 @@ thorasForecast:
   podEligibilityMinRunningTime: "2m"
   enableDecoupledTraining: true
   trainingJitterMinutes: 0
+  useAstMetricsSeries: false
   # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
   minLookbackToScale: "3h"
   # Specify the complete resources block (takes precedence if set)


### PR DESCRIPTION
# What's changing and why?

Introducing new `USE_AST_METRICS_SERIES` environment variable to the forecast worker, with possible values of true and false, defaulting to false.

This wires in the catalog-free training data path where the forecaster fetches timeseries data via the AST metrics series endpoint instead of requiring catalog metric IDs. When enabled, model artifacts are keyed by MetricKey (AST-scoped) rather than catalog-assigned metric IDs. 

 [X] Do any feature flags need to be managed?
                                                                                                                                                         
 Yes, `thorasForecast.useAstMetricsSeries` in values.yaml (defaults to false, opt-in)