### PR TITLE
Remove enableCostSavingsSettingsRefresh feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -80,15 +80,14 @@ helm install \
 
 The following flags are considered temporary and gate access to specific behaviors that still undergoing testing before general availability.
 
-| Key                                            | Type    | Default | Description                                                |
-| ---------------------------------------------- | ------- | ------- | ---------------------------------------------------------- |
-| featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                        |
-| featureFlags.enableMigrationOnStartup          | Boolean | true    | If true, the main container handles migrations             |
-| featureFlags.enableCostSavingsSettingsRefresh  | Boolean | true    | If true, refreshes the costs savings settings periodically |
-| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects   |
-| featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations             |
-| featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations  |
-| featureFlags.enableMemoryLimit                 | Boolean | true    | If true, enables dynamic GOMEMLIMIT                        |
+| Key                                            | Type    | Default | Description                                               |
+| ---------------------------------------------- | ------- | ------- | --------------------------------------------------------- |
+| featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                       |
+| featureFlags.enableMigrationOnStartup          | Boolean | true    | If true, the main container handles migrations            |
+| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects  |
+| featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
+| featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
+| featureFlags.enableMemoryLimit                 | Boolean | true    | If true, enables dynamic GOMEMLIMIT                       |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -216,8 +216,6 @@ spec:
             value: {{ .Values.featureFlags.enableNodeDetailsCollector | ternary "true" "false" | quote}}
           - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
             value: "true"
-          - name: SERVICE_ENABLE_COST_SAVINGS_SETTINGS_REFRESH
-            value: {{ .Values.featureFlags.enableCostSavingsSettingsRefresh | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
             value: {{ .Values.featureFlags.enableMonitorActiveSuggestionFromCRD | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MIGRATION_ON_START

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1618,8 +1618,6 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
                   value: "true"
-                - name: SERVICE_ENABLE_COST_SAVINGS_SETTINGS_REFRESH
-                  value: "true"
                 - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
                   value: "false"
                 - name: SERVICE_ENABLE_MIGRATION_ON_START

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -56,7 +56,6 @@ featureFlags:
       # Forecast once per hour by default
       forecastCron: "17 * * * *"
   enableMigrationOnStartup: true
-  enableCostSavingsSettingsRefresh: true
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false
   enableDeploymentMonitor: true


### PR DESCRIPTION
# What's changing and why?

Removes the `enableCostSavingsSettingsRefresh` feature flag (always-on). Drops the values entry, worker env var, README row, and snapshot.