### PR TITLE
Add typed informer feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -88,6 +88,7 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableCostSavingsSettingsRefresh  | Boolean | true    | If true, refreshes the costs savings settings periodically |
 | featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects   |
 | featureFlags.enableInformersStripManagedFields | Boolean | false   | If true, enables informer memory optimizations             |
+| featureFlags.enableTypedInformers              | Boolean | false   | If true, enables additional informer memory optimizations  |
 | featureFlags.enableMemoryLimit                 | Boolean | false   | If true, enables dynamic GOMEMLIMIT                        |
 
 ## Affinity Configuration

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -228,6 +228,8 @@ spec:
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_TYPED_INFORMERS
+            value: {{ .Values.featureFlags.enableTypedInformers | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MEMORY_LIMIT
             value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           - name: SERVICE_OVERPROVISIONED_THRESHOLD

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -192,6 +192,8 @@ spec:
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_TYPED_INFORMERS
+            value: {{ .Values.featureFlags.enableTypedInformers | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MEMORY_LIMIT
             value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           - name: SERVICE_OVERPROVISIONED_THRESHOLD

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -236,6 +236,8 @@ spec:
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_TYPED_INFORMERS
+            value: {{ .Values.featureFlags.enableTypedInformers | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MEMORY_LIMIT
             value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           - name: SERVICE_OVERPROVISIONED_THRESHOLD

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -104,6 +104,8 @@ Default matches snapshot:
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
+                - name: SERVICE_ENABLE_TYPED_INFORMERS
+                  value: "false"
                 - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD
@@ -1250,6 +1252,8 @@ Default matches snapshot:
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "false"
+                - name: SERVICE_ENABLE_TYPED_INFORMERS
+                  value: "false"
                 - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD
@@ -1634,6 +1638,8 @@ Default matches snapshot:
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
+                  value: "false"
+                - name: SERVICE_ENABLE_TYPED_INFORMERS
                   value: "false"
                 - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -67,6 +67,7 @@ featureFlags:
   enableNoBlobApiServer: false
   enableForecastQueueStats: false
   enableInformersStripManagedFields: false
+  enableTypedInformers: false
   enableMemoryLimit: true
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)


### PR DESCRIPTION
# What's changing and why?

Adds `featureFlags.enableTypedInformers` (default `false`) to operator, API server, and worker deployments as `SERVICE_ENABLE_TYPED_INFORMERS`. Gates additional informer memory optimizations behind a flag for safe rollout.