### PR TITLE
Add probes to timescale container

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -165,6 +165,24 @@ spec:
           limits: {{ .Values.metricsCollector.timescale.limits | toYaml | nindent 12 }}
           requests: {{ .Values.metricsCollector.timescale.requests | toYaml | nindent 12 }}
         {{- end }}
+        startupProbe:
+          exec:
+            command: ["pg_isready", "-U", "postgres"]
+          periodSeconds: 5
+          failureThreshold: 60
+          timeoutSeconds: 2
+        readinessProbe:
+          exec:
+            command: ["pg_isready", "-U", "postgres"]
+          periodSeconds: 5
+          failureThreshold: 3
+          timeoutSeconds: 2
+        livenessProbe:
+          exec:
+            command: ["pg_isready", "-U", "postgres"]
+          periodSeconds: 10
+          failureThreshold: 6
+          timeoutSeconds: 2
         volumeMounts:
         {{- if .Values.metricsCollector.timescale.config.enabled }}
           - name: timescale-config

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -182,7 +182,7 @@ spec:
             command: ["pg_isready", "-U", "postgres"]
           periodSeconds: 10
           failureThreshold: 6
-          timeoutSeconds: 2
+          timeoutSeconds: 10
         volumeMounts:
         {{- if .Values.metricsCollector.timescale.config.enabled }}
           - name: timescale-config

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -18,9 +18,27 @@ Default containers should match snapshots:
             - stop
             - -m
             - fast
+    livenessProbe:
+      exec:
+        command:
+          - pg_isready
+          - -U
+          - postgres
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 2
     name: timescaledb
     ports:
       - containerPort: 5432
+    readinessProbe:
+      exec:
+        command:
+          - pg_isready
+          - -U
+          - postgres
+      failureThreshold: 3
+      periodSeconds: 5
+      timeoutSeconds: 2
     resources:
       limits:
         memory: 16384Mi
@@ -32,6 +50,15 @@ Default containers should match snapshots:
       capabilities:
         drop:
           - ALL
+    startupProbe:
+      exec:
+        command:
+          - pg_isready
+          - -U
+          - postgres
+      failureThreshold: 60
+      periodSeconds: 5
+      timeoutSeconds: 2
     volumeMounts:
       - mountPath: /var/lib/share
         name: timescale-data

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -26,7 +26,7 @@ Default containers should match snapshots:
           - postgres
       failureThreshold: 6
       periodSeconds: 10
-      timeoutSeconds: 2
+      timeoutSeconds: 10
     name: timescaledb
     ports:
       - containerPort: 5432

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -477,9 +477,27 @@ Default matches snapshot:
                       - stop
                       - -m
                       - fast
+              livenessProbe:
+                exec:
+                  command:
+                    - pg_isready
+                    - -U
+                    - postgres
+                failureThreshold: 6
+                periodSeconds: 10
+                timeoutSeconds: 2
               name: timescaledb
               ports:
                 - containerPort: 5432
+              readinessProbe:
+                exec:
+                  command:
+                    - pg_isready
+                    - -U
+                    - postgres
+                failureThreshold: 3
+                periodSeconds: 5
+                timeoutSeconds: 2
               resources:
                 limits:
                   memory: 16384Mi
@@ -491,6 +509,15 @@ Default matches snapshot:
                 capabilities:
                   drop:
                     - ALL
+              startupProbe:
+                exec:
+                  command:
+                    - pg_isready
+                    - -U
+                    - postgres
+                failureThreshold: 60
+                periodSeconds: 5
+                timeoutSeconds: 2
               volumeMounts:
                 - mountPath: /var/lib/share
                   name: timescale-data

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -485,7 +485,7 @@ Default matches snapshot:
                     - postgres
                 failureThreshold: 6
                 periodSeconds: 10
-                timeoutSeconds: 2
+                timeoutSeconds: 10
               name: timescaledb
               ports:
                 - containerPort: 5432


### PR DESCRIPTION
# What's changing and why?

Adds startup, readiness, and liveness probes to the timescale container using `pg_isready`.

Startup probe gives postgres up to 5 minutes to initialize; readiness and liveness probes detect connection failures and trigger restarts.