### PR TITLE
Default USE_AST_METRICS_SERIES to true

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -820,7 +820,7 @@ Default matches snapshot:
                 - name: ENABLE_DECOUPLED_TRAINING
                   value: "true"
                 - name: USE_AST_METRICS_SERIES
-                  value: "false"
+                  value: "true"
                 - name: TRAINING_JITTER_MINUTES
                   value: "0"
                 - name: AFFINITY_ID

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -287,24 +287,24 @@ tests:
             name: TRAINING_JITTER_MINUTES
             value: "30"
 
-  - it: renders USE_AST_METRICS_SERIES as false by default
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
-          content:
-            name: USE_AST_METRICS_SERIES
-            value: "false"
-
-  - it: renders USE_AST_METRICS_SERIES as true when useAstMetricsSeries is true
-    set:
-      thorasForecast:
-        useAstMetricsSeries: true
+  - it: renders USE_AST_METRICS_SERIES as true by default
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
           content:
             name: USE_AST_METRICS_SERIES
             value: "true"
+
+  - it: renders USE_AST_METRICS_SERIES as false when useAstMetricsSeries is false
+    set:
+      thorasForecast:
+        useAstMetricsSeries: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
+          content:
+            name: USE_AST_METRICS_SERIES
+            value: "false"
 
   - it: Should enable request and limit overrides
     set:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -424,7 +424,7 @@ thorasForecast:
   podEligibilityMinRunningTime: "2m"
   enableDecoupledTraining: true
   trainingJitterMinutes: 0
-  useAstMetricsSeries: false
+  useAstMetricsSeries: true
   # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
   minLookbackToScale: "3h"
   worker:


### PR DESCRIPTION
## What's changing and why?

Flips `useAstMetricsSeries` default to `true` so the forecast worker uses the new AST time series by default. Updates tests to match.