### PR TITLE
Ensure shutdown of blob-service

### DIFF
--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -236,7 +236,7 @@ spec:
             psql -U postgres -h localhost -c "ALTER USER postgres WITH PASSWORD '${POSTGRES_PASSWORD}'";
         {{- end }}
 
-            ./blob-service
+            exec ./blob-service
         env:
           - name: SERVICE_CLUSTER_NAME
             value: "{{ .Values.cluster.name }}"

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -92,7 +92,7 @@ Default containers should match snapshots:
         echo "setting password"
         psql -U postgres -h localhost -c "ALTER USER postgres WITH PASSWORD '${POSTGRES_PASSWORD}'";
 
-        ./blob-service
+        exec ./blob-service
     command:
       - /bin/sh
       - -c

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -550,7 +550,7 @@ Default matches snapshot:
                   echo "setting password"
                   psql -U postgres -h localhost -c "ALTER USER postgres WITH PASSWORD '${POSTGRES_PASSWORD}'";
 
-                  ./blob-service
+                  exec ./blob-service
               command:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
## What's changing and why?

Uses `exec` to launch `blob-service` so Kubernetes signals (SIGTERM) are delivered directly to the process instead of being swallowed by the shell wrapper, enabling clean graceful shutdown.