### PR TITLE
Release 4.119.0 / app 4.98.0

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.118.1
+version: 4.119.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.118.1](https://img.shields.io/badge/Version-4.118.1-informational?style=flat-square) ![AppVersion: 4.97.0](https://img.shields.io/badge/AppVersion-4.97.0-informational?style=flat-square)
+![Version: 4.119.0](https://img.shields.io/badge/Version-4.119.0-informational?style=flat-square) ![AppVersion: 4.98.0](https://img.shields.io/badge/AppVersion-4.98.0-informational?style=flat-square)
 
 # Installs
 

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "4.97.0"
+thorasVersion: "4.98.0"
 cluster:
   name: ""
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Delivers chart 4.119.0 with Thoras app version 4.98.0.

## What's changing?

- Bump chart version to 4.119.0 in `Chart.yaml`
- Bump `thorasVersion` to 4.98.0 in `values.yaml`
- Update README version badges

## How Tested

Version bumps only — verified values match across all three files.

Generated with [Claude Code](https://claude.com/claude-code)
