### PR TITLE
add oom remediation configurables to thoras-scaling-thoras workloads

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -287,31 +287,31 @@ spec:
           - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_MEMORY_UPPER_BOUND
             value: {{ .Values.metricsCollector.upperbound.memory | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_ENABLED
-            value: {{ .Values.thorasForecast.worker.oom_remediation.enabled | quote }}
+            value: {{ .Values.thorasForecast.worker.oom_remediation.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
             value: {{ .Values.thorasForecast.worker.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_ENABLED
-            value: {{ .Values.thorasApiServerV2.oom_remediation.enabled | quote }}
+            value: {{ .Values.thorasApiServerV2.oom_remediation.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_STABILIZATION_WINDOW
             value: {{ .Values.thorasApiServerV2.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_ENABLED
-            value: {{ .Values.thorasDashboard.oom_remediation.enabled | quote }}
+            value: {{ .Values.thorasDashboard.oom_remediation.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_STABILIZATION_WINDOW
             value: {{ .Values.thorasDashboard.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_ENABLED
-            value: {{ .Values.thorasMonitor.oom_remediation.enabled | quote }}
+            value: {{ .Values.thorasMonitor.oom_remediation.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_STABILIZATION_WINDOW
             value: {{ .Values.thorasMonitor.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_ENABLED
-            value: {{ .Values.thorasOperator.oom_remediation.enabled | quote }}
+            value: {{ .Values.thorasOperator.oom_remediation.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_STABILIZATION_WINDOW
             value: {{ .Values.thorasOperator.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_ENABLED
-            value: {{ .Values.thorasWorker.oom_remediation.enabled | quote }}
+            value: {{ .Values.thorasWorker.oom_remediation.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
             value: {{ .Values.thorasWorker.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_ENABLED
-            value: {{ .Values.metricsCollector.oom_remediation.enabled | quote }}
+            value: {{ .Values.metricsCollector.oom_remediation.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_STABILIZATION_WINDOW
             value: {{ .Values.metricsCollector.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -286,6 +286,34 @@ spec:
             value: {{ .Values.metricsCollector.upperbound.cpu | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_MEMORY_UPPER_BOUND
             value: {{ .Values.metricsCollector.upperbound.memory | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_ENABLED
+            value: {{ .Values.thorasForecast.worker.oom_remediation.enabled | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
+            value: {{ .Values.thorasForecast.worker.oom_remediation.stabilization_window | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_ENABLED
+            value: {{ .Values.thorasApiServerV2.oom_remediation.enabled | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_STABILIZATION_WINDOW
+            value: {{ .Values.thorasApiServerV2.oom_remediation.stabilization_window | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_ENABLED
+            value: {{ .Values.thorasDashboard.oom_remediation.enabled | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_STABILIZATION_WINDOW
+            value: {{ .Values.thorasDashboard.oom_remediation.stabilization_window | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_ENABLED
+            value: {{ .Values.thorasMonitor.oom_remediation.enabled | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_STABILIZATION_WINDOW
+            value: {{ .Values.thorasMonitor.oom_remediation.stabilization_window | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_ENABLED
+            value: {{ .Values.thorasOperator.oom_remediation.enabled | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_STABILIZATION_WINDOW
+            value: {{ .Values.thorasOperator.oom_remediation.stabilization_window | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_ENABLED
+            value: {{ .Values.thorasWorker.oom_remediation.enabled | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
+            value: {{ .Values.thorasWorker.oom_remediation.stabilization_window | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_ENABLED
+            value: {{ .Values.metricsCollector.oom_remediation.enabled | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_STABILIZATION_WINDOW
+            value: {{ .Values.metricsCollector.oom_remediation.stabilization_window | quote }}
           - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
             value: {{ .Values.thorasForecast.worker.scaler.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -288,32 +288,46 @@ spec:
             value: {{ .Values.metricsCollector.upperbound.memory | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_ENABLED
             value: {{ .Values.thorasForecast.worker.oom_remediation.enabled | ternary "true" "false" | quote }}
+          {{- with .Values.thorasForecast.worker.oom_remediation.stabilization_window }}
           - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
-            value: {{ .Values.thorasForecast.worker.oom_remediation.stabilization_window | quote }}
+            value: {{ . | quote }}
+          {{- end }}
           - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_ENABLED
             value: {{ .Values.thorasApiServerV2.oom_remediation.enabled | ternary "true" "false" | quote }}
+          {{- with .Values.thorasApiServerV2.oom_remediation.stabilization_window }}
           - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_STABILIZATION_WINDOW
-            value: {{ .Values.thorasApiServerV2.oom_remediation.stabilization_window | quote }}
+            value: {{ . | quote }}
+          {{- end }}
           - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_ENABLED
             value: {{ .Values.thorasDashboard.oom_remediation.enabled | ternary "true" "false" | quote }}
+          {{- with .Values.thorasDashboard.oom_remediation.stabilization_window }}
           - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_STABILIZATION_WINDOW
-            value: {{ .Values.thorasDashboard.oom_remediation.stabilization_window | quote }}
+            value: {{ . | quote }}
+          {{- end }}
           - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_ENABLED
             value: {{ .Values.thorasMonitor.oom_remediation.enabled | ternary "true" "false" | quote }}
+          {{- with .Values.thorasMonitor.oom_remediation.stabilization_window }}
           - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_STABILIZATION_WINDOW
-            value: {{ .Values.thorasMonitor.oom_remediation.stabilization_window | quote }}
+            value: {{ . | quote }}
+          {{- end }}
           - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_ENABLED
             value: {{ .Values.thorasOperator.oom_remediation.enabled | ternary "true" "false" | quote }}
+          {{- with .Values.thorasOperator.oom_remediation.stabilization_window }}
           - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_STABILIZATION_WINDOW
-            value: {{ .Values.thorasOperator.oom_remediation.stabilization_window | quote }}
+            value: {{ . | quote }}
+          {{- end }}
           - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_ENABLED
             value: {{ .Values.thorasWorker.oom_remediation.enabled | ternary "true" "false" | quote }}
+          {{- with .Values.thorasWorker.oom_remediation.stabilization_window }}
           - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
-            value: {{ .Values.thorasWorker.oom_remediation.stabilization_window | quote }}
+            value: {{ . | quote }}
+          {{- end }}
           - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_ENABLED
             value: {{ .Values.metricsCollector.oom_remediation.enabled | ternary "true" "false" | quote }}
+          {{- with .Values.metricsCollector.oom_remediation.stabilization_window }}
           - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_STABILIZATION_WINDOW
-            value: {{ .Values.metricsCollector.oom_remediation.stabilization_window | quote }}
+            value: {{ . | quote }}
+          {{- end }}
           - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
             value: {{ .Values.thorasForecast.worker.scaler.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1664,6 +1664,34 @@ Default matches snapshot:
                   value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_MEMORY_UPPER_BOUND
                   value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_ENABLED
+                  value: "true"
+                - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_ENABLED
+                  value: "true"
+                - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_STABILIZATION_WINDOW
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_ENABLED
+                  value: "true"
+                - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_STABILIZATION_WINDOW
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_ENABLED
+                  value: "true"
+                - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_STABILIZATION_WINDOW
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_ENABLED
+                  value: "true"
+                - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_STABILIZATION_WINDOW
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_ENABLED
+                  value: "true"
+                - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
+                  value: ""
+                - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_ENABLED
+                  value: "true"
+                - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_STABILIZATION_WINDOW
+                  value: ""
                 - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
                   value: "false"
                 - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1666,32 +1666,18 @@ Default matches snapshot:
                   value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_ENABLED
                   value: "true"
-                - name: SERVICE_THORAS_SCALING_THORAS_FORECAST_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
-                  value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_ENABLED
                   value: "true"
-                - name: SERVICE_THORAS_SCALING_THORAS_API_SERVER_OOM_REMEDIATION_STABILIZATION_WINDOW
-                  value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_ENABLED
                   value: "true"
-                - name: SERVICE_THORAS_SCALING_THORAS_DASHBOARD_OOM_REMEDIATION_STABILIZATION_WINDOW
-                  value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_ENABLED
                   value: "true"
-                - name: SERVICE_THORAS_SCALING_THORAS_MONITOR_OOM_REMEDIATION_STABILIZATION_WINDOW
-                  value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_ENABLED
                   value: "true"
-                - name: SERVICE_THORAS_SCALING_THORAS_OPERATOR_OOM_REMEDIATION_STABILIZATION_WINDOW
-                  value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_ENABLED
                   value: "true"
-                - name: SERVICE_THORAS_SCALING_THORAS_WORKER_OOM_REMEDIATION_STABILIZATION_WINDOW
-                  value: ""
                 - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_ENABLED
                   value: "true"
-                - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_STABILIZATION_WINDOW
-                  value: ""
                 - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
                   value: "false"
                 - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -126,6 +126,14 @@ thorasOperator:
   upperbound:
     cpu: ""
     memory: ""
+  # OOM remediation used when thorasManageThoras is enabled. Enabled by
+  # default so that an OOM on a Thoras workload raises its memory floor via
+  # the operator's standard OOM remediation flow. stabilization_window is a
+  # duration string (e.g. "1h"); empty defers to the operator default of
+  # max(forecast_interval, 1h).
+  oom_remediation:
+    enabled: true
+    stabilization_window: ""
   serviceAccount:
     name: thoras-operator
   podAnnotations: {}
@@ -176,6 +184,14 @@ metricsCollector:
   upperbound:
     cpu: ""
     memory: ""
+  # OOM remediation used when thorasManageThoras is enabled. Enabled by
+  # default so that an OOM on a Thoras workload raises its memory floor via
+  # the operator's standard OOM remediation flow. stabilization_window is a
+  # duration string (e.g. "1h"); empty defers to the operator default of
+  # max(forecast_interval, 1h).
+  oom_remediation:
+    enabled: true
+    stabilization_window: ""
   persistence:
     enabled: false
     volumeName: ""
@@ -248,6 +264,14 @@ thorasApiServerV2:
   upperbound:
     cpu: ""
     memory: ""
+  # OOM remediation used when thorasManageThoras is enabled. Enabled by
+  # default so that an OOM on a Thoras workload raises its memory floor via
+  # the operator's standard OOM remediation flow. stabilization_window is a
+  # duration string (e.g. "1h"); empty defers to the operator default of
+  # max(forecast_interval, 1h).
+  oom_remediation:
+    enabled: true
+    stabilization_window: ""
   rbac:
     create: true
   serviceAccount:
@@ -287,6 +311,14 @@ thorasWorker:
   upperbound:
     cpu: ""
     memory: ""
+  # OOM remediation used when thorasManageThoras is enabled. Enabled by
+  # default so that an OOM on a Thoras workload raises its memory floor via
+  # the operator's standard OOM remediation flow. stabilization_window is a
+  # duration string (e.g. "1h"); empty defers to the operator default of
+  # max(forecast_interval, 1h).
+  oom_remediation:
+    enabled: true
+    stabilization_window: ""
   serviceAccount:
     name: thoras-worker
   podAnnotations: {}
@@ -330,6 +362,14 @@ thorasDashboard:
   upperbound:
     cpu: ""
     memory: ""
+  # OOM remediation used when thorasManageThoras is enabled. Enabled by
+  # default so that an OOM on a Thoras workload raises its memory floor via
+  # the operator's standard OOM remediation flow. stabilization_window is a
+  # duration string (e.g. "1h"); empty defers to the operator default of
+  # max(forecast_interval, 1h).
+  oom_remediation:
+    enabled: true
+    stabilization_window: ""
   serviceAccount:
     name: thoras-dashboard
     create: true
@@ -395,6 +435,14 @@ thorasMonitor:
   upperbound:
     cpu: ""
     memory: ""
+  # OOM remediation used when thorasManageThoras is enabled. Enabled by
+  # default so that an OOM on a Thoras workload raises its memory floor via
+  # the operator's standard OOM remediation flow. stabilization_window is a
+  # duration string (e.g. "1h"); empty defers to the operator default of
+  # max(forecast_interval, 1h).
+  oom_remediation:
+    enabled: true
+    stabilization_window: ""
   serviceAccount:
     name: thoras-monitor
   unittesting: false
@@ -434,6 +482,14 @@ thorasForecast:
     upperbound:
       cpu: "2"
       memory: "4Gi"
+    # OOM remediation used when thorasManageThoras is enabled. Enabled by
+    # default so that an OOM on the forecast worker raises its memory floor
+    # via the operator's standard OOM remediation flow. stabilization_window
+    # is a duration string (e.g. "1h"); empty defers to the operator default
+    # of max(forecast_interval, 1h).
+    oom_remediation:
+      enabled: true
+      stabilization_window: ""
     pollingInterval: 15
     podAnnotations: {}
     retrainSteadyStateHours: ""


### PR DESCRIPTION
Relates to https://github.com/thoras-ai/platform/issues/4453

# What's changing and why?
Allows reactive OOM remediation for Thoras workloads when they are managed by Thoras.