### PR TITLE
Remove inactive flags, enable deployment monitor worker

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -251,6 +251,7 @@ must be pre-installed and managed externally.
 | thorasWorker.prometheus.enabled                      | Boolean | true          | Enables a prometheus metric exporter                         |
 | thorasWorker.prometheus.port                         | Number  | 9102          | Port for the prometheus metric exporter                      |
 | thorasWorker.enableMetricIntegrityWorker             | Boolean | false         | Enable metric integrity worker                               |
+| thorasWorker.enableDeploymentMonitorWorker           | Boolean | false         | Enable deployment monitor worker                             |
 | thorasWorker.enableMonitorActiveSuggestionFromCRD    | Boolean | false         | Enable monitoring active suggestions using the AST           |
 | thorasWorker.maxTimeseriesMetricCacheSizeMb          | Number  | 1000          | Configure cache size that triggers LRU eviction              |
 | thorasWorker.enableUnifiedAstUtilizationMonitor      | Boolean | false         | Enable the unified AST utilization monitor                   |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -251,7 +251,6 @@ must be pre-installed and managed externally.
 | thorasWorker.prometheus.enabled                      | Boolean | true          | Enables a prometheus metric exporter                         |
 | thorasWorker.prometheus.port                         | Number  | 9102          | Port for the prometheus metric exporter                      |
 | thorasWorker.enableMetricIntegrityWorker             | Boolean | false         | Enable metric integrity worker                               |
-| thorasWorker.enableActiveSuggestionWorker            | Boolean | true          | Enable active suggestions worker                             |
 | thorasWorker.enableMonitorActiveSuggestionFromCRD    | Boolean | false         | Enable monitoring active suggestions using the AST           |
 | thorasWorker.maxTimeseriesMetricCacheSizeMb          | Number  | 1000          | Configure cache size that triggers LRU eviction              |
 | thorasWorker.enableUnifiedAstUtilizationMonitor      | Boolean | false         | Enable the unified AST utilization monitor                   |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -250,7 +250,7 @@ must be pre-installed and managed externally.
 | thorasWorker.queriesPerSecond                        | String  | "50"          | Sets a maximum threshold for K8s API qps                     |
 | thorasWorker.prometheus.enabled                      | Boolean | true          | Enables a prometheus metric exporter                         |
 | thorasWorker.prometheus.port                         | Number  | 9102          | Port for the prometheus metric exporter                      |
-| thorasWorker.enableMetricIntegrityWorker             | Boolean | false         | Enable metric integrity worker                               |
+| thorasWorker.enableMetricIntegrityWorker             | Boolean | true          | Enable metric integrity worker                               |
 | thorasWorker.enableDeploymentMonitorWorker           | Boolean | false         | Enable deployment monitor worker                             |
 | thorasWorker.enableMonitorActiveSuggestionFromCRD    | Boolean | false         | Enable monitoring active suggestions using the AST           |
 | thorasWorker.maxTimeseriesMetricCacheSizeMb          | Number  | 1000          | Configure cache size that triggers LRU eviction              |

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -78,6 +78,8 @@ spec:
             value: "http://thoras-api-server-v2"
           - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
             value: {{ .Values.thorasWorker.enableMetricIntegrityWorker | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
+            value: {{ .Values.thorasWorker.enableDeploymentMonitorWorker | ternary "true" "false" | quote }}
           - name: SERVICE_CHART_VERSION
             value: {{ .Chart.Version | quote }}
           - name: SERVICE_PLATFORM_VERSION

--- a/charts/thoras/templates/monitor/deployment.yaml
+++ b/charts/thoras/templates/monitor/deployment.yaml
@@ -78,8 +78,6 @@ spec:
             value: "http://thoras-api-server-v2"
           - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
             value: {{ .Values.thorasWorker.enableMetricIntegrityWorker | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
-            value: {{ .Values.thorasWorker.enableActiveSuggestionWorker | ternary "true" "false" | quote }}
           - name: SERVICE_CHART_VERSION
             value: {{ .Chart.Version | quote }}
           - name: SERVICE_PLATFORM_VERSION

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -170,6 +170,8 @@ spec:
           {{- end }}
           - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
             value: {{ .Values.thorasWorker.enableMetricIntegrityWorker | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
+            value: {{ .Values.thorasWorker.enableDeploymentMonitorWorker | ternary "true" "false" | quote }}
           - name: SERVICE_COLLECTOR_MEM_REQUEST
             value: "{{ .Values.metricsCollector.timescale.requests.memory | default "3072Mi" }}"
           - name: SERVICE_PORT

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -170,8 +170,6 @@ spec:
           {{- end }}
           - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
             value: {{ .Values.thorasWorker.enableMetricIntegrityWorker | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
-            value: {{ .Values.thorasWorker.enableActiveSuggestionWorker | ternary "true" "false" | quote }}
           - name: SERVICE_COLLECTOR_MEM_REQUEST
             value: "{{ .Values.metricsCollector.timescale.requests.memory | default "3072Mi" }}"
           - name: SERVICE_PORT

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -978,8 +978,6 @@ Default matches snapshot:
                   value: http://thoras-api-server-v2
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "true"
-                - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
-                  value: "true"
                 - name: SERVICE_CHART_VERSION
                   value: 4.7.0
                 - name: SERVICE_PLATFORM_VERSION
@@ -1580,8 +1578,6 @@ Default matches snapshot:
                 - name: SERVICE_PLATFORM_VERSION
                   value: TEST
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
-                  value: "true"
-                - name: SERVICE_ENABLE_ACTIVE_SUGGESTION_WORKER
                   value: "true"
                 - name: SERVICE_COLLECTOR_MEM_REQUEST
                   value: 3072Mi

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -978,6 +978,8 @@ Default matches snapshot:
                   value: http://thoras-api-server-v2
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "true"
+                - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
+                  value: "false"
                 - name: SERVICE_CHART_VERSION
                   value: 4.7.0
                 - name: SERVICE_PLATFORM_VERSION
@@ -1579,6 +1581,8 @@ Default matches snapshot:
                   value: TEST
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "true"
+                - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
+                  value: "false"
                 - name: SERVICE_COLLECTOR_MEM_REQUEST
                   value: 3072Mi
                 - name: SERVICE_PORT

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -349,6 +349,7 @@ thorasWorker:
   enableAstViewCacheRefreshWorker: true
   enableAstViewCacheStateReconcilerWorker: true
   enableMetricIntegrityWorker: true
+  enableDeploymentMonitorWorker: false
   enableUnifiedAstUtilizationMonitor: true
   forecastJobTimeoutInterval: "2m"
   trainJobTimeoutInterval: "10m"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -349,7 +349,6 @@ thorasWorker:
   enableAstViewCacheRefreshWorker: true
   enableAstViewCacheStateReconcilerWorker: true
   enableMetricIntegrityWorker: true
-  enableActiveSuggestionWorker: true
   enableUnifiedAstUtilizationMonitor: true
   forecastJobTimeoutInterval: "2m"
   trainJobTimeoutInterval: "10m"


### PR DESCRIPTION
# What's changing and why?

- Remove unused `enableActiveSuggestionWorker` flag (removed from platform)
- Add `enableDeploymentMonitorWorker` flag (default: false)