### PR TITLE
feat: add cert-manager support for webhook certs

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -50,10 +50,17 @@ spec:
             defaultMode: 420
             secretName: thoras-tls-certs
             items:
+              {{- if .Values.thorasOperator.webhookCertGen.certManager.enabled }}
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+              {{- else }}
               - key: cert
                 path: tls.crt
               - key: key
                 path: tls.key
+              {{- end }}
       initContainers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasOperator.imageTag }}
         name: wait-for-api-service

--- a/charts/thoras/templates/operator/webhooks-certgen-clusterrole.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.thorasOperator.webhookCertGen.certManager.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -19,3 +20,4 @@ rules:
     verbs:
       - get
       - update
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-clusterrolebinding.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.thorasOperator.webhookCertGen.certManager.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -18,3 +19,4 @@ subjects:
   - kind: ServiceAccount
     name: thoras-tls-certsgen
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-create.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-create.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.thorasOperator.webhookCertGen.certManager.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -48,3 +49,4 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-network-policy.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled (not .Values.thorasOperator.webhookCertGen.certManager.enabled) }}
 {{- if eq .Values.networkPolicy.flavor "kubernetes" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.thorasOperator.webhookCertGen.certManager.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -98,3 +99,4 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-registry-secret.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-registry-secret.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.imageCredentials.password .Values.imageCredentials.secretRef }}
 {{- fail "Error: Both '.Values.imageCredentials.password' and '.Values.imageCredentials.secretRef' are set, but only one should be defined" }}
 {{- end }}
