### PR TITLE
Use soft anti-affinity for operator pods

### DIFF
--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -60,18 +60,20 @@ podAntiAffinity:
 {{- end }}
 
 {{/*
-Default affinity for thorasOperator - hard anti-affinity with self to spread replicas across nodes
+Default affinity for thorasOperator - soft anti-affinity with self to spread replicas across nodes
 */}}
 {{- define "thoras.thorasOperator.defaultAffinity" -}}
 podAntiAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-  - labelSelector:
-      matchExpressions:
-      - key: app
-        operator: In
-        values:
-        - thoras-operator
-    topologyKey: kubernetes.io/hostname
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 100
+    podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - thoras-operator
+      topologyKey: kubernetes.io/hostname
 {{- end }}
 
 {{/*

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1153,14 +1153,16 @@ Default matches snapshot:
         spec:
           affinity:
             podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: app
-                        operator: In
-                        values:
-                          - thoras-operator
-                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - thoras-operator
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
           containers:
             - command:
                 - /app/operator

--- a/charts/thoras/tests/affinity_test.yaml
+++ b/charts/thoras/tests/affinity_test.yaml
@@ -57,10 +57,13 @@ tests:
       - isNotNull:
           path: spec.template.spec.affinity
       - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
           value: thoras-operator
       - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
           value: kubernetes.io/hostname
 
   - it: other components have no affinity by default
@@ -142,7 +145,7 @@ tests:
       - isNotNull:
           path: spec.template.spec.affinity.podAntiAffinity
       - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
           value: thoras-operator
 
   - it: other components get only global affinity
@@ -191,7 +194,7 @@ tests:
       - isNotNull:
           path: spec.template.spec.affinity.podAntiAffinity
       - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
           value: thoras-operator
 
   # Test 3b: Component-specific only - dashboard gets only component-specific
@@ -267,27 +270,25 @@ tests:
                 - global-value
       thorasOperator:
         affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 80
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                    - avoid-this
-                topologyKey: kubernetes.io/hostname
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - co-locate-with
+              topologyKey: kubernetes.io/hostname
     asserts:
       - equal:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
           value: global-key
       - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
-          value: 80
+          path: spec.template.spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          value: co-locate-with
       - equal:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
-          value: avoid-this
+          value: thoras-operator
 
   # Test 4b: Global + component - dashboard gets both merged
   - it: dashboard gets global plus component-specific affinity merged


### PR DESCRIPTION
# What's changing and why?

Operator default pod anti-affinity was `required`, blocking scheduling on single-node clusters when one replica is already running. Changed to `preferred` so replicas still spread across nodes in multi-node clusters but aren't stuck otherwise.

Updated affinity tests and snapshot to match.