### PR TITLE
add thorasManageThoras upperbounds

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -258,6 +258,34 @@ spec:
             value: {{ .Values.featureFlags.thorasManageThoras.db.forecastBlocks | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_FORECAST_CRON
             value: {{ .Values.featureFlags.thorasManageThoras.db.forecastCron | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_CPU_UPPER_BOUND
+            value: {{ .Values.thorasForecast.worker.upperbound.cpu | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_MEMORY_UPPER_BOUND
+            value: {{ .Values.thorasForecast.worker.upperbound.memory | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_CPU_UPPER_BOUND
+            value: {{ .Values.thorasApiServerV2.upperbound.cpu | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_MEMORY_UPPER_BOUND
+            value: {{ .Values.thorasApiServerV2.upperbound.memory | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_CPU_UPPER_BOUND
+            value: {{ .Values.thorasDashboard.upperbound.cpu | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_MEMORY_UPPER_BOUND
+            value: {{ .Values.thorasDashboard.upperbound.memory | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_CPU_UPPER_BOUND
+            value: {{ .Values.thorasMonitor.upperbound.cpu | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_MEMORY_UPPER_BOUND
+            value: {{ .Values.thorasMonitor.upperbound.memory | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_CPU_UPPER_BOUND
+            value: {{ .Values.thorasOperator.upperbound.cpu | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_MEMORY_UPPER_BOUND
+            value: {{ .Values.thorasOperator.upperbound.memory | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_WORKER_CPU_UPPER_BOUND
+            value: {{ .Values.thorasWorker.upperbound.cpu | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_WORKER_MEMORY_UPPER_BOUND
+            value: {{ .Values.thorasWorker.upperbound.memory | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_CPU_UPPER_BOUND
+            value: {{ .Values.metricsCollector.upperbound.cpu | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_MEMORY_UPPER_BOUND
+            value: {{ .Values.metricsCollector.upperbound.memory | quote }}
           - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
             value: {{ .Values.thorasForecast.worker.scaler.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1636,6 +1636,34 @@ Default matches snapshot:
                   value: 4h0s
                 - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_FORECAST_CRON
                   value: 17 * * * *
+                - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_CPU_UPPER_BOUND
+                  value: "2"
+                - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_MEMORY_UPPER_BOUND
+                  value: 4Gi
+                - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_CPU_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_MEMORY_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_CPU_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_MEMORY_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_CPU_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_MEMORY_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_CPU_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_MEMORY_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_WORKER_CPU_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_WORKER_MEMORY_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_CPU_UPPER_BOUND
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_MEMORY_UPPER_BOUND
+                  value: ""
                 - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
                   value: "false"
                 - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -121,6 +121,11 @@ rbac:
 
 thorasOperator:
   replicas: 2
+  # Resource upperbound used when thorasManageThoras is enabled. Empty means
+  # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
+  upperbound:
+    cpu: ""
+    memory: ""
   serviceAccount:
     name: thoras-operator
   podAnnotations: {}
@@ -166,6 +171,11 @@ thorasOperator:
   extraEgressRules: []
 
 metricsCollector:
+  # Resource upperbound used when thorasManageThoras is enabled. Empty means
+  # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
+  upperbound:
+    cpu: ""
+    memory: ""
   persistence:
     enabled: false
     volumeName: ""
@@ -233,6 +243,11 @@ metricsCollector:
   extraEgressRules: []
 
 thorasApiServerV2:
+  # Resource upperbound used when thorasManageThoras is enabled. Empty means
+  # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
+  upperbound:
+    cpu: ""
+    memory: ""
   rbac:
     create: true
   serviceAccount:
@@ -267,6 +282,11 @@ thorasApiServerV2:
 
 thorasWorker:
   enabled: true
+  # Resource upperbound used when thorasManageThoras is enabled. Empty means
+  # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
+  upperbound:
+    cpu: ""
+    memory: ""
   serviceAccount:
     name: thoras-worker
   podAnnotations: {}
@@ -305,6 +325,11 @@ thorasWorker:
 
 thorasDashboard:
   enabled: true
+  # Resource upperbound used when thorasManageThoras is enabled. Empty means
+  # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
+  upperbound:
+    cpu: ""
+    memory: ""
   serviceAccount:
     name: thoras-dashboard
     create: true
@@ -365,6 +390,11 @@ thorasDashboard:
 
 thorasMonitor:
   enabled: false
+  # Resource upperbound used when thorasManageThoras is enabled. Empty means
+  # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
+  upperbound:
+    cpu: ""
+    memory: ""
   serviceAccount:
     name: thoras-monitor
   unittesting: false
@@ -409,6 +439,11 @@ thorasForecast:
     cpu: "4"
   worker:
     replicas: 1
+    # Resource upperbound used when thorasManageThoras is enabled. Empty means
+    # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
+    upperbound:
+      cpu: "2"
+      memory: "4Gi"
     pollingInterval: 15
     podAnnotations: {}
     retrainSteadyStateHours: ""


### PR DESCRIPTION
# What's changing and why?
Adds per-workload upperbounds for the thorasManageThoras feature.

The forecaster defaults to 4Gi and 2 cores; all others default to no upperbound.