### PR TITLE
Add thoras-manages-thoras AST for worker

### DIFF
--- a/charts/thoras/templates/worker/ast.yaml
+++ b/charts/thoras/templates/worker/ast.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.featureFlags.thorasManageThoras.enabled }}
+apiVersion: thoras.ai/v1
+kind: AIScaleTarget
+metadata:
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasWorker.labels) | nindent 4 }}
+  name: thoras-worker
+  namespace: {{ .Release.Namespace }}
+spec:
+  horizontal:
+    mode: recommendation
+  model:
+    forecast_blocks: 20m
+    forecast_interval: 15m
+    mode: balanced
+  scaleTargetRef:
+    kind: Deployment
+    name: thoras-worker
+  vertical:
+    containers:
+    - cpu:
+        lowerbound: 1m
+      memory:
+        lowerbound: 1Mi
+        limit:
+          ratio: 3
+      name: '*'
+    update_policy:
+      update_mode: {{ .Values.featureFlags.thorasManageThoras.updateMode | default "recreate" }}
+    mode: {{ .Values.featureFlags.thorasManageThoras.mode | default "recommendation" }}
+{{- end }}


### PR DESCRIPTION
## What's changing and why?

Adds an `AIScaleTarget` for the `thoras-worker` deployment, gated behind the existing `featureFlags.thorasManageThoras.enabled` flag. Allows Thoras to manage its own worker's right-sizing when the feature flag is on.

## How this helps the customer

Enables self-managed resource optimization for the worker component when thoras-manages-thoras is enabled.

## Testing

Helm unit tests pass.