### PR TITLE
Enable typed informers and strip managed fields by default

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -87,9 +87,9 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableMigrationOnStartup          | Boolean | false   | If true, the main container handles migrations             |
 | featureFlags.enableCostSavingsSettingsRefresh  | Boolean | true    | If true, refreshes the costs savings settings periodically |
 | featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects   |
-| featureFlags.enableInformersStripManagedFields | Boolean | false   | If true, enables informer memory optimizations             |
-| featureFlags.enableTypedInformers              | Boolean | false   | If true, enables additional informer memory optimizations  |
-| featureFlags.enableMemoryLimit                 | Boolean | false   | If true, enables dynamic GOMEMLIMIT                        |
+| featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations             |
+| featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations  |
+| featureFlags.enableMemoryLimit                 | Boolean | true    | If true, enables dynamic GOMEMLIMIT                        |
 
 ## Affinity Configuration
 

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -103,9 +103,9 @@ Default matches snapshot:
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD
@@ -1278,9 +1278,9 @@ Default matches snapshot:
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD
@@ -1667,9 +1667,9 @@ Default matches snapshot:
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.26.1
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -66,8 +66,8 @@ featureFlags:
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastQueueStats: false
-  enableInformersStripManagedFields: false
-  enableTypedInformers: false
+  enableInformersStripManagedFields: true
+  enableTypedInformers: true
   enableMemoryLimit: true
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)


### PR DESCRIPTION
# What's changing and why?

Enables `enableTypedInformers` and `enableInformersStripManagedFields` feature flags by default (both were previously `false`). These memory optimizations have been validated and are ready for general availability.