### PR TITLE
Remove chunk interval dry run feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -249,7 +249,6 @@ must be pre-installed and managed externally.
 | thorasWorker.queriesPerSecond                        | String  | "50"          | Sets a maximum threshold for K8s API qps                     |
 | thorasWorker.prometheus.enabled                      | Boolean | true          | Enables a prometheus metric exporter                         |
 | thorasWorker.prometheus.port                         | Number  | 9102          | Port for the prometheus metric exporter                      |
-| thorasWorker.enableSnapshotChunkAutoSizing           | Boolean | false         | Enable auto resizing of metric snapshot chunks               |
 | thorasWorker.enableMetricIntegrityWorker             | Boolean | false         | Enable metric integrity worker                               |
 | thorasWorker.enableActiveSuggestionWorker            | Boolean | true          | Enable active suggestions worker                             |
 | thorasWorker.enableMonitorActiveSuggestionFromCRD    | Boolean | false         | Enable monitoring active suggestions using the AST           |

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -164,10 +164,6 @@ spec:
           - name: SERVICE_WATCH_NAMESPACES
             value: {{ join "," . | quote }}
           {{- end }}
-          {{- if .Values.thorasWorker.enableSnapshotChunkAutoSizing }}
-          - name: SERVICE_CHUNK_INTERVAL_UPDATER_DRY_RUN
-            value: "false"
-          {{- end }}
           {{- with .Values.thorasWorker.riverLogLevel }}
           - name: SERVICE_RIVER_LOG_LEVEL
             value: {{ . | quote }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1544,8 +1544,6 @@ Default matches snapshot:
                   value: 4.7.0
                 - name: SERVICE_PLATFORM_VERSION
                   value: TEST
-                - name: SERVICE_CHUNK_INTERVAL_UPDATER_DRY_RUN
-                  value: "false"
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "false"
                 - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -288,7 +288,6 @@ thorasWorker:
     port: 9102
   pprof:
     enabled: false
-  enableSnapshotChunkAutoSizing: true
   # Cost will not work in the dashboard if this is disabled. Used for debugging purposes.
   enableAstViewCacheRefreshWorker: true
   enableAstViewCacheStateReconcilerWorker: true


### PR DESCRIPTION
# What's changing and why?

Removes the `featureFlags.enableChunkIntervalDryRun` flag and its `SERVICE_ENABLE_CHUNK_INTERVAL_DRY_RUN` env var from the worker — the feature is no longer gated.