### PR TITLE
enable thorasManageThoras feature flag

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1649,7 +1649,7 @@ Default matches snapshot:
                 - name: SERVICE_UNDERPROVISIONED_THRESHOLD
                   value: "92"
                 - name: SERVICE_ENABLE_THORAS_SCALING_THORAS_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_THORAS_SCALING_THORAS_MODE
                   value: recommendation
                 - name: SERVICE_THORAS_SCALING_THORAS_UPDATE_MODE

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -45,7 +45,7 @@ featureFlags:
   # When enabled, AST scale mode may be configured via API
   enableUpdateScaleModeApi: false
   thorasManageThoras:
-    enabled: false
+    enabled: true
     # Recommendation Mode by default
     mode: "recommendation"
     updateMode: "in_place_or_recreate"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -45,7 +45,7 @@ featureFlags:
   # When enabled, AST scale mode may be configured via API
   enableUpdateScaleModeApi: false
   thorasManageThoras:
-    enabled: true
+    enabled: false
     # Recommendation Mode by default
     mode: "recommendation"
     updateMode: "in_place_or_recreate"


### PR DESCRIPTION
# What's changing and why?
Turn feature flag `thorasManageThoras` to enabled by default. Mode stays as recommendation, so suggestions will be made but no vertical scaling actions will be taken.