### PR TITLE
Add forecast worker scaling configuration

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -265,9 +265,7 @@ spec:
           - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
             value: {{ .Values.featureFlags.forecastWorkerScaler.deploymentName | quote }}
           - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+            value: {{ .Values.featureFlags.forecastWorkerScaler.deploymentNamespace | quote }}
           - name: SERVICE_FORECAST_WORKER_MIN_REPLICAS
             value: {{ .Values.featureFlags.forecastWorkerScaler.minReplicas | quote }}
           - name: SERVICE_FORECAST_WORKER_MAX_REPLICAS

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -258,6 +258,22 @@ spec:
             value: {{ .Values.featureFlags.thorasManageThoras.db.forecastBlocks | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_FORECAST_CRON
             value: {{ .Values.featureFlags.thorasManageThoras.db.forecastCron | quote }}
+          - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
+            value: {{ .Values.featureFlags.forecastWorkerScaler.enabled | ternary "true" "false" | quote }}
+          - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL
+            value: {{ .Values.featureFlags.forecastWorkerScaler.interval | quote }}
+          - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
+            value: {{ .Values.featureFlags.forecastWorkerScaler.deploymentName | quote }}
+          - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SERVICE_FORECAST_WORKER_MIN_REPLICAS
+            value: {{ .Values.featureFlags.forecastWorkerScaler.minReplicas | quote }}
+          - name: SERVICE_FORECAST_WORKER_MAX_REPLICAS
+            value: {{ .Values.featureFlags.forecastWorkerScaler.maxReplicas | quote }}
+          - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
+            value: {{ .Values.featureFlags.forecastWorkerScaler.astsPerReplica | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -259,19 +259,19 @@ spec:
           - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_FORECAST_CRON
             value: {{ .Values.featureFlags.thorasManageThoras.db.forecastCron | quote }}
           - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
-            value: {{ .Values.featureFlags.forecastWorkerScaler.enabled | ternary "true" "false" | quote }}
+            value: {{ .Values.thorasForecast.worker.scaler.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL
-            value: {{ .Values.featureFlags.forecastWorkerScaler.interval | quote }}
+            value: {{ .Values.thorasForecast.worker.scaler.interval | quote }}
           - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
-            value: {{ .Values.featureFlags.forecastWorkerScaler.deploymentName | quote }}
+            value: "thoras-forecast-worker"
           - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAMESPACE
             value: {{ .Release.Namespace | quote }}
           - name: SERVICE_FORECAST_WORKER_MIN_REPLICAS
-            value: {{ .Values.featureFlags.forecastWorkerScaler.minReplicas | quote }}
+            value: {{ .Values.thorasForecast.worker.scaler.minReplicas | quote }}
           - name: SERVICE_FORECAST_WORKER_MAX_REPLICAS
-            value: {{ .Values.featureFlags.forecastWorkerScaler.maxReplicas | quote }}
+            value: {{ .Values.thorasForecast.worker.scaler.maxReplicas | quote }}
           - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
-            value: {{ .Values.featureFlags.forecastWorkerScaler.astsPerReplica | quote }}
+            value: {{ .Values.thorasForecast.worker.scaler.astsPerReplica | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -265,7 +265,7 @@ spec:
           - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
             value: {{ .Values.featureFlags.forecastWorkerScaler.deploymentName | quote }}
           - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAMESPACE
-            value: {{ .Values.featureFlags.forecastWorkerScaler.deploymentNamespace | quote }}
+            value: {{ .Release.Namespace | quote }}
           - name: SERVICE_FORECAST_WORKER_MIN_REPLICAS
             value: {{ .Values.featureFlags.forecastWorkerScaler.minReplicas | quote }}
           - name: SERVICE_FORECAST_WORKER_MAX_REPLICAS

--- a/charts/thoras/templates/worker/rbac.yaml
+++ b/charts/thoras/templates/worker/rbac.yaml
@@ -95,7 +95,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.thorasWorker.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
-{{- if .Values.featureFlags.forecastWorkerScaler.enabled }}
+{{- if .Values.thorasForecast.worker.scaler.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -110,7 +110,7 @@ rules:
   resources:
   - deployments/scale
   resourceNames:
-  - {{ .Values.featureFlags.forecastWorkerScaler.deploymentName }}
+  - thoras-forecast-worker
   verbs:
   - get
   - update

--- a/charts/thoras/templates/worker/rbac.yaml
+++ b/charts/thoras/templates/worker/rbac.yaml
@@ -95,3 +95,40 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.thorasWorker.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.featureFlags.forecastWorkerScaler.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: thoras-worker-forecast-scaler
+  namespace: {{ .Values.featureFlags.forecastWorkerScaler.deploymentNamespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasWorker.labels) | nindent 4 }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  resourceNames:
+  - {{ .Values.featureFlags.forecastWorkerScaler.deploymentName }}
+  verbs:
+  - get
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: thoras-worker-forecast-scaler
+  namespace: {{ .Values.featureFlags.forecastWorkerScaler.deploymentNamespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasWorker.labels) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: thoras-worker-forecast-scaler
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.thorasWorker.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/thoras/templates/worker/rbac.yaml
+++ b/charts/thoras/templates/worker/rbac.yaml
@@ -101,7 +101,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: thoras-worker-forecast-scaler
-  namespace: {{ .Values.featureFlags.forecastWorkerScaler.deploymentNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasWorker.labels) | nindent 4 }}
 rules:
@@ -120,7 +120,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: thoras-worker-forecast-scaler
-  namespace: {{ .Values.featureFlags.forecastWorkerScaler.deploymentNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasWorker.labels) | nindent 4 }}
 roleRef:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1693,9 +1693,7 @@ Default matches snapshot:
                 - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
                   value: thoras-forecast-worker
                 - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
+                  value: thoras
                 - name: SERVICE_FORECAST_WORKER_MIN_REPLICAS
                   value: "1"
                 - name: SERVICE_FORECAST_WORKER_MAX_REPLICAS

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1693,7 +1693,7 @@ Default matches snapshot:
                 - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
                   value: thoras-forecast-worker
                 - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAMESPACE
-                  value: thoras
+                  value: foo
                 - name: SERVICE_FORECAST_WORKER_MIN_REPLICAS
                   value: "1"
                 - name: SERVICE_FORECAST_WORKER_MAX_REPLICAS

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1686,6 +1686,22 @@ Default matches snapshot:
                   value: 4h0s
                 - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_FORECAST_CRON
                   value: 17 * * * *
+                - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
+                  value: "false"
+                - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL
+                  value: 1m
+                - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
+                  value: thoras-forecast-worker
+                - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: SERVICE_FORECAST_WORKER_MIN_REPLICAS
+                  value: "1"
+                - name: SERVICE_FORECAST_WORKER_MAX_REPLICAS
+                  value: "100"
+                - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
+                  value: "67"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -57,6 +57,14 @@ featureFlags:
       forecastBlocks: "4h0s"
       # Forecast once per hour by default
       forecastCron: "17 * * * *"
+  forecastWorkerScaler:
+    enabled: false
+    interval: "1m"
+    deploymentName: "thoras-forecast-worker"
+    deploymentNamespace: "thoras"
+    minReplicas: 1
+    maxReplicas: 100
+    astsPerReplica: 67
   enableMigrationOnStartup: false
   enableCostSavingsSettingsRefresh: true
   enablePrometheusMetricScraping: false

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -426,7 +426,7 @@ thorasForecast:
       cpu: 1
       memory: 256Mi
     forecastTimeout: 600
-    forecastWorkerScaler:
+    scaler:
       enabled: false
       interval: "1m"
       minReplicas: 1

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -61,7 +61,6 @@ featureFlags:
     enabled: false
     interval: "1m"
     deploymentName: "thoras-forecast-worker"
-    deploymentNamespace: "thoras"
     minReplicas: 1
     maxReplicas: 100
     astsPerReplica: 67

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -57,13 +57,6 @@ featureFlags:
       forecastBlocks: "4h0s"
       # Forecast once per hour by default
       forecastCron: "17 * * * *"
-  forecastWorkerScaler:
-    enabled: false
-    interval: "1m"
-    deploymentName: "thoras-forecast-worker"
-    minReplicas: 1
-    maxReplicas: 100
-    astsPerReplica: 67
   enableMigrationOnStartup: false
   enableCostSavingsSettingsRefresh: true
   enablePrometheusMetricScraping: false
@@ -433,6 +426,12 @@ thorasForecast:
       cpu: 1
       memory: 256Mi
     forecastTimeout: 600
+    forecastWorkerScaler:
+      enabled: false
+      interval: "1m"
+      minReplicas: 1
+      maxReplicas: 100
+      astsPerReplica: 67
   prometheus:
     enabled: true
     port: 9101


### PR DESCRIPTION
# What's changing and why?

Adds optional feature flag `forecastWorkerScaler` for the worker service to dynamically scale the forecast worker deployment.

## What's changing

- New `featureFlags.forecastWorkerScaler` values block (disabled by default) with interval, deployment name/namespace, replica bounds, and ASTs-per-replica.
- Worker deployment env vars wired from the new values.
- Conditional `Role`/`RoleBinding` granting the worker `get/update/patch` on `deployments/scale` for the forecast worker deployment when the flag is enabled.

## How this helps customers

Lets the worker autoscale the forecast worker based on workload, improving forecast throughput without manual replica tuning.

## How tested

- `helm unittest ./charts/thoras --chart-tests-path ./charts/thoras/tests` (snapshot updated).