### PR TITLE
Pass timescale extension version to API server

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -224,6 +224,8 @@ spec:
             value: {{ .Values.featureFlags.enablePgLargeObjectStorage | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_UPDATE_SCALE_MODE_API
             value: {{ .Values.featureFlags.enableUpdateScaleModeApi | ternary "true" "false" | quote }}
+          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         volumeMounts:
           - name: monitor-config

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -186,6 +186,8 @@ spec:
           {{- end }}
           - name: SERVICE_ENABLE_MIGRATION_ON_START
             value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
+          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -234,6 +234,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1585,6 +1585,8 @@ Default matches snapshot:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+                  value: 2.26.1
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-worker

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -100,6 +100,8 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_UPDATE_SCALE_MODE_API
                   value: "false"
+                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+                  value: 2.26.1
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1217,6 +1217,8 @@ Default matches snapshot:
                       name: thoras-cloud-sync
                 - name: SERVICE_ENABLE_MIGRATION_ON_START
                   value: "false"
+                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+                  value: 2.26.1
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-operator


### PR DESCRIPTION
# What's changing and why?

Passes `SERVICE_TIMESCALE_EXTENSION_VERSION` env var to the API server container, sourced from `metricsCollector.timescale.extensionVersion`.

## How Tested

Helm unit tests pass.