### PR TITLE
Allow monitor egress to Kubernetes API server

### DIFF
--- a/charts/thoras/templates/monitor/network-policy.yaml
+++ b/charts/thoras/templates/monitor/network-policy.yaml
@@ -22,6 +22,14 @@ spec:
   # Allow all egress to pods within the same namespace
   - to:
     - podSelector: {}
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here).
+  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
+  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
   # Allow DNS resolution
   - to:
     - namespaceSelector:
@@ -58,6 +66,9 @@ spec:
   # Allow all egress to endpoints within the same namespace
   - toEndpoints:
     - {}
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  - toEntities:
+    - kube-apiserver
   # Allow DNS resolution
   - toEndpoints:
     - matchLabels:


### PR DESCRIPTION
# What's changing and why?

Adds egress rules to the `thoras-monitor` NetworkPolicy (both `kubernetes` and `cilium` flavors) so the monitor can reach the Kubernetes API server. The metrics-server API is proxied through kube-apiserver, and without these rules the monitor's metrics-server calls were blocked when network policies are enabled.

- Kubernetes flavor: permits TCP egress on 443/6443 (standard NetworkPolicy cannot target the API server by label, so destination is unrestricted on those ports — noted in a comment).
- Cilium flavor: uses `toEntities: kube-apiserver` for precise scoping.

## How this helps customers

Restores monitor functionality on clusters where `networkPolicy.enabled: true`, so metrics-server-backed features keep working without operators having to add custom egress rules.

## How tested

- `helm unittest ./charts/thoras --chart-tests-path ./charts/thoras/tests` (existing snapshots cover both flavors).
- Manual review of rendered NetworkPolicy / CiliumNetworkPolicy.