### PR TITLE
update CRDs

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -1146,28 +1146,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              jobs:
-                additionalProperties:
-                  properties:
-                    jobID:
-                      description: JobID is the unique identifier for this job, assigned
-                        by Thoras when the job is created.
-                      type: string
-                    lastRunStatus:
-                      description: LastRunStatus is the status of the last execution
-                        of this job.
-                      type: string
-                    lastRunTime:
-                      description: LastRunTime is the timestamp of the last time this
-                        job was executed.
-                      format: date-time
-                      type: string
-                    workerID:
-                      description: WorkerID is the identifier of the Thoras worker
-                        that claimed this job for processing.
-                      type: string
-                  type: object
-                type: object
               labelSelector:
                 type: string
               lastCollectionTime:

--- a/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
+++ b/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
@@ -611,6 +611,22 @@ spec:
                           - type
                           type: object
                         type: array
+                      maxReplicas:
+                        description: |-
+                          maxReplicas is the upper limit for the number of replicas to which the Thoras
+                          can scale up.
+                          If not set, Thoras will use the MaxReplicas value from the target's HPA if available.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      minReplicas:
+                        description: |-
+                          minReplicas is the lower limit for the number of replicas to which the Thoras
+                          can scale down.
+                          If not set, Thoras will use the MinReplicas value from the target's HPA if available.
+                        format: int32
+                        minimum: 0
+                        type: integer
                       mode:
                         enum:
                         - autonomous
@@ -705,6 +721,10 @@ spec:
                     required:
                     - mode
                     type: object
+                    x-kubernetes-validations:
+                    - message: minReplicas must not be greater than maxReplicas
+                      rule: '!has(self.minReplicas) || !has(self.maxReplicas) || self.minReplicas
+                        <= self.maxReplicas'
                   model:
                     description: |-
                       Defines the forecasting and scaling behavior for an AIScaleTarget, including
@@ -936,6 +956,22 @@ spec:
                         - recommend
                         - rec
                         type: string
+                      oom_remediation:
+                        description: |-
+                          OOMRemediation configures operator-driven memory adjustment during active OOM episodes.
+                          When nil or Enabled is false, no automatic adjustment is applied.
+                        properties:
+                          enabled:
+                            description: Enabled activates automatic memory adjustment
+                              when OOM kills are detected.
+                            type: boolean
+                          stabilization_window:
+                            description: |-
+                              StabilizationWindow is the minimum time the workload must run without a new OOM before the
+                              operator allows a forecast to lower memory below the OOM-adjusted value. The floor
+                              resets on each new OOM. When nil, defaults to max(forecast_interval, 1h).
+                            type: string
+                        type: object
                       scaling_behavior:
                         description: Rules for how large a proposed scale event must
                           be before triggering


### PR DESCRIPTION
## What's changing and why?

- `ClusterAIScaleTemplate`: add `minReplicas`/`maxReplicas` fields with a validation rule (`minReplicas <= maxReplicas`) and add `oom_remediation` block (`enabled`, `stabilization_window`) to model behavior config.
- `AIScaleTarget`: drop the `status.jobs` map (no longer reported by the operator).

Regenerated CRDs to match the latest operator API.