### PR TITLE
Add blob service probes

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -292,6 +292,30 @@ spec:
           limits: {{ .Values.metricsCollector.blobService.limits | toYaml | nindent 12 }}
           requests: {{ .Values.metricsCollector.blobService.requests | toYaml | nindent 12 }}
         {{- end }}
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 10
+          failureThreshold: 30
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /health?db=true
+            port: http
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 30
+          failureThreshold: 3
+          timeoutSeconds: 2
+        ports:
+        - containerPort: {{ .Values.metricsCollector.blobService.containerPort }}
+          name: http
         volumeMounts:
           - mountPath: /var/lib/share
       {{- if and .Values.metricsCollector.persistence.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -310,8 +310,8 @@ spec:
           httpGet:
             path: /health
             port: http
-          periodSeconds: 30
-          failureThreshold: 3
+          periodSeconds: 10
+          failureThreshold: 9
           timeoutSeconds: 2
         ports:
         - containerPort: {{ .Values.metricsCollector.blobService.containerPort }}

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -126,11 +126,11 @@ Default containers should match snapshots:
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     livenessProbe:
-      failureThreshold: 3
+      failureThreshold: 9
       httpGet:
         path: /health
         port: http
-      periodSeconds: 30
+      periodSeconds: 10
       timeoutSeconds: 2
     name: thoras-blob-api
     ports:

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -125,7 +125,24 @@ Default containers should match snapshots:
         value: "false"
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /health
+        port: http
+      periodSeconds: 30
+      timeoutSeconds: 2
     name: thoras-blob-api
+    ports:
+      - containerPort: 8080
+        name: http
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /health?db=true
+        port: http
+      periodSeconds: 10
+      timeoutSeconds: 2
     resources:
       limits:
         memory: 8192Mi
@@ -137,6 +154,13 @@ Default containers should match snapshots:
       capabilities:
         drop:
           - ALL
+    startupProbe:
+      failureThreshold: 30
+      httpGet:
+        path: /health
+        port: http
+      periodSeconds: 10
+      timeoutSeconds: 2
     volumeMounts:
       - mountPath: /var/lib/share
         name: timescale-data

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -585,7 +585,24 @@ Default matches snapshot:
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 30
+                timeoutSeconds: 2
               name: thoras-blob-api
+              ports:
+                - containerPort: 8080
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health?db=true
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 2
               resources:
                 limits:
                   memory: 8192Mi
@@ -597,6 +614,13 @@ Default matches snapshot:
                 capabilities:
                   drop:
                     - ALL
+              startupProbe:
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 2
               volumeMounts:
                 - mountPath: /var/lib/share
                   name: timescale-data

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -586,11 +586,11 @@ Default matches snapshot:
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                failureThreshold: 3
+                failureThreshold: 9
                 httpGet:
                   path: /health
                   port: http
-                periodSeconds: 30
+                periodSeconds: 10
                 timeoutSeconds: 2
               name: thoras-blob-api
               ports:


### PR DESCRIPTION
# What's changing and why?

Adds startup, readiness, and liveness probes to the blob service container in the collector deployment, consistent with the pattern used by other services. Also exposes the HTTP port needed for the probes.

## How tested

Helm unit tests pass; snapshot updated.