### PR TITLE
reduce webhook timeoutSeconds to 3s

### DIFF
--- a/charts/thoras/templates/operator/webhooks.yaml
+++ b/charts/thoras/templates/operator/webhooks.yaml
@@ -25,6 +25,7 @@ webhooks:
       path: /mutate--v1-pod
   sideEffects: None
   failurePolicy: 'Ignore'
+  timeoutSeconds: 3
   admissionReviewVersions:
     - v1
 - name: "scale.thoras.ai"
@@ -46,6 +47,7 @@ webhooks:
       path: /mutate-autoscaling-v1-scale
   sideEffects: None
   failurePolicy: 'Ignore'
+  timeoutSeconds: 3
   admissionReviewVersions:
     - v1
 ---
@@ -74,7 +76,7 @@ webhooks:
         path: /validate-thoras-ai-v1-aiscaletarget
     sideEffects: None
     failurePolicy: 'Ignore'
-    timeoutSeconds: 5
+    timeoutSeconds: 3
     admissionReviewVersions:
       - v1
   - name: "scale-validation.thoras.ai"
@@ -95,6 +97,6 @@ webhooks:
         path: /validate-autoscaling-v1-scale
     sideEffects: None
     failurePolicy: 'Ignore'
-    timeoutSeconds: 5
+    timeoutSeconds: 3
     admissionReviewVersions:
       - v1


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Shorter webhook timeouts reduce latency on pod creation and scale operations when the webhook is slow to respond, since all webhooks use `failurePolicy: Ignore`.

## What's changing?

- Reduce all four webhook `timeoutSeconds` from 5 to 3 (or add missing timeout to the two mutating webhooks that had none)

## How Tested

Helm unit tests pass (219 tests).
