### PR TITLE
Add health probes to forecast worker

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -219,7 +219,7 @@ spec:
           - name: SERVICE_ENABLE_NODE_DETAILS_COLLECTOR
             value: {{ .Values.featureFlags.enableNodeDetailsCollector | ternary "true" "false" | quote}}
           - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
-            value: {{ .Values.featureFlags.enableCheckDatabaseHealth | ternary "true" "false" | quote }}
+            value: "true"
           - name: SERVICE_ENABLE_COST_SAVINGS_SETTINGS_REFRESH
             value: {{ .Values.featureFlags.enableCostSavingsSettingsRefresh | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
@@ -244,6 +244,27 @@ spec:
         ports:
           - name: http-metrics
             containerPort: {{ .Values.thorasWorker.prometheus.port }}
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http-metrics
+          periodSeconds: 10
+          failureThreshold: 30
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http-metrics
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http-metrics
+          periodSeconds: 30
+          failureThreshold: 3
+          timeoutSeconds: 2
         {{- if .Values.thorasWorker.resources }}
         resources: {{ .Values.thorasWorker.resources | toYaml | nindent 10 }}
         {{- else }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1584,7 +1584,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_NODE_DETAILS_COLLECTOR
                   value: "true"
                 - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_COST_SAVINGS_SETTINGS_REFRESH
                   value: "true"
                 - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
@@ -1607,10 +1607,24 @@ Default matches snapshot:
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health
+                  port: http-metrics
+                periodSeconds: 30
+                timeoutSeconds: 2
               name: thoras-worker
               ports:
                 - containerPort: 9102
                   name: http-metrics
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health
+                  port: http-metrics
+                periodSeconds: 10
+                timeoutSeconds: 2
               resources:
                 limits:
                   memory: 2Gi
@@ -1622,6 +1636,13 @@ Default matches snapshot:
                 capabilities:
                   drop:
                     - ALL
+              startupProbe:
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: http-metrics
+                periodSeconds: 10
+                timeoutSeconds: 2
               volumeMounts:
                 - mountPath: /app/config.yaml
                   name: monitor-config


### PR DESCRIPTION
# What's changing and why?

Adds startup, readiness, and liveness probes to the forecast worker using the existing `/health` endpoint on the metrics port.