### PR TITLE
feat: add disruption scheduler worker flag and AST disruption controls

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -676,6 +676,11 @@ spec:
                     x-kubernetes-int-or-string: true
                   metrics:
                     additionalProperties:
+                      description: |-
+                        Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                        The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                        because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                        That check is handled by the admission webhook, which has full context.
                       properties:
                         forecast_buffer_percentage:
                           description: Buffer percentage for this metric. Overrides
@@ -940,6 +945,45 @@ spec:
                         rule: '!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
                           || (has(self.memory) && has(self.memory.limit))'
                     type: array
+                  disruption:
+                    description: |-
+                      Disruption controls how aggressively Thoras evicts pods when applying
+                      vertical recommendations that require pod recreation.
+                    properties:
+                      interval:
+                        default: 60s
+                        description: |-
+                          Interval is the minimum duration the operator waits after a batch of
+                          evictions before evicting the next batch. Defaults to 60s.
+                        type: string
+                      max_disrupted:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 20%
+                        description: |-
+                          MaxDisrupted is the maximum number of pods that may be
+                          disrupted at once across the workload. A pod is "disrupted" if it is
+                          terminating or its Ready condition is not True. The operator only
+                          evicts up to the remaining headroom in each batch, so prior batches
+                          that haven't finished rolling reduce the next batch's size. After
+                          issuing a batch, the operator waits Interval before issuing the next
+                          batch. Unlike PodDisruptionBudget.maxUnavailable, this cap is enforced
+                          by the operator itself: pods that are unavailable for reasons
+                          unrelated to Thoras (e.g. failing readiness probes) still consume the
+                          budget.
+
+                          Accepts an absolute integer (e.g. 2) or a percentage of the workload's
+                          desired replicas (e.g. "25%"). Defaults to 20%.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                    x-kubernetes-validations:
+                    - message: max_disrupted must be a positive integer or a percentage
+                        between 1% and 100%
+                      rule: '!has(self.max_disrupted) || (type(self.max_disrupted)
+                        == int ? self.max_disrupted >= 1 : self.max_disrupted.matches(''^([1-9][0-9]?|100)%$''))'
+                    - message: interval must be a positive duration
+                      rule: '!has(self.interval) || duration(self.interval) > duration(''0s'')'
                   in_place_resizing:
                     description: |-
                       Deprecated: Use UpdatePolicy instead.
@@ -1213,16 +1257,19 @@ spec:
                     format: date-time
                     type: string
                   forecastErrorGeneral:
-                    description: ForecastErrorGeneral is set when a general forecasting
-                      error occurred that blocks all scaling.
+                    description: |-
+                      ForecastErrorGeneral is set when a general forecasting error occurred that blocks all scaling.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
                     type: string
                   forecastErrorHorizontal:
-                    description: ForecastErrorHorizontal is set when a horizontal-specific
-                      forecasting error occurred.
+                    description: |-
+                      ForecastErrorHorizontal is set when a horizontal-specific forecasting error occurred.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
                     type: string
                   forecastErrorVertical:
-                    description: ForecastErrorVertical is set when a vertical-specific
-                      forecasting error occurred.
+                    description: |-
+                      ForecastErrorVertical is set when a vertical-specific forecasting error occurred.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
                     type: string
                   forecastedTotals:
                     description: ForecastedTotals contains predicted resource usage

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -207,6 +207,8 @@ spec:
             value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
           - name: SERVICE_UNDERPROVISIONED_THRESHOLD
             value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
+          - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
+            value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -340,6 +340,8 @@ spec:
             value: {{ .Values.thorasForecast.worker.scaler.maxReplicas | quote }}
           - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
             value: {{ .Values.thorasForecast.worker.scaler.astsPerReplica | quote }}
+          - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
+            value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1259,6 +1259,8 @@ Default matches snapshot:
                   value: "60"
                 - name: SERVICE_UNDERPROVISIONED_THRESHOLD
                   value: "92"
+                - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -1714,6 +1716,8 @@ Default matches snapshot:
                   value: "100"
                 - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
                   value: "67"
+                - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,6 +65,7 @@ featureFlags:
   enableInformersStripManagedFields: true
   enableTypedInformers: true
   enableMemoryLimit: true
+  enableDisruptionSchedulerWorker: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Enables customers to control how aggressively Thoras evicts pods when applying vertical recommendations, preventing excessive disruption during rollouts. The new disruption scheduler worker is gated behind a feature flag for safe rollout.

## What's changing?

- Add `featureFlags.enableDisruptionSchedulerWorker` (default `false`), wired into operator and worker deployments via `SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER`
- Add `disruption` block to AIScaleTarget CRD with `interval` (default 60s) and `max_disrupted` (default 20%) fields, plus CEL validations
- Update forecast error status fields to document required non-omitempty behavior
- Document CEL-validation boundary on metric percentile config

## How Tested

Updated snapshot tests pass (`helm unittest`). CRD changes verified by Helm template rendering.
