### PR TITLE
Add pprof enable flags for operator and worker

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -174,6 +174,7 @@ All components support `<component>.useGlobalAffinity` (default: `true`) and `<c
 | thorasOperator.queriesPerSecond    | String  | "50"            | Sets a maximum threshold for K8s API qps                     |
 | thorasOperator.prometheus.enabled  | Boolean | true            | Enables a prometheus metric exporter                         |
 | thorasOperator.prometheus.port     | Number  | 9101            | Port for the prometheus metric exporter                      |
+| thorasOperator.pprof.enabled       | Boolean | false           | Enable pprof endpoint.                                       |
 
 ## External TimescaleDB
 
@@ -255,6 +256,7 @@ must be pre-installed and managed externally.
 | thorasWorker.maxTimeseriesMetricCacheSizeMb          | Number  | 1000          | Configure cache size that triggers LRU eviction              |
 | thorasWorker.enableUnifiedAstUtilizationMonitor      | Boolean | false         | Enable the unified AST utilization monitor                   |
 | thorasWorker.enableAstViewCacheStateReconcilerWorker | Boolean | true          | Enable view cache state reconciler jobs                      |
+| thorasWorker.pprof.enabled                           | Boolean | false         | Enable pprof endpoint.                                       |
 
 ## Thoras Dashboard
 

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -184,6 +184,8 @@ spec:
           - name: SERVICE_FIELD_MANAGER
             value: {{ .Values.flux.fieldManager | quote }}
           {{- end }}
+          - name: SERVICE_ENABLE_PPROF
+            value: {{ .Values.thorasOperator.pprof.enabled | quote }}
           - name: SERVICE_ENABLE_MIGRATION_ON_START
             value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -154,6 +154,8 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasWorker.queriesPerSecond | default .Values.queriesPerSecond | quote }}
+          - name: SERVICE_ENABLE_PPROF
+            value: {{ .Values.thorasWorker.pprof.enabled | quote }}
           - name: SERVICE_CHART_VERSION
             value: {{ .Chart.Version | quote }}
           - name: SERVICE_PLATFORM_VERSION

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1223,6 +1223,8 @@ Default matches snapshot:
                     secretKeyRef:
                       key: clusterKey
                       name: thoras-cloud-sync
+                - name: SERVICE_ENABLE_PPROF
+                  value: "false"
                 - name: SERVICE_ENABLE_MIGRATION_ON_START
                   value: "false"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
@@ -1536,6 +1538,8 @@ Default matches snapshot:
                   value: ""
                 - name: SERVICE_QUERIES_PER_SECOND
                   value: "50"
+                - name: SERVICE_ENABLE_PPROF
+                  value: "false"
                 - name: SERVICE_CHART_VERSION
                   value: 4.7.0
                 - name: SERVICE_PLATFORM_VERSION

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -138,6 +138,8 @@ thorasOperator:
   prometheus:
     enabled: true
     port: 9101
+  pprof:
+    enabled: false
   # Set to true to apply global affinity rules to this component
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
@@ -284,6 +286,8 @@ thorasWorker:
   prometheus:
     enabled: true
     port: 9102
+  pprof:
+    enabled: false
   enableSnapshotChunkAutoSizing: true
   # Cost will not work in the dashboard if this is disabled. Used for debugging purposes.
   enableAstViewCacheRefreshWorker: true


### PR DESCRIPTION
# What's changing and why?

Adds `thorasOperator.pprof.enabled` and `thorasWorker.pprof.enabled` flags (default: `false`), propagated as `SERVICE_ENABLE_PPROF` env vars. Allows enabling pprof endpoints per-component without a chart change.