### PR TITLE
Add RBAC rules for pod eviction and resizing

### DIFF
--- a/charts/thoras/templates/worker/rbac.yaml
+++ b/charts/thoras/templates/worker/rbac.yaml
@@ -29,6 +29,18 @@ rules:
   - get
   - create
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/resize
+  verbs:
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .rbacNamespace }}

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1799,6 +1799,18 @@ Default matches snapshot:
           - get
           - create
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - pods/resize
+        verbs:
+          - patch
   35: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Grants the worker the RBAC permissions needed to evict and in-place resize pods, enabling autonomous disruption/right-sizing actions to actually run instead of failing on forbidden API calls.

## What's changing?

- Add `create` on `pods/eviction` to the worker role
- Add `patch` on `pods/resize` to the worker role

## How Tested

Rendered the chart with `helm template` to confirm the role includes the new rules. Verified locally that the worker can evict and resize pods with these permissions.