### PR TITLE
Remove enableCheckDatabaseHealth feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -83,7 +83,6 @@ The following flags are considered temporary and gate access to specific behavio
 | Key                                            | Type    | Default | Description                                                |
 | ---------------------------------------------- | ------- | ------- | ---------------------------------------------------------- |
 | featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                        |
-| featureFlags.enableCheckDatabaseHealth         | Boolean | false   | If true, pings the database in the health endpoint         |
 | featureFlags.enableMigrationOnStartup          | Boolean | false   | If true, the main container handles migrations             |
 | featureFlags.enableCostSavingsSettingsRefresh  | Boolean | true    | If true, refreshes the costs savings settings periodically |
 | featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects   |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -190,8 +190,6 @@ spec:
             value: "{{ .Values.thorasForecast.podEligibilityMinRunningTime }}"
           - name: SERVICE_MIN_LOOKBACK_TO_SCALE
             value: "{{ .Values.thorasForecast.minLookbackToScale | default "3h" }}"
-          - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
-            value: {{ .Values.featureFlags.enableCheckDatabaseHealth | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
             value: {{ .Values.featureFlags.enablePrometheusMetricScraping | quote }}
           - name: SERVICE_ENABLE_MIGRATION_ON_START

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -79,8 +79,6 @@ Default matches snapshot:
                   value: 2m
                 - name: SERVICE_MIN_LOOKBACK_TO_SCALE
                   value: 3h
-                - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
-                  value: "false"
                 - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
                   value: "false"
                 - name: SERVICE_ENABLE_MIGRATION_ON_START

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -57,7 +57,6 @@ featureFlags:
       forecastBlocks: "4h0s"
       # Forecast once per hour by default
       forecastCron: "17 * * * *"
-  enableCheckDatabaseHealth: false
   enableMigrationOnStartup: false
   enableCostSavingsSettingsRefresh: true
   enablePrometheusMetricScraping: false


### PR DESCRIPTION
# What's changing and why?

Removes the `enableCheckDatabaseHealth` feature flag — it's no longer in use.