-{{- if .Values.imageCredentials.password }}
+{{- if and .Values.imageCredentials.password (not .Values.thorasOperator.webhookCertGen.certManager.enabled) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/thoras/templates/operator/webhooks-certgen-role.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-role.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.thorasOperator.webhookCertGen.certManager.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -19,3 +20,4 @@ rules:
     verbs:
       - get
       - create
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-rolebinding.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.thorasOperator.webhookCertGen.certManager.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -19,3 +20,4 @@ subjects:
   - kind: ServiceAccount
     name: thoras-tls-certsgen
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certgen-serviceaccount.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.thorasOperator.webhookCertGen.certManager.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,3 +12,4 @@ metadata:
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
     app.kubernetes.io/component: webhook-certgen
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks-certmanager.yaml
+++ b/charts/thoras/templates/operator/webhooks-certmanager.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.thorasOperator.webhookCertGen.certManager.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: thoras-webhooks-selfsigned
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
+    app.kubernetes.io/component: webhook-certgen
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: thoras-tls-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
+    app.kubernetes.io/component: webhook-certgen
+spec:
+  secretName: thoras-tls-certs
+  dnsNames:
+    - thoras-webhooks
+    - thoras-webhooks.{{ .Release.Namespace }}
+    - thoras-webhooks.{{ .Release.Namespace }}.svc
+    - thoras-webhooks.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: thoras-webhooks-selfsigned
+    kind: Issuer
+{{- end }}

--- a/charts/thoras/templates/operator/webhooks.yaml
+++ b/charts/thoras/templates/operator/webhooks.yaml
@@ -3,6 +3,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: "pods.thoras.ai"
+  {{- if .Values.thorasOperator.webhookCertGen.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/thoras-tls-certs
+  {{- end }}
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
 webhooks:
@@ -55,6 +59,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: "validation.thoras.ai"
+  {{- if .Values.thorasOperator.webhookCertGen.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/thoras-tls-certs
+  {{- end }}
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
 webhooks:

--- a/charts/thoras/tests/webhooks_certgen_test.yaml
+++ b/charts/thoras/tests/webhooks_certgen_test.yaml
@@ -163,3 +163,171 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: kube-webhook-certgen:v2.0.0$
+
+  ############################
+  # cert-manager mode
+  ############################
+  - it: Skips certgen create Job when cert-manager is enabled
+    template: operator/webhooks-certgen-create.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen patch Jobs when cert-manager is enabled
+    template: operator/webhooks-certgen-patch.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen ServiceAccount when cert-manager is enabled
+    template: operator/webhooks-certgen-serviceaccount.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen ClusterRole when cert-manager is enabled
+    template: operator/webhooks-certgen-clusterrole.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen ClusterRoleBinding when cert-manager is enabled
+    template: operator/webhooks-certgen-clusterrolebinding.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen Role when cert-manager is enabled
+    template: operator/webhooks-certgen-role.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen RoleBinding when cert-manager is enabled
+    template: operator/webhooks-certgen-rolebinding.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen registry pull secret when cert-manager is enabled
+    template: operator/webhooks-certgen-registry-secret.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+      imageCredentials.password: "test-password"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Skips certgen NetworkPolicy when cert-manager is enabled
+    template: operator/webhooks-certgen-network-policy.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Omits cert-manager Issuer and Certificate by default
+    template: operator/webhooks-certmanager.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Creates self-signed Issuer and Certificate when cert-manager is enabled
+    template: operator/webhooks-certmanager.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Issuer
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: thoras-webhooks-selfsigned
+        documentIndex: 0
+      - exists:
+          path: spec.selfSigned
+        documentIndex: 0
+      - isKind:
+          of: Certificate
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: thoras-tls-certs
+        documentIndex: 1
+      - equal:
+          path: spec.secretName
+          value: thoras-tls-certs
+        documentIndex: 1
+      - equal:
+          path: spec.issuerRef.name
+          value: thoras-webhooks-selfsigned
+        documentIndex: 1
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+        documentIndex: 1
+      - contains:
+          path: spec.dnsNames
+          content: thoras-webhooks
+        documentIndex: 1
+      - contains:
+          path: spec.dnsNames
+          content: thoras-webhooks.NAMESPACE.svc
+        documentIndex: 1
+
+  - it: Annotates webhook configs with cert-manager inject-ca-from when enabled
+    template: operator/webhooks.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+          value: NAMESPACE/thoras-tls-certs
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+          value: NAMESPACE/thoras-tls-certs
+        documentIndex: 1
+
+  - it: Does not add inject-ca-from annotation when cert-manager is disabled
+    template: operator/webhooks.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+        documentIndex: 0
+      - notExists:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+        documentIndex: 1
+
+  - it: Operator deployment volume uses tls.crt/tls.key keys when cert-manager is enabled
+    template: operator/deployment.yaml
+    set:
+      thorasOperator.webhookCertGen.certManager.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes[?(@.name == 'tls')].secret.items
+          content:
+            key: tls.crt
+            path: tls.crt
+      - contains:
+          path: spec.template.spec.volumes[?(@.name == 'tls')].secret.items
+          content:
+            key: tls.key
+            path: tls.key

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -159,6 +159,12 @@ thorasOperator:
   # Webhook certificate generation configuration
   webhookCertGen:
     imageTag: v1.4.4
+    # When enabled, cert-manager provisions the thoras-tls-certs secret and
+    # injects the CA bundle into the webhook configurations. The bundled
+    # kube-webhook-certgen Jobs (and their RBAC/NetworkPolicy/registry secret)
+    # are skipped. Requires cert-manager to be installed in the cluster.
+    certManager:
+      enabled: false
   # namespaceSelector applied to all webhook configurations. Set to null when
   # using an admission enforcer (e.g. OPA Gatekeeper's admissionsenforcer) that
   # manages namespaceSelector itself, to avoid upgrade conflicts:


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Lets customers who already run cert-manager provision the operator webhook TLS certs through it instead of the bundled `kube-webhook-certgen` Jobs. This aligns with their existing PKI/rotation workflows and removes the certgen Jobs, RBAC, NetworkPolicy, and registry pull secret when not needed.

## What's changing?

- Add `thorasOperator.webhookCertGen.certManager.enabled` (default `false`)
- When disabled: create a self-signed `Issuer` + `Certificate` producing the `thoras-tls-certs` secret and annotate the webhook configs with `cert-manager.io/inject-ca-from`
- When enabled: skip the certgen Job, ServiceAccount, Roles/Bindings, NetworkPolicy, and registry pull secret
- Operator deployment mounts `tls.crt`/`tls.key` keys (cert-manager's secret layout) in this mode

## How Tested

Added Helm unit tests covering both modes: cert-manager objects are absent by default, all certgen resources are skipped when enabled, webhook configs get the inject-ca annotation, and the operator volume references the correct secret keys.
