### PR TITLE
Add GOMEMLIMIT feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -88,6 +88,7 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableCostSavingsSettingsRefresh  | Boolean | true    | If true, refreshes the costs savings settings periodically |
 | featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects   |
 | featureFlags.enableInformersStripManagedFields | Boolean | false   | If true, enables informer memory optimizations             |
+| featureFlags.enableMemoryLimit                 | Boolean | false   | If true, enables dynamic GOMEMLIMIT                        |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -228,6 +228,8 @@ spec:
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_MEMORY_LIMIT
+            value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         volumeMounts:
           - name: monitor-config

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -104,6 +104,8 @@ spec:
             value: {{ .Chart.Version | quote }}
           - name: SERVICE_PLATFORM_VERSION
             value: {{ .Values.thorasVersion | quote }}
+          - name: SERVICE_ENABLE_MEMORY_LIMIT
+            value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         {{- if .Values.thorasMonitor.resources }}
         resources: {{ .Values.thorasMonitor.resources | toYaml | nindent 10 }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -192,6 +192,8 @@ spec:
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_MEMORY_LIMIT
+            value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -240,6 +240,8 @@ spec:
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_MEMORY_LIMIT
+            value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -104,6 +104,8 @@ Default matches snapshot:
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
+                - name: SERVICE_ENABLE_MEMORY_LIMIT
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -962,6 +964,8 @@ Default matches snapshot:
                   value: 4.7.0
                 - name: SERVICE_PLATFORM_VERSION
                   value: TEST
+                - name: SERVICE_ENABLE_MEMORY_LIMIT
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               name: thoras-monitor
@@ -1230,6 +1234,8 @@ Default matches snapshot:
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+                  value: "false"
+                - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
@@ -1604,6 +1610,8 @@ Default matches snapshot:
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+                  value: "false"
+                - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -67,6 +67,7 @@ featureFlags:
   enableNoBlobApiServer: false
   enableForecastQueueStats: false
   enableInformersStripManagedFields: false
+  enableMemoryLimit: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
## What's changing and why?

Adds `featureFlags.enableMemoryLimit` (default `false`) which propagates `SERVICE_ENABLE_MEMORY_LIMIT` to api-server-v2, operator, worker, and monitor deployments, letting services opt into dynamic `GOMEMLIMIT` behaviour via a flag flip rather than a chart change.

## How tested?

Helm unit tests pass; snapshots updated.