### PR TITLE
Remove unused forecast worker resource values

### DIFF
--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -397,16 +397,6 @@ thorasForecast:
   useAstMetricsSeries: false
   # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
   minLookbackToScale: "3h"
-  # Specify the complete resources block (takes precedence if set)
-  resources: {}
-  # Legacy field for backward compatibility (used if resources is empty)
-  requests:
-    cpu: "256m"
-    memory: "256Mi"
-  # Legacy field for backward compatibility (used if resources is empty)
-  limits:
-    memory: "8Gi"
-    cpu: "4"
   worker:
     replicas: 1
     pollingInterval: 15


### PR DESCRIPTION
# What's changing and why?

Removes `resources`, `requests`, and `limits` fields from `thorasForecast` in `values.yaml` — these were unused dead config.