### PR TITLE
Add utilization thresholds for over/under provisioned services

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -230,6 +230,10 @@ spec:
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MEMORY_LIMIT
             value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
+          - name: SERVICE_OVERPROVISIONED_THRESHOLD
+            value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
+          - name: SERVICE_UNDERPROVISIONED_THRESHOLD
+            value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         volumeMounts:
           - name: monitor-config

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -194,6 +194,10 @@ spec:
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MEMORY_LIMIT
             value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
+          - name: SERVICE_OVERPROVISIONED_THRESHOLD
+            value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
+          - name: SERVICE_UNDERPROVISIONED_THRESHOLD
+            value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -242,6 +242,10 @@ spec:
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MEMORY_LIMIT
             value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
+          - name: SERVICE_OVERPROVISIONED_THRESHOLD
+            value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
+          - name: SERVICE_UNDERPROVISIONED_THRESHOLD
+            value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -106,6 +106,10 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"
+                - name: SERVICE_OVERPROVISIONED_THRESHOLD
+                  value: "60"
+                - name: SERVICE_UNDERPROVISIONED_THRESHOLD
+                  value: "92"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -1239,8 +1243,6 @@ Default matches snapshot:
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
-                - name: SERVICE_ENABLE_MEMORY_LIMIT
-                  value: "true"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-operator
@@ -1615,8 +1617,6 @@ Default matches snapshot:
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
-                - name: SERVICE_ENABLE_MEMORY_LIMIT
-                  value: "true"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1243,6 +1243,12 @@ Default matches snapshot:
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
+                - name: SERVICE_ENABLE_MEMORY_LIMIT
+                  value: "true"
+                - name: SERVICE_OVERPROVISIONED_THRESHOLD
+                  value: "60"
+                - name: SERVICE_UNDERPROVISIONED_THRESHOLD
+                  value: "92"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-operator
@@ -1617,6 +1623,12 @@ Default matches snapshot:
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
+                - name: SERVICE_ENABLE_MEMORY_LIMIT
+                  value: "true"
+                - name: SERVICE_OVERPROVISIONED_THRESHOLD
+                  value: "60"
+                - name: SERVICE_UNDERPROVISIONED_THRESHOLD
+                  value: "92"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -208,3 +208,23 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_BLOB_SERVICE_API_URL')]
+  - it: Should set default utilization thresholds
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_OVERPROVISIONED_THRESHOLD')].value
+          value: "60"
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_UNDERPROVISIONED_THRESHOLD')].value
+          value: "92"
+  - it: Should override utilization thresholds
+    set:
+      utilizationThresholds:
+        overprovisioned: 50
+        underprovisioned: 85
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_OVERPROVISIONED_THRESHOLD')].value
+          value: "50"
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_UNDERPROVISIONED_THRESHOLD')].value
+          value: "85"

--- a/charts/thoras/tests/operator_deployment_test.yaml
+++ b/charts/thoras/tests/operator_deployment_test.yaml
@@ -106,3 +106,23 @@ tests:
               memory: "1Gi"
               cpu: "1"
               hugepages-1Gi: "2Gi"
+  - it: Should set default utilization thresholds
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_OVERPROVISIONED_THRESHOLD')].value
+          value: "60"
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_UNDERPROVISIONED_THRESHOLD')].value
+          value: "92"
+  - it: Should override utilization thresholds
+    set:
+      utilizationThresholds:
+        overprovisioned: 50
+        underprovisioned: 85
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_OVERPROVISIONED_THRESHOLD')].value
+          value: "50"
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_UNDERPROVISIONED_THRESHOLD')].value
+          value: "85"

--- a/charts/thoras/tests/worker_deployment_test.yaml
+++ b/charts/thoras/tests/worker_deployment_test.yaml
@@ -125,3 +125,23 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME')].value
           value: "5m"
+  - it: Should set default utilization thresholds
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_OVERPROVISIONED_THRESHOLD')].value
+          value: "60"
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_UNDERPROVISIONED_THRESHOLD')].value
+          value: "92"
+  - it: Should override utilization thresholds
+    set:
+      utilizationThresholds:
+        overprovisioned: 50
+        underprovisioned: 85
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_OVERPROVISIONED_THRESHOLD')].value
+          value: "50"
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_UNDERPROVISIONED_THRESHOLD')].value
+          value: "85"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -470,3 +470,8 @@ flux:
   # Field manager name used when patching Kubernetes resources (e.g. restartedAt).
   # Override only if your Flux installation uses a non-default field manager name.
   fieldManager: "flux-client-side-apply"
+
+# Utilization thresholds in which a target is considered over or under provisioned
+utilizationThresholds:
+  overprovisioned: 60
+  underprovisioned: 92


### PR DESCRIPTION
# What's changing and why?

Adds `utilizationThresholds.overprovisioned` (default `60`) and `utilizationThresholds.underprovisioned` (default `92`) to `values.yaml`, wired through to the api-server-v2, operator, and worker deployments as `SERVICE_OVERPROVISIONED_THRESHOLD` / `SERVICE_UNDERPROVISIONED_THRESHOLD` env vars. Lets operators tune the thresholds at which a target is classified as over- or under-provisioned without a chart change.

## How does this help customers?

Customers can tune over/under-provisioned classification thresholds via Helm values to match their environment's utilization profile.

## How Tested

- Added unit tests covering default and overridden threshold values for api-server-v2, operator, and worker deployments
- Updated global label snapshot to include the new env vars
- `helm unittest ./charts/thoras --chart-tests-path ./charts/thoras/tests`