### PR TITLE
set forecastJobTimeoutInterval to default 10m

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -228,6 +228,8 @@ spec:
             value: {{ .Values.featureFlags.enableDeploymentMonitor | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
             value: {{ not .Values.featureFlags.enableForecastQueueStats | ternary "true" "false" | quote }}
+          - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL
+            value: {{ .Values.thorasWorker.forecastJobTimeoutInterval | quote }}
           - name: SERVICE_POD_NAME
             valueFrom:
               fieldRef:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1577,6 +1577,8 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "true"
+                - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL
+                  value: 10m
                 - name: SERVICE_POD_NAME
                   valueFrom:
                     fieldRef:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -292,6 +292,7 @@ thorasWorker:
   enableMetricIntegrityWorker: false
   enableActiveSuggestionWorker: true
   enableUnifiedAstUtilizationMonitor: true
+  forecastJobTimeoutInterval: "10m"
   # Set to true to apply global affinity rules to this component
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)


### PR DESCRIPTION
# What's changing and why?
Make SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL configurable with a 10 minute default