### PR TITLE
Release 4.124.0

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.123.0
+version: 4.124.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.123.0](https://img.shields.io/badge/Version-4.123.0-informational?style=flat-square) ![AppVersion: 4.101.0](https://img.shields.io/badge/AppVersion-4.101.0-informational?style=flat-square)
+![Version: 4.124.0](https://img.shields.io/badge/Version-4.124.0-informational?style=flat-square) ![AppVersion: 4.101.0](https://img.shields.io/badge/AppVersion-4.101.0-informational?style=flat-square)
 
 # Installs
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Releases chart version 4.124.0, making cert-manager support for webhook certificate generation available to customers installing the Thoras platform.

## What's changing?

- Bump chart `version` to 4.124.0 in `Chart.yaml`
- Update README version badge to 4.124.0
- Bundles PR #741 (cert-manager support for webhook certs)

## How Tested

Helm unit tests pass in CI. Chart version follows existing release pattern.