### PR TITLE
Upgrade TimescaleDB to 2.27.0

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -200,8 +200,8 @@ must be pre-installed and managed externally.
 | metricsCollector.podAnnotations                                 | Object  | {}               | Pod Annotations for Thoras metrics collector                 |
 | metricsCollector.labels                                         | Object  | {}               | Pod/service labels for Thoras metrics collector              |
 | metricsCollector.timescale.image                                | String  | timescaledb      | Timescale image                                              |
-| metricsCollector.timescale.imageTag                             | String  | 2.26.1-pg16      | Timescale image tag                                          |
-| metricsCollector.timescale.extensionVersion                     | String  | 2.26.1           | Timescale extension version - should match imageTag          |
+| metricsCollector.timescale.imageTag                             | String  | 2.26.4-pg16      | Timescale image tag                                          |
+| metricsCollector.timescale.extensionVersion                     | String  | 2.26.4           | Timescale extension version - should match imageTag          |
 | metricsCollector.timescale.name                                 | String  | timescale        | Timescale container name                                     |
 | metricsCollector.timescale.containerPort                        | Number  | 5432             | Timescale port                                               |
 | metricsCollector.blobService.port                               | Number  | 80               | Blob service external port                                   |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -204,8 +204,8 @@ must be pre-installed and managed externally.
 | metricsCollector.podAnnotations                                 | Object  | {}               | Pod Annotations for Thoras metrics collector                 |
 | metricsCollector.labels                                         | Object  | {}               | Pod/service labels for Thoras metrics collector              |
 | metricsCollector.timescale.image                                | String  | timescaledb      | Timescale image                                              |
-| metricsCollector.timescale.imageTag                             | String  | 2.26.1-pg16      | Timescale image tag                                          |
-| metricsCollector.timescale.extensionVersion                     | String  | 2.26.1           | Timescale extension version - should match imageTag          |
+| metricsCollector.timescale.imageTag                             | String  | 2.27.0-pg16      | Timescale image tag                                          |
+| metricsCollector.timescale.extensionVersion                     | String  | 2.27.0           | Timescale extension version - should match imageTag          |
 | metricsCollector.timescale.name                                 | String  | timescale        | Timescale container name                                     |
 | metricsCollector.timescale.containerPort                        | Number  | 5432             | Timescale port                                               |
 | metricsCollector.blobService.port                               | Number  | 80               | Blob service external port                                   |

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -8,7 +8,7 @@ Default containers should match snapshots:
             name: thoras-timescale-password
       - name: PGDATA
         value: /var/lib/share/postgresql
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.3-pg16
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.4-pg16
     imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -8,7 +8,7 @@ Default containers should match snapshots:
             name: thoras-timescale-password
       - name: PGDATA
         value: /var/lib/share/postgresql
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.1-pg16
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.3-pg16
     imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -8,7 +8,7 @@ Default containers should match snapshots:
             name: thoras-timescale-password
       - name: PGDATA
         value: /var/lib/share/postgresql
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.1-pg16
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.27.0-pg16
     imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -176,7 +176,7 @@ Default matches snapshot:
                 - name: DATABASE_URL
                   value: $(DATABASE_HOST)/thoras?sslmode=disable
                 - name: EXTENSION_VERSION
-                  value: 2.26.3
+                  value: 2.26.4
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               name: wait-for-postgres
               resources: {}
@@ -445,7 +445,7 @@ Default matches snapshot:
                       name: thoras-timescale-password
                 - name: PGDATA
                   value: /var/lib/share/postgresql
-              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.3-pg16
+              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.4-pg16
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -1646,7 +1646,7 @@ Default matches snapshot:
                 - name: DATABASE_URL
                   value: $(DATABASE_HOST)/thoras?sslmode=disable
                 - name: EXTENSION_VERSION
-                  value: 2.26.3
+                  value: 2.26.4
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               name: wait-for-postgres
               resources: {}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -176,7 +176,7 @@ Default matches snapshot:
                 - name: DATABASE_URL
                   value: $(DATABASE_HOST)/thoras?sslmode=disable
                 - name: EXTENSION_VERSION
