### PR TITLE
Add observation modes to CRD enums

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -556,6 +556,8 @@ spec:
                     - recommendation
                     - recommend
                     - rec
+                    - observe
+                    - observation
                     type: string
                   scaling_behavior:
                     description: Rules for how large a proposed scale event must be
@@ -955,6 +957,8 @@ spec:
                     - recommendation
                     - recommend
                     - rec
+                    - observe
+                    - observation
                     type: string
                   oom_remediation:
                     description: |-

--- a/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
+++ b/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
@@ -634,6 +634,8 @@ spec:
                         - recommendation
                         - recommend
                         - rec
+                        - observe
+                        - observation
                         type: string
                       scaling_behavior:
                         description: Rules for how large a proposed scale event must
@@ -977,6 +979,8 @@ spec:
                         - recommendation
                         - recommend
                         - rec
+                        - observe
+                        - observation
                         type: string
                       oom_remediation:
                         description: |-


### PR DESCRIPTION
# What's changing and why?

Adds `observe` and `observation` as valid enum values for the `mode` field in `AIScaleTarget` and `ClusterAIScaleTemplate` CRDs, enabling observation-only scaling behavior.

**How tested:** Manual review of CRD enum values.