### PR TITLE
Enable metric integrity worker

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -953,7 +953,7 @@ Default matches snapshot:
                 - name: SERVICE_THORAS_API_BASE_URL
                   value: http://thoras-api-server-v2
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
                   value: "true"
                 - name: SERVICE_CHART_VERSION
@@ -1556,7 +1556,7 @@ Default matches snapshot:
                 - name: SERVICE_PLATFORM_VERSION
                   value: TEST
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
                   value: "true"
                 - name: SERVICE_COLLECTOR_MEM_REQUEST

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -312,7 +312,7 @@ thorasWorker:
   # Cost will not work in the dashboard if this is disabled. Used for debugging purposes.
   enableAstViewCacheRefreshWorker: true
   enableAstViewCacheStateReconcilerWorker: true
-  enableMetricIntegrityWorker: false
+  enableMetricIntegrityWorker: true
   enableActiveSuggestionWorker: true
   enableUnifiedAstUtilizationMonitor: true
   forecastJobTimeoutInterval: "2m"


### PR DESCRIPTION
# What's changing and why?

Enables `enableMetricIntegrityWorker` by default (`false` → `true`). The worker is now stable enough for general use.