### PR TITLE
Validate forecast_block >= forecast_interval in CRDs

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -716,6 +716,10 @@ spec:
                 - message: forecastCron and forecastInterval are mutually exclusive
                   rule: '!has(self.forecast_cron) || self.forecast_cron == '''' ||
                     !has(self.forecast_interval) || self.forecast_interval == '''''
+                - message: forecastInterval must be less than or equal to forecastBlocks
+                  rule: '!has(self.forecast_interval) || self.forecast_interval ==
+                    '''' || !has(self.forecast_blocks) || self.forecast_blocks ==
+                    '''' || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
               scaleTargetRef:
                 properties:
                   apiVersion:

--- a/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
+++ b/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
@@ -778,6 +778,10 @@ spec:
                       rule: '!has(self.forecast_cron) || self.forecast_cron == ''''
                         || !has(self.forecast_interval) || self.forecast_interval
                         == '''''
+                    - message: forecastInterval must be less than or equal to forecastBlocks
+                      rule: '!has(self.forecast_interval) || self.forecast_interval
+                        == '''' || !has(self.forecast_blocks) || self.forecast_blocks
+                        == '''' || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
                   vertical:
                     properties:
                       containers:


### PR DESCRIPTION
# What's changing and why?

Adds a CEL validation rule to both `AiScaleTarget` and `ClusterAiScaleTemplate` CRDs ensuring `forecast_interval <= forecast_blocks`, preventing invalid configurations at admission time.

## How Tested

Helm unit tests pass.