### PR TITLE
Add operator liveness probe

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -236,6 +236,13 @@ spec:
           periodSeconds: 5
           failureThreshold: 2
           timeoutSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: http-health
+          periodSeconds: 5
+          failureThreshold: 60
+          timeoutSeconds: 2
         {{- if .Values.thorasOperator.resources }}
         resources: {{ .Values.thorasOperator.resources | toYaml | nindent 10 }}
         {{- else }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1251,6 +1251,13 @@ Default matches snapshot:
                   value: "92"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /readyz
+                  port: http-health
+                periodSeconds: 5
+                timeoutSeconds: 2
               name: thoras-operator
               ports:
                 - containerPort: 9443


### PR DESCRIPTION
# What's changing and why?

Adds a liveness probe to the operator deployment so Kubernetes can detect and restart hung operator pods. Uses the existing `/readyz` health endpoint with a generous failure threshold (60) to allow for slow startup scenarios.