### PR TITLE
set thorasManageThoras default to autonomous

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1651,7 +1651,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_THORAS_SCALING_THORAS_WORKER
                   value: "true"
                 - name: SERVICE_THORAS_SCALING_THORAS_MODE
-                  value: recommendation
+                  value: autonomous
                 - name: SERVICE_THORAS_SCALING_THORAS_UPDATE_MODE
                   value: in_place_or_recreate
                 - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_UPDATE_MODE

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -46,14 +46,17 @@ featureFlags:
   enableUpdateScaleModeApi: false
   thorasManageThoras:
     enabled: true
-    # Recommendation Mode by default
-    mode: "recommendation"
+    mode: "autonomous"
     updateMode: "in_place_or_recreate"
     db:
       updateMode: "in_place_or_recreate"
       # Look 4h ahead by default
       forecastBlocks: "4h0s"
       # Forecast once per hour by default
+      #
+      # TODO: Consider using interval-based scheduling instead of cron
+      # to prevent the scenario where the no forecast is generated due to
+      # missed cron schedules (e.g. due to a restart).
       forecastCron: "17 * * * *"
   enableMigrationOnStartup: true
   enablePrometheusMetricScraping: false


### PR DESCRIPTION
# What's changing and why?
- Change the default thoras-scaling-thoras mode to autonomous so Thoras pods are automatically rightsized out-of-the-box.
- Comment that database forecasting should be migrated from cron based scheduling to interval based scheduling.

This PR can sit until we are ready to cut over to autoscaling Thoras workloads by default. I am not aware of any blockers for cutting over, but we should make the default behavior change clear to customers in release notes.