### PR TITLE
Add enableInformersStripManagedFields feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -80,13 +80,14 @@ helm install \
 
 The following flags are considered temporary and gate access to specific behaviors that still undergoing testing before general availability.
 
-| Key                                           | Type    | Default | Description                                                |
-| --------------------------------------------- | ------- | ------- | ---------------------------------------------------------- |
-| featureFlags.enableNodeDetailsCollector       | Boolean | true    | Collection of node detail snapshots                        |
-| featureFlags.enableCheckDatabaseHealth        | Boolean | false   | If true, pings the database in the health endpoint         |
-| featureFlags.enableMigrationOnStartup         | Boolean | false   | If true, the main container handles migrations             |
-| featureFlags.enableCostSavingsSettingsRefresh | Boolean | true    | If true, refreshes the costs savings settings periodically |
-| featureFlags.enablePgLargeObjectStorage       | Boolean | false   | If true, enables storing blobs as postgres large objects   |
+| Key                                            | Type    | Default | Description                                                |
+| ---------------------------------------------- | ------- | ------- | ---------------------------------------------------------- |
+| featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                        |
+| featureFlags.enableCheckDatabaseHealth         | Boolean | false   | If true, pings the database in the health endpoint         |
+| featureFlags.enableMigrationOnStartup          | Boolean | false   | If true, the main container handles migrations             |
+| featureFlags.enableCostSavingsSettingsRefresh  | Boolean | true    | If true, refreshes the costs savings settings periodically |
+| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects   |
+| featureFlags.enableInformersStripManagedFields | Boolean | false   | If true, enables informer memory optimizations             |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -226,6 +226,8 @@ spec:
             value: {{ .Values.featureFlags.enableUpdateScaleModeApi | ternary "true" "false" | quote }}
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
+          - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+            value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         volumeMounts:
           - name: monitor-config

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -188,6 +188,8 @@ spec:
             value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
+          - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+            value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -236,6 +236,8 @@ spec:
                 fieldPath: metadata.name
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
+          - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+            value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -102,6 +102,8 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
+                - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -1225,6 +1227,8 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
+                - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-operator
@@ -1595,6 +1599,8 @@ Default matches snapshot:
                       fieldPath: metadata.name
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
+                - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-worker

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -66,6 +66,7 @@ featureFlags:
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastQueueStats: false
+  enableInformersStripManagedFields: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

Adds `featureFlags.enableInformersStripManagedFields` (default: `false`) and propagates it as `SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS` to the operator, API server, and worker deployments. Gates an informer memory optimization that strips managed fields from objects before caching.