### PR TITLE
add operator readiness probe

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -215,8 +215,9 @@ spec:
             path: /readyz
             port: http-health
           initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 3
+          periodSeconds: 5
+          failureThreshold: 2
+          timeoutSeconds: 2
         {{- if .Values.thorasOperator.resources }}
         resources: {{ .Values.thorasOperator.resources | toYaml | nindent 10 }}
         {{- else }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -210,11 +210,17 @@ spec:
             containerPort: {{ .Values.thorasOperator.prometheus.port }}
           - name: http-health
             containerPort: 8081
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: http-health
+          periodSeconds: 5
+          failureThreshold: 60
+          timeoutSeconds: 2
         readinessProbe:
           httpGet:
             path: /readyz
             port: http-health
-          initialDelaySeconds: 5
           periodSeconds: 5
           failureThreshold: 2
           timeoutSeconds: 2

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -208,6 +208,15 @@ spec:
             containerPort: 9443
           - name: http-metrics
             containerPort: {{ .Values.thorasOperator.prometheus.port }}
+          - name: http-health
+            containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: http-health
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
         {{- if .Values.thorasOperator.resources }}
         resources: {{ .Values.thorasOperator.resources | toYaml | nindent 10 }}
         {{- else }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1230,7 +1230,6 @@ Default matches snapshot:
                 httpGet:
                   path: /readyz
                   port: http-health
-                initialDelaySeconds: 5
                 periodSeconds: 5
                 timeoutSeconds: 2
               resources:
@@ -1244,6 +1243,13 @@ Default matches snapshot:
                 capabilities:
                   drop:
                     - ALL
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /readyz
+                  port: http-health
+                periodSeconds: 5
+                timeoutSeconds: 2
               volumeMounts:
                 - mountPath: /app/system-config.yaml
                   name: system-config

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1223,6 +1223,15 @@ Default matches snapshot:
                   name: https-web-hooks
                 - containerPort: 9101
                   name: http-metrics
+                - containerPort: 8081
+                  name: http-health
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /readyz
+                  port: http-health
+                initialDelaySeconds: 5
+                periodSeconds: 10
               resources:
                 limits:
                   memory: 2Gi

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1226,12 +1226,13 @@ Default matches snapshot:
                 - containerPort: 8081
                   name: http-health
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 2
                 httpGet:
                   path: /readyz
                   port: http-health
                 initialDelaySeconds: 5
-                periodSeconds: 10
+                periodSeconds: 5
+                timeoutSeconds: 2
               resources:
                 limits:
                   memory: 2Gi


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Wires up the operator's new `/readyz` endpoint to Kubernetes, so the operator pod is
removed from Service endpoints during restarts until its informer caches are synced and
the webhook server is ready. This prevents webhook timeouts and the resulting 409 conflicts
on scale operations that can occur when traffic is routed to an unready pod.

## What's changing

- Adds `readinessProbe` to the operator Deployment pointing at `/readyz` on port 8081
- Exposes port 8081 (`http-health`) on the operator container

Depends on platform change: [<!-- link platform PR here -->](https://github.com/thoras-ai/platform/pull/4224)

## How Tested

Deployed to minikube and confirmed pods are held unready during startup and only receive
webhook traffic once `/readyz` returns 200.
