### PR TITLE
Release 4.111.0 / app 4.92.0

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.110.0
+version: 4.111.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.110.0](https://img.shields.io/badge/Version-4.110.0-informational?style=flat-square) ![AppVersion: 4.91.0](https://img.shields.io/badge/AppVersion-4.91.0-informational?style=flat-square)
+![Version: 4.111.0](https://img.shields.io/badge/Version-4.111.0-informational?style=flat-square) ![AppVersion: 4.92.0](https://img.shields.io/badge/AppVersion-4.92.0-informational?style=flat-square)
 
 # Installs
 

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -52,7 +52,7 @@ helm install \
 
 | Key                                | Type    | Default                                          | Description                                                                                                          |
 | ---------------------------------- | ------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| thorasVersion                      | String  | 4.85.0                                           | Thoras app version                                                                                                   |
+| thorasVersion                      | String  | 4.92.0                                           | Thoras app version                                                                                                   |
 | imageCredentials.registry          | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                                                                              |
 | imageCredentials.username          | String  | \_json_key_base64                                | Container registry username                                                                                          |
 | imageCredentials.password          | String  | ""                                               | Container registry auth string                                                                                       |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "4.91.0"
+thorasVersion: "4.92.0"
 cluster:
   name: ""
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Delivers chart 4.111.0 with Thoras app version 4.92.0.

## What's changing?

- Bump chart version to 4.111.0 in `Chart.yaml`
- Bump `thorasVersion` to 4.92.0 in `values.yaml`
- Update README version badges

## How Tested

Version bumps only — verified values match across all three files.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>