### PR TITLE
feat: hard anti-affinity for operator pods

### DIFF
--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -60,6 +60,21 @@ podAntiAffinity:
 {{- end }}
 
 {{/*
+Default affinity for thorasOperator - hard anti-affinity with self to spread replicas across nodes
+*/}}
+{{- define "thoras.thorasOperator.defaultAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - thoras-operator
+    topologyKey: kubernetes.io/hostname
+{{- end }}
+
+{{/*
 Default affinity for thorasForecast - anti-affinity with metrics-collector and self
 */}}
 {{- define "thoras.thorasForecast.defaultAffinity" -}}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -223,17 +223,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $defaultAffinity := include "thoras.thorasOperator.defaultAffinity" . | fromYaml }}
       {{- if .Values.thorasOperator.useGlobalAffinity }}
         {{- $globalAffinity := .Values.affinity | default dict | deepCopy }}
         {{- $componentAffinity := .Values.thorasOperator.affinity | default dict | deepCopy }}
-        {{- $mergedAffinity := mustMerge dict $globalAffinity $componentAffinity }}
-        {{- with $mergedAffinity }}
+        {{- $mergedAffinity := mustMerge dict $defaultAffinity $globalAffinity $componentAffinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $mergedAffinity | nindent 8 }}
       {{- else }}
-        {{- with .Values.thorasOperator.affinity }}
+        {{- $componentAffinity := .Values.thorasOperator.affinity | default dict | deepCopy }}
+        {{- $mergedAffinity := mustMerge dict $defaultAffinity $componentAffinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $mergedAffinity | nindent 8 }}
       {{- end }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1147,6 +1147,16 @@ Default matches snapshot:
             globalLabel: globalValue
           name: thoras-operator
         spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - thoras-operator
+                  topologyKey: kubernetes.io/hostname
           containers:
             - command:
                 - /app/operator

--- a/charts/thoras/tests/affinity_test.yaml
+++ b/charts/thoras/tests/affinity_test.yaml
@@ -49,10 +49,22 @@ tests:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
           value: thoras-forecast-worker
 
-  # Test 1c: Default - other components have NO affinity
-  - it: other components have no affinity by default
+  # Test 1c: Default - operator has self anti-affinity; other components have NO affinity
+  - it: operator has self anti-affinity by default
     templates:
       - operator/deployment.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.affinity
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          value: thoras-operator
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: other components have no affinity by default
+    templates:
       - api-server-v2/deployment.yaml
       - worker/deployment.yaml
       - dashboard/deployment.yaml
@@ -109,10 +121,32 @@ tests:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
           value: node-pool
 
-  # Test 2c: Global affinity - other components get only global
-  - it: other components get only global affinity
+  # Test 2c: Global affinity - operator gets global + default anti-affinity; others get only global
+  - it: operator gets global plus default anti-affinity
     templates:
       - operator/deployment.yaml
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-pool
+                operator: In
+                values:
+                - standard-pool
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: node-pool
+      - isNotNull:
+          path: spec.template.spec.affinity.podAntiAffinity
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          value: thoras-operator
+
+  - it: other components get only global affinity
+    templates:
       - api-server-v2/deployment.yaml
       - worker/deployment.yaml
       - dashboard/deployment.yaml
@@ -134,8 +168,8 @@ tests:
       - isNull:
           path: spec.template.spec.affinity.podAntiAffinity
 
-  # Test 3a: Component-specific only - operator gets only component-specific
-  - it: operator gets only component-specific affinity when opted out
+  # Test 3a: Component-specific only - operator gets component-specific plus default anti-affinity when opted out
+  - it: operator gets component-specific plus default anti-affinity when opted out
     templates:
       - operator/deployment.yaml
     set:
@@ -154,8 +188,11 @@ tests:
       - equal:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
           value: operator-node
-      - isNull:
+      - isNotNull:
           path: spec.template.spec.affinity.podAntiAffinity
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          value: thoras-operator
 
   # Test 3b: Component-specific only - dashboard gets only component-specific
   - it: dashboard gets only component-specific affinity when opted out


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Operator replicas now land on separate nodes, improving availability during node failures.

## What's changing?

- Add `thoras.thorasOperator.defaultAffinity` helper with `requiredDuringSchedulingIgnoredDuringExecution` self-anti-affinity
- Wire it into operator deployment (always applied, merges with global/component affinity)
- Update affinity tests and snapshot to reflect operator's new default behavior

## How Tested

Helm unit tests updated and passing (221 tests). Verified rendered output with `helm template`.
