### PR TITLE
Add AFFINITY_ID env var to forecast worker

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             value: {{ .Values.thorasForecast.useAstMetricsSeries | ternary "true" "false" | quote }}
           - name: TRAINING_JITTER_MINUTES
             value: {{ .Values.thorasForecast.trainingJitterMinutes | quote }}
+          - name: AFFINITY_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           {{- if .Values.thorasForecast.prometheus.enabled }}
           - name: METRICS_PORT
             value: {{ .Values.thorasForecast.prometheus.port | quote }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -831,6 +831,10 @@ Default matches snapshot:
                   value: "false"
                 - name: TRAINING_JITTER_MINUTES
                   value: "0"
+                - name: AFFINITY_ID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
                 - name: METRICS_PORT
                   value: "9101"
                 - name: WORKER_HEARTBEAT_FILE


### PR DESCRIPTION
## What's changing and why?

Sets `AFFINITY_ID` on the forecast worker container from the pod's `metadata.uid` via the downward API, giving each worker pod a unique, stable affinity identifier for the lifetime of the pod.

## How tested?

Helm unit tests pass; snapshot updated.