### PR TITLE
Auto-size memory requests based on cluster state

### DIFF
--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -122,3 +122,117 @@ true
 {{ toYaml $out -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Cluster pod count via lookup. Returns 0 when the dynamic-sizing feature flag is off,
+or when lookup is unavailable (--dry-run, helm template, no RBAC). Caller treats 0
+as "use fallback".
+*/}}
+{{- define "thoras.cluster.podCount" -}}
+{{- if not .Values.featureFlags.dynamicResourceSizing.enabled -}}
+0
+{{- else -}}
+{{- $pods := lookup "v1" "Pod" "" "" -}}
+{{- if and $pods (kindIs "map" $pods) (hasKey $pods "items") -}}
+{{- len $pods.items -}}
+{{- else -}}
+0
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Cluster workload count = Deployments + StatefulSets + Argo Rollouts.
+Rollouts are guarded: if the CRD is not present, count 0 rollouts.
+Returns 0 when the feature flag is off or lookup is unavailable.
+*/}}
+{{- define "thoras.cluster.workloadCount" -}}
+{{- if not .Values.featureFlags.dynamicResourceSizing.enabled -}}
+0
+{{- else -}}
+{{- $deploys := lookup "apps/v1" "Deployment" "" "" -}}
+{{- $sts := lookup "apps/v1" "StatefulSet" "" "" -}}
+{{- $deployCount := 0 -}}
+{{- $stsCount := 0 -}}
+{{- if and $deploys (hasKey $deploys "items") -}}{{- $deployCount = len $deploys.items -}}{{- end -}}
+{{- if and $sts (hasKey $sts "items") -}}{{- $stsCount = len $sts.items -}}{{- end -}}
+{{- $rolloutCount := 0 -}}
+{{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "rollouts.argoproj.io" -}}
+{{- if $crd -}}
+{{- $rollouts := lookup "argoproj.io/v1alpha1" "Rollout" "" "" -}}
+{{- if and $rollouts (hasKey $rollouts "items") -}}{{- $rolloutCount = len $rollouts.items -}}{{- end -}}
+{{- end -}}
+{{- add $deployCount $stsCount $rolloutCount -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compute memory request bytes from cluster state using the configured coefficients.
+Returns "" when the feature flag is off or both counts are 0 (caller substitutes
+the per-component fallback).
+*/}}
+{{- define "thoras.sizing.memoryRequestBytes" -}}
+{{- if .Values.featureFlags.dynamicResourceSizing.enabled -}}
+{{- $pods := include "thoras.cluster.podCount" . | int -}}
+{{- $workloads := include "thoras.cluster.workloadCount" . | int -}}
+{{- if or (gt $pods 0) (gt $workloads 0) -}}
+{{- $cfg := .Values.featureFlags.dynamicResourceSizing.memoryRequest -}}
+{{- $perPodBytes := mulf $cfg.perPodKB 1024.0 -}}
+{{- $perWorkloadBytes := mulf $cfg.perWorkloadKB 1024.0 -}}
+{{- $baseBytes := mulf $cfg.baseMB 1048576.0 -}}
+{{- $bytes := addf (mulf $perPodBytes $pods) (mulf $perWorkloadBytes $workloads) $baseBytes -}}
+{{- printf "%d" (int64 $bytes) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Auto-sized memory request for thoras-api-server-v2. Falls back to
+.Values.thorasApiServerV2.requests.memory when the formula has no cluster data.
+*/}}
+{{- define "thoras.apiServerV2.memoryRequest" -}}
+{{- $computed := include "thoras.sizing.memoryRequestBytes" . -}}
+{{- if $computed -}}{{- $computed -}}{{- else -}}{{- .Values.thorasApiServerV2.requests.memory -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Auto-sized memory request for thoras-operator. Falls back to
+.Values.thorasOperator.requests.memory when the formula has no cluster data.
+*/}}
+{{- define "thoras.operator.memoryRequest" -}}
+{{- $computed := include "thoras.sizing.memoryRequestBytes" . -}}
+{{- if $computed -}}{{- $computed -}}{{- else -}}{{- .Values.thorasOperator.requests.memory -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Auto-sized memory request for thoras-worker. Falls back to
+.Values.thorasWorker.requests.memory when the formula has no cluster data.
+*/}}
+{{- define "thoras.worker.memoryRequest" -}}
+{{- $computed := include "thoras.sizing.memoryRequestBytes" . -}}
+{{- if $computed -}}{{- $computed -}}{{- else -}}{{- .Values.thorasWorker.requests.memory -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Auto-scaled forecast-worker replicas. When the feature flag is off, returns the
+configured .Values.thorasForecast.worker.replicas verbatim. When on, returns
+ceil(workloadCount / workloadsPerForecastWorker) floored at the configured replicas.
+*/}}
+{{- define "thoras.forecastWorker.replicas" -}}
+{{- $configured := .Values.thorasForecast.worker.replicas | int -}}
+{{- if not .Values.featureFlags.dynamicResourceSizing.enabled -}}
+{{- $configured -}}
+{{- else -}}
+{{- $workloads := include "thoras.cluster.workloadCount" . | int -}}
+{{- $perWorker := .Values.featureFlags.dynamicResourceSizing.workloadsPerForecastWorker | int -}}
+{{- $derived := 0 -}}
+{{- if and (gt $workloads 0) (gt $perWorker 0) -}}
+{{- $derived = div (add $workloads (sub $perWorker 1)) $perWorker -}}
+{{- end -}}
+{{- if gt $derived $configured -}}
+{{- $derived -}}
+{{- else -}}
+{{- $configured -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -249,7 +249,7 @@ spec:
         {{- else }}
         resources:
           limits: {{ .Values.thorasApiServerV2.limits | toYaml | nindent 12 }}
-          requests: {{ .Values.thorasApiServerV2.requests | toYaml | nindent 12 }}
+          requests: {{ mergeOverwrite (deepCopy .Values.thorasApiServerV2.requests) (dict "memory" (include "thoras.apiServerV2.memoryRequest" .)) | toYaml | nindent 12 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasForecast.worker.labels) | nindent 4 }}
 spec:
-  replicas:  {{ .Values.thorasForecast.worker.replicas }}
+  replicas: {{ include "thoras.forecastWorker.replicas" . }}
   selector:
     matchLabels:
       app: thoras-forecast-worker

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -209,7 +209,7 @@ spec:
         {{- else }}
         resources:
           limits: {{ .Values.thorasOperator.limits | toYaml | nindent 12 }}
-          requests: {{ .Values.thorasOperator.requests | toYaml | nindent 12 }}
+          requests: {{ mergeOverwrite (deepCopy .Values.thorasOperator.requests) (dict "memory" (include "thoras.operator.memoryRequest" .)) | toYaml | nindent 12 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -239,7 +239,7 @@ spec:
         {{- else }}
         resources:
           limits: {{ .Values.thorasWorker.limits | toYaml | nindent 12 }}
-          requests: {{ .Values.thorasWorker.requests | toYaml | nindent 12 }}
+          requests: {{ mergeOverwrite (deepCopy .Values.thorasWorker.requests) (dict "memory" (include "thoras.worker.memoryRequest" .)) | toYaml | nindent 12 }}
         {{- end }}
         volumeMounts:
         - name: monitor-config

--- a/charts/thoras/tests/dynamic_resource_sizing_test.yaml
+++ b/charts/thoras/tests/dynamic_resource_sizing_test.yaml
@@ -1,0 +1,146 @@
+suite: Dynamic Resource Sizing
+templates:
+  - api-server-v2/deployment.yaml
+  - operator/deployment.yaml
+  - worker/deployment.yaml
+  - forecast-worker/deployment.yaml
+set:
+  thorasMonitor:
+    unittesting: true
+tests:
+  - it: api-server-v2 uses values.yaml fallback memory request when flag is off
+    template: api-server-v2/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 128m
+
+  - it: operator uses values.yaml fallback memory request when flag is off
+    template: operator/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+
+  - it: worker uses values.yaml fallback memory request when flag is off
+    template: worker/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 128m
+
+  - it: forecast-worker uses configured replicas when flag is off
+    template: forecast-worker/deployment.yaml
+    set:
+      thorasForecast:
+        worker:
+          replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: api-server-v2 falls back to values.yaml memory when flag is on but lookup empty
+    template: api-server-v2/deployment.yaml
+    set:
+      featureFlags:
+        dynamicResourceSizing:
+          enabled: true
+          memoryRequest:
+            perPodKB: 102.93
+            perWorkloadKB: 102.42
+            baseMB: 33.55
+          workloadsPerForecastWorker: 100
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+
+  - it: operator falls back to values.yaml memory when flag is on but lookup empty
+    template: operator/deployment.yaml
+    set:
+      featureFlags:
+        dynamicResourceSizing:
+          enabled: true
+          memoryRequest:
+            perPodKB: 102.93
+            perWorkloadKB: 102.42
+            baseMB: 33.55
+          workloadsPerForecastWorker: 100
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+
+  - it: worker falls back to values.yaml memory when flag is on but lookup empty
+    template: worker/deployment.yaml
+    set:
+      featureFlags:
+        dynamicResourceSizing:
+          enabled: true
+          memoryRequest:
+            perPodKB: 102.93
+            perWorkloadKB: 102.42
+            baseMB: 33.55
+          workloadsPerForecastWorker: 100
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+
+  - it: forecast-worker keeps configured replicas as floor when flag is on but lookup empty
+    template: forecast-worker/deployment.yaml
+    set:
+      thorasForecast:
+        worker:
+          replicas: 2
+      featureFlags:
+        dynamicResourceSizing:
+          enabled: true
+          memoryRequest:
+            perPodKB: 102.93
+            perWorkloadKB: 102.42
+            baseMB: 33.55
+          workloadsPerForecastWorker: 100
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: explicit thorasApiServerV2.resources still wins over auto-sizing
+    template: api-server-v2/deployment.yaml
+    set:
+      featureFlags:
+        dynamicResourceSizing:
+          enabled: true
+          memoryRequest:
+            perPodKB: 102.93
+            perWorkloadKB: 102.42
+            baseMB: 33.55
+          workloadsPerForecastWorker: 100
+      thorasApiServerV2:
+        resources:
+          requests:
+            cpu: 999m
+            memory: 999Mi
+          limits:
+            memory: 9Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 999Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 999m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 9Gi

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -64,6 +64,27 @@ featureFlags:
   enablePgLargeObjectStorage: false
   enableNoBlobApiServer: false
   enableForecastWorkerReadinessProbe: false
+  # Dynamically size memory requests based on actual cluster pod and workload
+  # counts, discovered via Helm `lookup` at install/upgrade time. When disabled
+  # (default), the chart uses the hardcoded `requests.memory` values on each
+  # component as today.
+  #
+  # Formula (when enabled):
+  #   mem_request_bytes = (perPodKB * podCount + perWorkloadKB * workloadCount) * 1024
+  #                     + baseMB * 1024 * 1024
+  #
+  # Coefficients are derived from empirical measurement; override only with data
+  # from your environment. Setting a component's `.resources` block still takes
+  # precedence over the computed value.
+  dynamicResourceSizing:
+    enabled: false
+    memoryRequest:
+      perPodKB: 128 # 102.93
+      perWorkloadKB: 128 # 102.42
+      baseMB: 48.0 # 33.55
+    # One forecast-worker replica per this many workloads (rounded up). The
+    # chart still respects thorasForecast.worker.replicas as a floor.
+    workloadsPerForecastWorker: 100
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:
@@ -128,7 +149,10 @@ thorasOperator:
   # Legacy field for backward compatibility (used if resources is empty)
   limits:
     memory: 2Gi
-  # Legacy field for backward compatibility (used if resources is empty)
+  # When featureFlags.dynamicResourceSizing.enabled is true, memory is computed
+  # at install time from cluster pod + workload counts via Helm lookup. The
+  # value below is the fallback when the flag is off or lookup is unavailable.
+  # CPU is never auto-sized. To pin all fields, set thorasOperator.resources.
   requests:
     cpu: 100m
     memory: 128Mi
@@ -242,7 +266,10 @@ thorasApiServerV2:
   # Legacy field for backward compatibility (used if resources is empty)
   limits:
     memory: 2Gi
-  # Legacy field for backward compatibility (used if resources is empty)
+  # When featureFlags.dynamicResourceSizing.enabled is true, memory is computed
+  # at install time from cluster pod + workload counts via Helm lookup. The
+  # value below is the fallback when the flag is off or lookup is unavailable.
+  # CPU is never auto-sized. To pin all fields, set thorasApiServerV2.resources.
   requests:
     cpu: 128m
     memory: 256Mi
@@ -273,7 +300,10 @@ thorasWorker:
   # Legacy field for backward compatibility (used if resources is empty)
   limits:
     memory: 2Gi
-  # Legacy field for backward compatibility (used if resources is empty)
+  # When featureFlags.dynamicResourceSizing.enabled is true, memory is computed
+  # at install time from cluster pod + workload counts via Helm lookup. The
+  # value below is the fallback when the flag is off or lookup is unavailable.
+  # CPU is never auto-sized. To pin all fields, set thorasWorker.resources.
   requests:
     cpu: 128m
     memory: 256Mi
@@ -398,6 +428,10 @@ thorasForecast:
     memory: "8Gi"
     cpu: "4"
   worker:
+    # When featureFlags.dynamicResourceSizing.enabled is true, this is the
+    # floor — the chart provisions one replica per workloadsPerForecastWorker
+    # workloads, never less than this. When the flag is off, this value is
+    # used verbatim.
     replicas: 1
     pollingInterval: 15
     podAnnotations: {}


### PR DESCRIPTION
## What's changing and why?

Adds `featureFlags.dynamicResourceSizing` (default off). When enabled, `api-server-v2`, `operator`, and `worker` memory requests are computed at install/upgrade time via Helm `lookup` from live pod and workload counts. Forecast-worker replicas also scale (`ceil(workloads / workloadsPerForecastWorker)`). Falls back to today's hardcoded values when lookup is unavailable.

## How tested

- All 226 helm unit tests pass, 50 snapshots unchanged
- `helm template` with flag off renders today's hardcoded values
- `helm template` with flag on + no kube context falls back correctly