### PR TITLE
feat: add USE_FORECASTER_COMPUTED_METRIC_ID env var to forecast worker

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -148,6 +148,7 @@ All components support `<component>.useGlobalAffinity` (default: `true`) and `<c
 | thorasForecast.ignoreNewPods           | Boolean  | true                   | Directs forecaster to adjust CPU and memory metrics temporarily for new pods                   |
 | thorasForecast.enableDecoupledTraining | Boolean  | true                   | Enables async training mode where forecasts report "needs_training" instead of training inline |
 | thorasForecast.useAstMetricsSeries     | Boolean  | false                  | Enables catalog-free training data fetching via the AST metrics series endpoint                |
+| thorasForecast.useForecasterComputedMetricId | Boolean  | false             | Computes legacy metric IDs locally in Python instead of fetching from the catalog              |
 | thorasForecast.worker.podAnnotations   | Object   | {}                     | Pod Annotations for Thoras Forecast                                                            |
 | thorasForecast.worker.labels           | Object   | {}                     | Pod labels for Thoras Forecast                                                                 |
 | thorasForecast.worker.replicas         | Number   | 1                      | Number of `thoras-forecast-worker` replicas to use                                             |

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -78,6 +78,8 @@ spec:
             value: {{ .Values.thorasForecast.enableDecoupledTraining | ternary "true" "false" | quote }}
           - name: USE_AST_METRICS_SERIES
             value: {{ .Values.thorasForecast.useAstMetricsSeries | ternary "true" "false" | quote }}
+          - name: USE_FORECASTER_COMPUTED_METRIC_ID
+            value: {{ .Values.thorasForecast.useForecasterComputedMetricId | ternary "true" "false" | quote }}
           - name: TRAINING_JITTER_MINUTES
             value: {{ .Values.thorasForecast.trainingJitterMinutes | quote }}
           - name: AFFINITY_ID

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -845,6 +845,8 @@ Default matches snapshot:
                   value: "true"
                 - name: USE_AST_METRICS_SERIES
                   value: "true"
+                - name: USE_FORECASTER_COMPUTED_METRIC_ID
+                  value: "false"
                 - name: TRAINING_JITTER_MINUTES
                   value: "0"
                 - name: AFFINITY_ID

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -306,6 +306,25 @@ tests:
             name: USE_AST_METRICS_SERIES
             value: "false"
 
+  - it: renders USE_FORECASTER_COMPUTED_METRIC_ID as false by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
+          content:
+            name: USE_FORECASTER_COMPUTED_METRIC_ID
+            value: "false"
+
+  - it: renders USE_FORECASTER_COMPUTED_METRIC_ID as true when useForecasterComputedMetricId is true
+    set:
+      thorasForecast:
+        useForecasterComputedMetricId: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
+          content:
+            name: USE_FORECASTER_COMPUTED_METRIC_ID
+            value: "true"
+
   - it: Should enable request and limit overrides
     set:
       thorasForecast:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -477,6 +477,7 @@ thorasForecast:
   enableDecoupledTraining: true
   trainingJitterMinutes: 0
   useAstMetricsSeries: true
+  useForecasterComputedMetricId: false
   # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
   minLookbackToScale: "3h"
   worker:


### PR DESCRIPTION
# What's changing and why?

Introducing new `USE_FORECASTER_COMPUTED_METRIC_ID` environment variable to the forecast worker, with possible values of true and false, defaulting to false.

When enabled alongside `USE_AST_METRICS_SERIES`, the forecaster computes legacy metric IDs locally in Python using the same hashing algorithm as Go's `MetricDefinition.Id()`, eliminating the catalog API call entirely. This is the final step in removing the forecaster's dependency on the catalog service.

[X] Do any feature flags need to be managed?

Yes, `thorasForecast.useForecasterComputedMetricId` in values.yaml (defaults to false, opt-in)