### PR TITLE
Remove forecast worker readiness feature flag

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -84,10 +84,8 @@ spec:
           - name: METRICS_PORT
             value: {{ .Values.thorasForecast.prometheus.port | quote }}
           {{- end }}
-          {{- if .Values.featureFlags.enableForecastWorkerLivenessProbe }}
           - name: WORKER_HEARTBEAT_FILE
             value: /var/run/thoras/worker-heartbeat
-          {{- end }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         {{- if .Values.thorasForecast.worker.resources }}
         resources: {{ .Values.thorasForecast.worker.resources | toYaml | nindent 10 }}
@@ -117,11 +115,9 @@ spec:
         volumeMounts:
           - name: worker-state
             mountPath: /var/run/thoras
-      {{- if .Values.featureFlags.enableForecastWorkerLivenessProbe }}
       volumes:
         - name: worker-state
           emptyDir: {}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -40,28 +40,6 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.imageCredentials.secretRef }}
       {{- end }}
-      {{- if not .Values.featureFlags.enableForecastWorkerReadinessProbe }}
-      initContainers:
-      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
-        name: wait-for-api-service
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
-        env:
-          - name: API_HEALTH_URL
-            value: "http://thoras-api-server-v2/health"
-          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
-            if [ $? -ne 0 ]; then
-              echo "Failed to connect to API service"
-              exit 1
-            fi
-        resources: {}
-      {{- end }}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-forecast:{{ default .Values.thorasVersion .Values.thorasForecast.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -118,7 +96,6 @@ spec:
           limits: {{ .Values.thorasForecast.worker.limits | toYaml | nindent 12 }}
           requests: {{ .Values.thorasForecast.worker.requests | toYaml | nindent 12 }}
         {{- end }}
-        {{- if .Values.featureFlags.enableForecastWorkerReadinessProbe }}
         readinessProbe:
           exec:
             command:
@@ -128,21 +105,18 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 5
           failureThreshold: 48
-        {{- end }}
-        {{- if .Values.featureFlags.enableForecastWorkerLivenessProbe }}
         livenessProbe:
           exec:
             command:
               - /bin/sh
               - -c
-              - "test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat 2>/dev/null || echo 0) )) -lt 300"
+              - "test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat 2>/dev/null || echo 0) )) -lt 600"
           initialDelaySeconds: 120
           periodSeconds: 60
           failureThreshold: 5
         volumeMounts:
           - name: worker-state
             mountPath: /var/run/thoras
-        {{- end }}
       {{- if .Values.featureFlags.enableForecastWorkerLivenessProbe }}
       volumes:
         - name: worker-state

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -834,7 +834,7 @@ Default matches snapshot:
                   command:
                     - /bin/sh
                     - -c
-                    - test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat 2>/dev/null || echo 0) )) -lt 300
+                    - test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat 2>/dev/null || echo 0) )) -lt 600
                 failureThreshold: 5
                 initialDelaySeconds: 120
                 periodSeconds: 60

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -827,6 +827,8 @@ Default matches snapshot:
                   value: "0"
                 - name: METRICS_PORT
                   value: "9101"
+                - name: WORKER_HEARTBEAT_FILE
+                  value: /var/run/thoras/worker-heartbeat
               image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-forecast:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -869,6 +871,9 @@ Default matches snapshot:
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: thoras-forecast-worker
+          volumes:
+            - emptyDir: {}
+              name: worker-state
   18: |
     apiVersion: v1
     imagePullSecrets:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -829,7 +829,25 @@ Default matches snapshot:
                   value: "9101"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-forecast:TEST
               imagePullPolicy: IfNotPresent
+              livenessProbe:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - test $(( $(date +%s) - $(stat -c %Y /var/run/thoras/worker-heartbeat 2>/dev/null || echo 0) )) -lt 300
+                failureThreshold: 5
+                initialDelaySeconds: 120
+                periodSeconds: 60
               name: thoras-forecast-worker
+              readinessProbe:
+                exec:
+                  command:
+                    - curl
+                    - -sf
+                    - http://thoras-api-server-v2/health
+                failureThreshold: 48
+                periodSeconds: 5
+                timeoutSeconds: 5
               resources:
                 limits:
                   cpu: 2
@@ -842,28 +860,9 @@ Default matches snapshot:
                 capabilities:
                   drop:
                     - ALL
-          initContainers:
-            - args:
-                - |
-                  curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
-                  if [ $? -ne 0 ]; then
-                    echo "Failed to connect to API service"
-                    exit 1
-                  fi
-              command:
-                - /bin/sh
-                - -c
-              env:
-                - name: API_HEALTH_URL
-                  value: http://thoras-api-server-v2/health
-              image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
-              name: wait-for-api-service
-              resources: {}
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
+              volumeMounts:
+                - mountPath: /var/run/thoras
+                  name: worker-state
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -306,37 +306,6 @@ tests:
             name: USE_AST_METRICS_SERIES
             value: "true"
 
-  - it: Uses init container by default
-    asserts:
-      - equal:
-          path: spec.template.spec.initContainers[0].name
-          value: wait-for-api-service
-      - notExists:
-          path: spec.template.spec.containers[0].readinessProbe
-
-  - it: Replaces init container with readiness probe when enableForecastWorkerReadinessProbe is true
-    set:
-      featureFlags:
-        enableForecastWorkerReadinessProbe: true
-    asserts:
-      - notExists:
-          path: spec.template.spec.initContainers
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.exec.command
-          value:
-            - curl
-            - -sf
-            - http://thoras-api-server-v2/health
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
-          value: 5
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
-          value: 5
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
-          value: 48
-
   - it: Should enable request and limit overrides
     set:
       thorasForecast:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,8 +65,6 @@ featureFlags:
   enableDeploymentMonitor: true
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
-  enableForecastWorkerReadinessProbe: false
-  enableForecastWorkerLivenessProbe: false
   enableForecastQueueStats: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)


### PR DESCRIPTION
# What's changing and why?

Removes `enableForecastWorkerReadinessProbe` and `enableForecastWorkerLivenessProbe` feature flags — probes are now always enabled. Also removes the init container fallback that was used when the readiness probe was off.

## How Tested

Helm unit tests pass.