-                  value: 2.26.1
+                  value: 2.26.3
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               name: wait-for-postgres
               resources: {}
@@ -445,7 +445,7 @@ Default matches snapshot:
                       name: thoras-timescale-password
                 - name: PGDATA
                   value: /var/lib/share/postgresql
-              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.1-pg16
+              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.3-pg16
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -1616,7 +1616,7 @@ Default matches snapshot:
                 - name: DATABASE_URL
                   value: $(DATABASE_HOST)/thoras?sslmode=disable
                 - name: EXTENSION_VERSION
-                  value: 2.26.1
+                  value: 2.26.3
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               name: wait-for-postgres
               resources: {}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -101,7 +101,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_UPDATE_SCALE_MODE_API
                   value: "false"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.26.1
+                  value: 2.27.0
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -200,7 +200,7 @@ Default matches snapshot:
                 - name: DATABASE_URL
                   value: $(DATABASE_HOST)/thoras?sslmode=disable
                 - name: EXTENSION_VERSION
-                  value: 2.26.1
+                  value: 2.27.0
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               name: wait-for-postgres
               resources: {}
@@ -469,7 +469,7 @@ Default matches snapshot:
                       name: thoras-timescale-password
                 - name: PGDATA
                   value: /var/lib/share/postgresql
-              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.1-pg16
+              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.27.0-pg16
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -1276,7 +1276,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_MIGRATION_ON_START
                   value: "false"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.26.1
+                  value: 2.27.0
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -1665,7 +1665,7 @@ Default matches snapshot:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.26.1
+                  value: 2.27.0
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -1760,7 +1760,7 @@ Default matches snapshot:
                 - name: DATABASE_URL
                   value: $(DATABASE_HOST)/thoras?sslmode=disable
                 - name: EXTENSION_VERSION
-                  value: 2.26.1
+                  value: 2.27.0
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               name: wait-for-postgres
               resources: {}

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -108,11 +108,11 @@ tests:
     set:
       metricsCollector:
         timescale:
-          extensionVersion: "2.26.1"
+          extensionVersion: "2.27.0"
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].env[?(@.name == 'EXTENSION_VERSION')].value
-          value: "2.26.1"
+          value: "2.27.0"
   - it: Should enable request and limit overrides
     set:
       thorasApiServerV2:

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.3-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.4-pg16
   - it: Default containers should match snapshots
     chart:
       version: "4.50.0"

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.1-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.3-pg16
   - it: Default containers should match snapshots
     chart:
       version: "4.50.0"

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.26.1-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.27.0-pg16
   - it: Default containers should match snapshots
     chart:
       version: "4.50.0"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -191,8 +191,8 @@ metricsCollector:
       memory: "32Mi"
   timescale:
     image: "timescaledb"
-    imageTag: "2.26.3-pg16"
-    extensionVersion: "2.26.3"
+    imageTag: "2.26.4-pg16"
+    extensionVersion: "2.26.4"
     name: timescale
     containerPort: 5432
     # Specify the complete resources block (takes precedence if set)

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -191,8 +191,8 @@ metricsCollector:
       memory: "32Mi"
   timescale:
     image: "timescaledb"
-    imageTag: "2.26.1-pg16"
-    extensionVersion: "2.26.1"
+    imageTag: "2.26.3-pg16"
+    extensionVersion: "2.26.3"
     name: timescale
     containerPort: 5432
     # Specify the complete resources block (takes precedence if set)

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -194,8 +194,8 @@ metricsCollector:
       memory: "32Mi"
   timescale:
     image: "timescaledb"
-    imageTag: "2.26.1-pg16"
-    extensionVersion: "2.26.1"
+    imageTag: "2.27.0-pg16"
+    extensionVersion: "2.27.0"
     name: timescale
     containerPort: 5432
     # Specify the complete resources block (takes precedence if set)


### PR DESCRIPTION
# What's changing and why?

Bumps TimescaleDB from 2.26.1 to 2.27.0 (pg16) to pick up the latest patch release.

## How Tested

Helm unit tests pass.