### PR TITLE
Add probes to monitor

### DIFF
--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -43,26 +43,6 @@ spec:
       - name: config
         configMap:
           name: thoras-monitor-config
-      initContainers:
-      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasMonitor.imageTag }}
-        name: wait-for-api-service
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
-        env:
-          - name: API_HEALTH_URL
-            value: "http://thoras-api-server-v2/health"
-          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
-            if [ $? -ne 0 ]; then
-              echo "Failed to connect to API service"
-              exit 1
-            fi
-        resources: {}
       containers:
       - name: thoras-monitor
         image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasMonitor.imageTag }}
@@ -114,6 +94,18 @@ spec:
           limits: {{ .Values.thorasMonitor.limits | toYaml | nindent 12 }}
           requests: {{ .Values.thorasMonitor.requests | toYaml | nindent 12 }}
         {{- end }}
+        readinessProbe:
+          exec:
+            command: ["curl", "-sf", "http://thoras-api-server-v2/health"]
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 48
+        livenessProbe:
+          exec:
+            command: ["curl", "-sf", "http://thoras-api-server-v2/health"]
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 48
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -988,7 +988,25 @@ Default matches snapshot:
                   value: "true"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
+              livenessProbe:
+                exec:
+                  command:
+                    - curl
+                    - -sf
+                    - http://thoras-api-server-v2/health
+                failureThreshold: 48
+                periodSeconds: 5
+                timeoutSeconds: 5
               name: thoras-monitor
+              readinessProbe:
+                exec:
+                  command:
+                    - curl
+                    - -sf
+                    - http://thoras-api-server-v2/health
+                failureThreshold: 48
+                periodSeconds: 5
+                timeoutSeconds: 5
               resources:
                 limits:
                   memory: 8192Mi
@@ -1005,28 +1023,6 @@ Default matches snapshot:
                   name: config
                   readOnly: true
                   subPath: config.yaml
-          initContainers:
-            - args:
-                - |
-                  curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
-                  if [ $? -ne 0 ]; then
-                    echo "Failed to connect to API service"
-                    exit 1
-                  fi
-              command:
-                - /bin/sh
-                - -c
-              env:
-                - name: API_HEALTH_URL
-                  value: http://thoras-api-server-v2/health
-              image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
-              name: wait-for-api-service
-              resources: {}
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534


### PR DESCRIPTION
# What's changing and why?

Replaces the init container (which blocked startup) with readiness/liveness probes on the monitor container that poll the API health endpoint. This aligns with how other components handle API dependency.