### PR TITLE
Add readiness probe for API server

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -245,17 +245,29 @@ spec:
             subPath: system-config.yaml
             readOnly: true
         ports:
-        - containerPort: {{ .Values.thorasApiServerV2.containerPort }}
+        - name: http
+          containerPort: {{ .Values.thorasApiServerV2.containerPort }}
         startupProbe:
           httpGet:
             path: /health
-            port: {{ .Values.thorasApiServerV2.containerPort }}
-          failureThreshold: 12
+            port: http
           periodSeconds: 10
+          failureThreshold: 30
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /health?db=true
+            port: http
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 2
         livenessProbe:
           httpGet:
             path: /health
-            port: {{ .Values.thorasApiServerV2.containerPort }}
+            port: http
+          periodSeconds: 30
+          failureThreshold: 3
+          timeoutSeconds: 2
         {{- if .Values.thorasApiServerV2.resources }}
         resources: {{ .Values.thorasApiServerV2.resources | toYaml | nindent 10 }}
         {{- else }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -113,12 +113,23 @@ Default matches snapshot:
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
+                failureThreshold: 3
                 httpGet:
                   path: /health
-                  port: 8080
+                  port: http
+                periodSeconds: 30
+                timeoutSeconds: 2
               name: thoras-api-server-v2
               ports:
                 - containerPort: 8080
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health?db=true
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 2
               resources:
                 limits:
                   memory: 4Gi
@@ -131,11 +142,12 @@ Default matches snapshot:
                   drop:
                     - ALL
               startupProbe:
-                failureThreshold: 12
+                failureThreshold: 30
                 httpGet:
                   path: /health
-                  port: 8080
+                  port: http
                 periodSeconds: 10
+                timeoutSeconds: 2
               volumeMounts:
                 - mountPath: /app/config.yaml
                   name: monitor-config


### PR DESCRIPTION
# What's changing and why?

Adds a readiness probe to the API server that checks `/health?db=true`, ensuring traffic is only routed once the DB connection is healthy. Also names the port (`http`) and tightens probe configs (startup threshold bumped to 30, liveness/readiness with explicit timeouts).