### PR TITLE
Add startup and liveness probes to dashboard

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -39,27 +39,6 @@ spec:
         - name: nginx-config
           configMap:
             name: thoras-dashboard-nginx-config
-      initContainers:
-      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
-        name: wait-for-api-service
-        securityContext:
-          runAsUser: 65534 # user: nobody
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
-        env:
-          - name: API_HEALTH_URL
-            value: "http://thoras-api-server-v2/health"
-          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
-            if [ $? -ne 0 ]; then
-              echo "Failed to connect to API service"
-              exit 1
-            fi
-        resources: {}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/thoras-dashboard-v2:{{ default .Values.thorasVersion .Values.thorasDashboard.imageTag }}
         name: thoras-dashboard
@@ -75,6 +54,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ .Values.thorasDashboard.containerPort }}
+          name: http
         {{- if .Values.thorasDashboard.resources }}
         resources: {{ .Values.thorasDashboard.resources | toYaml | nindent 10 }}
         {{- else }}
@@ -82,6 +62,24 @@ spec:
           limits: {{ .Values.thorasDashboard.limits | toYaml | nindent 12 }}
           requests: {{ .Values.thorasDashboard.requests | toYaml | nindent 12 }}
         {{- end }}
+        startupProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds: 5
+          failureThreshold: 12
+        readinessProbe:
+          exec:
+            command: ["curl", "-sf", "http://thoras-api-server-v2/health"]
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 2
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds: 5
+          failureThreshold: 48
         volumeMounts:
           - name: nginx-config
             mountPath: /etc/nginx/nginx.conf

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -688,9 +688,25 @@ Default matches snapshot:
           containers:
             - image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard-v2:TEST
               imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 48
+                httpGet:
+                  path: /
+                  port: http
+                periodSeconds: 5
               name: thoras-dashboard
               ports:
                 - containerPort: 8080
+                  name: http
+              readinessProbe:
+                exec:
+                  command:
+                    - curl
+                    - -sf
+                    - http://thoras-api-server-v2/health
+                failureThreshold: 2
+                periodSeconds: 5
+                timeoutSeconds: 5
               resources:
                 limits:
                   memory: 2Gi
@@ -703,33 +719,16 @@ Default matches snapshot:
                   drop:
                     - ALL
                 runAsUser: 101
+              startupProbe:
+                failureThreshold: 12
+                httpGet:
+                  path: /
+                  port: http
+                periodSeconds: 5
               volumeMounts:
                 - mountPath: /etc/nginx/nginx.conf
                   name: nginx-config
                   subPath: nginx.conf
-          initContainers:
-            - args:
-                - |
-                  curl -s --fail-with-body --retry-all-errors --retry 48 --retry-delay 5 ${API_HEALTH_URL}
-                  if [ $? -ne 0 ]; then
-                    echo "Failed to connect to API service"
-                    exit 1
-                  fi
-              command:
-                - /bin/sh
-                - -c
-              env:
-                - name: API_HEALTH_URL
-                  value: http://thoras-api-server-v2/health
-              image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
-              name: wait-for-api-service
-              resources: {}
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                runAsUser: 65534
           securityContext:
             runAsNonRoot: true
             seccompProfile:


### PR DESCRIPTION
## What's changing and why?

Replaces the `wait-for-api-service` init container with startup/liveness probes on nginx (`httpGet /` on port `http`). Readiness still checks the API server health endpoint.