### PR TITLE
Increase baseline memory limits and requests

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -115,10 +115,10 @@ Default matches snapshot:
                 - containerPort: 8080
               resources:
                 limits:
-                  memory: 2Gi
+                  memory: 4Gi
                 requests:
                   cpu: 128m
-                  memory: 256Mi
+                  memory: 1Gi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
@@ -1250,10 +1250,10 @@ Default matches snapshot:
                 timeoutSeconds: 2
               resources:
                 limits:
-                  memory: 2Gi
+                  memory: 4Gi
                 requests:
                   cpu: 100m
-                  memory: 128Mi
+                  memory: 1Gi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
@@ -1627,10 +1627,10 @@ Default matches snapshot:
                 timeoutSeconds: 2
               resources:
                 limits:
-                  memory: 2Gi
+                  memory: 4Gi
                 requests:
                   cpu: 128m
-                  memory: 256Mi
+                  memory: 1Gi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -130,11 +130,11 @@ thorasOperator:
   resources: {}
   # Legacy field for backward compatibility (used if resources is empty)
   limits:
-    memory: 2Gi
+    memory: 4Gi
   # Legacy field for backward compatibility (used if resources is empty)
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 1Gi
   prometheus:
     enabled: true
     port: 9101
@@ -246,11 +246,11 @@ thorasApiServerV2:
   resources: {}
   # Legacy field for backward compatibility (used if resources is empty)
   limits:
-    memory: 2Gi
+    memory: 4Gi
   # Legacy field for backward compatibility (used if resources is empty)
   requests:
     cpu: 128m
-    memory: 256Mi
+    memory: 1Gi
   port: 80
   logLevel: "info"
   prometheus:
@@ -277,11 +277,11 @@ thorasWorker:
   resources: {}
   # Legacy field for backward compatibility (used if resources is empty)
   limits:
-    memory: 2Gi
+    memory: 4Gi
   # Legacy field for backward compatibility (used if resources is empty)
   requests:
     cpu: 128m
-    memory: 256Mi
+    memory: 1Gi
   logLevel: "info"
   prometheus:
     enabled: true


### PR DESCRIPTION
# What's changing and why?

Bumps memory limits from 2Gi → 4Gi and requests from 128–256Mi → 1Gi for the operator, API server, and worker. Aligns defaults with observed production usage to reduce OOMKills on fresh installs.