### PR TITLE
Remove enableMigrationOnStartup feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -83,7 +83,6 @@ The following flags are considered temporary and gate access to specific behavio
 | Key                                            | Type    | Default | Description                                                |
 | ---------------------------------------------- | ------- | ------- | ---------------------------------------------------------- |
 | featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                        |
-| featureFlags.enableMigrationOnStartup          | Boolean | true    | If true, the main container handles migrations             |
 | featureFlags.enableCostSavingsSettingsRefresh  | Boolean | true    | If true, refreshes the costs savings settings periodically |
 | featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects   |
 | featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations             |

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -50,68 +50,6 @@ spec:
       - name: system-config
         configMap:
           name: thoras-operator-system-config
-      {{- if .Values.featureFlags.enableMigrationOnStartup }}
-      {{- else }}
-      initContainers:
-      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
-        name: wait-for-postgres
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
-        env:
-          - name: DATABASE_HOST
-            valueFrom:
-              secretKeyRef:
-              {{- if .Values.externalTimescale.secretRefName }}
-                name: {{ .Values.externalTimescale.secretRefName }}
-                key: {{ .Values.externalTimescale.secretRefKey }}
-              {{- else }}
-                name: thoras-timescale-password
-                key: host
-              {{- end }}
-          - name: DATABASE_URL
-          {{- if include "thoras.externalTimescaleEnabled" . }}
-            value: "$(DATABASE_HOST)"
-          {{- else }}
-            value: "$(DATABASE_HOST)/thoras?sslmode=disable"
-          {{- end }}
-          - name: EXTENSION_VERSION
-            value: "{{ .Values.metricsCollector.timescale.extensionVersion }}"
-          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            retries=0
-            max_retries=48
-            until [ $retries -ge $max_retries ]; do
-              if pg_isready -q -d ${DATABASE_URL}; then
-                break
-              else
-                echo "postgres not ready"
-                retries=$((retries+1))
-                sleep 5
-              fi
-            done
-            if [ $retries -ge $max_retries ]; then
-              echo "Failed to connect to database after $max_retries retries"
-              exit 1
-            fi
-        {{- if not (include "thoras.externalTimescaleEnabled" .) }}
-
-            # Update the timescale extension first
-            # Validate version format (only allow alphanumeric, dots, and hyphens)
-            if ! echo "$EXTENSION_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "Invalid extension version format: $EXTENSION_VERSION"
-              exit 1
-            fi
-            /usr/bin/psql $DATABASE_URL -c "ALTER EXTENSION timescaledb UPDATE TO '$EXTENSION_VERSION';"
-        {{- end }}
-
-            # run any migrations, accounting for upgrade/downgrade scenarios
-            ./scripts/migrate_database.sh
-        resources: {}
-      {{- end }}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasApiServerV2.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -192,8 +130,6 @@ spec:
             value: "{{ .Values.thorasForecast.minLookbackToScale | default "3h" }}"
           - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
             value: {{ .Values.featureFlags.enablePrometheusMetricScraping | quote }}
-          - name: SERVICE_ENABLE_MIGRATION_ON_START
-            value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_CLOUD_SYNC
           {{- if (and .Values.cloudSync.baseUrl .Values.cloudSync.clusterKeyID)}}
             value: "true"

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -160,6 +160,8 @@ spec:
             value: {{ .Values.featureFlags.enableUpdateScaleModeApi | ternary "true" "false" | quote }}
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
+          - name: SERVICE_SHOULD_MIGRATE_ON_START
+            value: true
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -158,10 +158,10 @@ spec:
             value: {{ .Values.featureFlags.enablePgLargeObjectStorage | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_UPDATE_SCALE_MODE_API
             value: {{ .Values.featureFlags.enableUpdateScaleModeApi | ternary "true" "false" | quote }}
-          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_SHOULD_MIGRATE_ON_START
             value: true
+          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -193,8 +193,6 @@ spec:
           {{- end }}
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.thorasOperator.pprof.enabled | quote }}
-          - name: SERVICE_ENABLE_MIGRATION_ON_START
-            value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -193,10 +193,10 @@ spec:
           {{- end }}
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.thorasOperator.pprof.enabled | quote }}
-          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_SHOULD_MIGRATE_ON_START
             value: true
+          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -195,6 +195,8 @@ spec:
             value: {{ .Values.thorasOperator.pprof.enabled | quote }}
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
+          - name: SERVICE_SHOULD_MIGRATE_ON_START
+            value: true
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -166,10 +166,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_SHOULD_MIGRATE_ON_START
             value: true
+          - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+            value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -168,6 +168,8 @@ spec:
                 fieldPath: metadata.name
           - name: SERVICE_TIMESCALE_EXTENSION_VERSION
             value: {{ .Values.metricsCollector.timescale.extensionVersion | quote }}
