### PR TITLE
add trainJobTimeoutInterval

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -228,6 +228,8 @@ spec:
             value: {{ not .Values.featureFlags.enableForecastQueueStats | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL
             value: {{ .Values.thorasWorker.forecastJobTimeoutInterval | quote }}
+          - name: SERVICE_TRAIN_JOB_TIMEOUT_INTERVAL
+            value: {{ .Values.thorasWorker.trainJobTimeoutInterval | quote }}
           - name: SERVICE_POD_NAME
             valueFrom:
               fieldRef:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1626,6 +1626,8 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "true"
                 - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL
+                  value: 2m
+                - name: SERVICE_TRAIN_JOB_TIMEOUT_INTERVAL
                   value: 10m
                 - name: SERVICE_POD_NAME
                   valueFrom:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -295,7 +295,8 @@ thorasWorker:
   enableMetricIntegrityWorker: false
   enableActiveSuggestionWorker: true
   enableUnifiedAstUtilizationMonitor: true
-  forecastJobTimeoutInterval: "10m"
+  forecastJobTimeoutInterval: "2m"
+  trainJobTimeoutInterval: "10m"
   # Set to true to apply global affinity rules to this component
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)


### PR DESCRIPTION
# What's changing and why?
Helm changes for https://github.com/thoras-ai/platform/pull/4372/changes

- Adds `SERVICE_TRAIN_JOB_TIMEOUT_INTERVAL` with a 10 minute default
- Changes `SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL` default from 10 minutes to 2 minutes