+          - name: SERVICE_SHOULD_MIGRATE_ON_START
+            value: true
           - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -48,68 +48,6 @@ spec:
       - name: monitor-config
         configMap:
           name: thoras-monitor-config
-      {{- if .Values.featureFlags.enableMigrationOnStartup }}
-      {{- else }}
-      initContainers:
-      - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasWorker.imageTag }}
-        name: wait-for-postgres
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
-        env:
-          - name: DATABASE_HOST
-            valueFrom:
-              secretKeyRef:
-              {{- if .Values.externalTimescale.secretRefName }}
-                name: {{ .Values.externalTimescale.secretRefName }}
-                key: {{ .Values.externalTimescale.secretRefKey }}
-              {{- else }}
-                name: thoras-timescale-password
-                key: host
-              {{- end }}
-          - name: DATABASE_URL
-          {{- if include "thoras.externalTimescaleEnabled" . }}
-            value: "$(DATABASE_HOST)"
-          {{- else }}
-            value: "$(DATABASE_HOST)/thoras?sslmode=disable"
-          {{- end }}
-          - name: EXTENSION_VERSION
-            value: "{{ .Values.metricsCollector.timescale.extensionVersion }}"
-          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            retries=0
-            max_retries=48
-            until [ $retries -ge $max_retries ]; do
-              if pg_isready -q -d ${DATABASE_URL}; then
-                break
-              else
-                echo "postgres not ready"
-                retries=$((retries+1))
-                sleep 5
-              fi
-            done
-            if [ $retries -ge $max_retries ]; then
-              echo "Failed to connect to database after $max_retries retries"
-              exit 1
-            fi
-        {{- if not (include "thoras.externalTimescaleEnabled" .) }}
-
-            # Update the timescale extension first
-            # Validate version format (only allow alphanumeric, dots, and hyphens)
-            if ! echo "$EXTENSION_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "Invalid extension version format: $EXTENSION_VERSION"
-              exit 1
-            fi
-            /usr/bin/psql $DATABASE_URL -c "ALTER EXTENSION timescaledb UPDATE TO '$EXTENSION_VERSION';"
-        {{- end }}
-
-            # run any migrations, accounting for upgrade/downgrade scenarios
-            ./scripts/migrate_database.sh
-        resources: {}
-      {{- end }}
       containers:
       - image: {{ .Values.imageCredentials.registry }}/services:{{ default .Values.thorasVersion .Values.thorasWorker.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -220,8 +158,6 @@ spec:
             value: {{ .Values.featureFlags.enableCostSavingsSettingsRefresh | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
             value: {{ .Values.featureFlags.enableMonitorActiveSuggestionFromCRD | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_MIGRATION_ON_START
-            value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
             value: {{ .Values.featureFlags.enableDeploymentMonitor | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -81,8 +81,6 @@ Default matches snapshot:
                   value: 3h
                 - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
                   value: "false"
-                - name: SERVICE_ENABLE_MIGRATION_ON_START
-                  value: "true"
                 - name: SERVICE_ENABLE_CLOUD_SYNC
                   value: "false"
                 - name: SERVICE_CLOUD_SYNC_CLUSTER_KEY_ID
@@ -1245,8 +1243,6 @@ Default matches snapshot:
                       name: thoras-cloud-sync
                 - name: SERVICE_ENABLE_PPROF
                   value: "false"
-                - name: SERVICE_ENABLE_MIGRATION_ON_START
-                  value: "true"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.27.0
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
@@ -1622,8 +1618,6 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
                   value: "false"
-                - name: SERVICE_ENABLE_MIGRATION_ON_START
-                  value: "true"
                 - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
                   value: "true"
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -98,6 +98,8 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.27.0
+                - name: SERVICE_SHOULD_MIGRATE_ON_START
+                  value: true
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -976,8 +978,8 @@ Default matches snapshot:
                   value: http://thoras-api-server-v2
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "true"
-                - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
-                  value: "true"
+                - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
+                  value: "false"
                 - name: SERVICE_CHART_VERSION
                   value: 4.7.0
                 - name: SERVICE_PLATFORM_VERSION
@@ -1245,6 +1247,8 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.27.0
+                - name: SERVICE_SHOULD_MIGRATE_ON_START
+                  value: true
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -1255,6 +1259,10 @@ Default matches snapshot:
                   value: "60"
                 - name: SERVICE_UNDERPROVISIONED_THRESHOLD
                   value: "92"
+                - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
+                  value: "false"
+                - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -1577,8 +1585,8 @@ Default matches snapshot:
                   value: TEST
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "true"
-                - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
-                  value: "true"
+                - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
+                  value: "false"
                 - name: SERVICE_COLLECTOR_MEM_REQUEST
                   value: 3072Mi
                 - name: SERVICE_PORT
@@ -1614,12 +1622,8 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
                   value: "true"
-                - name: SERVICE_ENABLE_COST_SAVINGS_SETTINGS_REFRESH
-                  value: "true"
                 - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
                   value: "false"
-                - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
-                  value: "true"
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "true"
                 - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL
@@ -1632,6 +1636,8 @@ Default matches snapshot:
                       fieldPath: metadata.name
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
                   value: 2.27.0
+                - name: SERVICE_SHOULD_MIGRATE_ON_START
+                  value: true
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -1697,7 +1703,7 @@ Default matches snapshot:
                 - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_OOM_REMEDIATION_ENABLED
                   value: "true"
                 - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL
                   value: 1m
                 - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME
@@ -1710,6 +1716,8 @@ Default matches snapshot:
                   value: "100"
                 - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
                   value: "67"
+                - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -1791,6 +1799,18 @@ Default matches snapshot:
           - get
           - create
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - pods/resize
+        verbs:
+          - patch
   35: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -1851,6 +1871,49 @@ Default matches snapshot:
         name: thoras-worker
         namespace: foo
   38: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: thoras
+        globalLabel: globalValue
+        helm.sh/chart: thoras-4.7.0
+      name: thoras-worker-forecast-scaler
+      namespace: foo
+    rules:
+      - apiGroups:
+          - apps
+        resourceNames:
+          - thoras-forecast-worker
+        resources:
+          - deployments/scale
+        verbs:
+          - get
+          - update
+          - patch
+  39: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: thoras
+        globalLabel: globalValue
+        helm.sh/chart: thoras-4.7.0
+      name: thoras-worker-forecast-scaler
+      namespace: foo
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: thoras-worker-forecast-scaler
+    subjects:
+      - kind: ServiceAccount
+        name: thoras-worker
+        namespace: foo
+  40: |
     apiVersion: v1
     imagePullSecrets:
       - name: test-secret-registry
@@ -1864,7 +1927,7 @@ Default matches snapshot:
         helm.sh/chart: thoras-4.7.0
       name: thoras-worker
       namespace: foo
-  39: |
+  41: |
     apiVersion: v1
     kind: Service
     metadata:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -96,10 +96,10 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_UPDATE_SCALE_MODE_API
                   value: "false"
-                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.27.0
                 - name: SERVICE_SHOULD_MIGRATE_ON_START
                   value: true
+                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+                  value: 2.27.0
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -1245,10 +1245,10 @@ Default matches snapshot:
                       name: thoras-cloud-sync
                 - name: SERVICE_ENABLE_PPROF
                   value: "false"
-                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.27.0
                 - name: SERVICE_SHOULD_MIGRATE_ON_START
                   value: true
+                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+                  value: 2.27.0
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -1634,10 +1634,10 @@ Default matches snapshot:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.27.0
                 - name: SERVICE_SHOULD_MIGRATE_ON_START
                   value: true
+                - name: SERVICE_TIMESCALE_EXTENSION_VERSION
+                  value: 2.27.0
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -104,17 +104,6 @@ tests:
       - equal:
           path: spec.template.metadata.annotations["custom-annotation"]
           value: "test-value"
-  - it: Should ensure default extensionVersion is substring of default imageTag
-    set:
-      featureFlags:
-        enableMigrationOnStartup: false
-      metricsCollector:
-        timescale:
-          extensionVersion: "2.27.0"
-    asserts:
-      - equal:
-          path: spec.template.spec.initContainers[0].env[?(@.name == 'EXTENSION_VERSION')].value
-          value: "2.27.0"
   - it: Should enable request and limit overrides
     set:
       thorasApiServerV2:

--- a/charts/thoras/tests/worker_deployment_test.yaml
+++ b/charts/thoras/tests/worker_deployment_test.yaml
@@ -56,17 +56,6 @@ tests:
       - equal:
           path: spec.template.metadata.annotations["custom-annotation"]
           value: "test-value"
-  - it: Should ensure default extensionVersion is substring of default imageTag
-    set:
-      featureFlags:
-        enableMigrationOnStartup: false
-      metricsCollector:
-        timescale:
-          extensionVersion: "2.27.0"
-    asserts:
-      - equal:
-          path: spec.template.spec.initContainers[0].env[?(@.name == 'EXTENSION_VERSION')].value
-          value: "2.27.0"
   - it: Cloud sync is disabled by default
     asserts:
       - equal:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -55,7 +55,6 @@ featureFlags:
       forecastBlocks: "4h0s"
       # Forecast once per hour by default
       forecastCron: "17 * * * *"
-  enableMigrationOnStartup: true
   enableCostSavingsSettingsRefresh: true
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false


### PR DESCRIPTION
# What's changing and why?

The `enableMigrationOnStartup` flag has been permanently `true` and is no longer needed. Removing the flag, the now-dead `wait-for-postgres` init containers, and the related env vars from api-server, worker, and operator deployments.