### PR TITLE
Enable deployment monitor worker

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -250,7 +250,7 @@ must be pre-installed and managed externally.
 | thorasWorker.prometheus.enabled                      | Boolean | true          | Enables a prometheus metric exporter                         |
 | thorasWorker.prometheus.port                         | Number  | 9102          | Port for the prometheus metric exporter                      |
 | thorasWorker.enableMetricIntegrityWorker             | Boolean | true          | Enable metric integrity worker                               |
-| thorasWorker.enableDeploymentMonitorWorker           | Boolean | false         | Enable deployment monitor worker                             |
+| thorasWorker.enableDeploymentMonitorWorker           | Boolean | true          | Enable deployment monitor worker                             |
 | thorasWorker.enableMonitorActiveSuggestionFromCRD    | Boolean | false         | Enable monitoring active suggestions using the AST           |
 | thorasWorker.maxTimeseriesMetricCacheSizeMb          | Number  | 1000          | Configure cache size that triggers LRU eviction              |
 | thorasWorker.enableUnifiedAstUtilizationMonitor      | Boolean | false         | Enable the unified AST utilization monitor                   |

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         {{- end }}
       {{- if or .Values.podAnnotations .Values.thorasWorker.prometheus.enabled .Values.thorasWorker.podAnnotations }}
       annotations:
+        {{- if not .Values.thorasMonitor.unittesting }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/monitor/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.thorasWorker.prometheus.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -979,7 +979,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "true"
                 - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_CHART_VERSION
                   value: 4.7.0
                 - name: SERVICE_PLATFORM_VERSION
@@ -1584,7 +1584,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_METRIC_INTEGRITY_WORKER
                   value: "true"
                 - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_COLLECTOR_MEM_REQUEST
                   value: 3072Mi
                 - name: SERVICE_PORT
@@ -1625,7 +1625,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_MIGRATION_ON_START
                   value: "true"
                 - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
-                  value: "true"
+                  value: "false"
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "true"
                 - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -58,7 +58,6 @@ featureFlags:
   enableMigrationOnStartup: true
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false
-  enableDeploymentMonitor: true
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastQueueStats: false

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -58,7 +58,7 @@ featureFlags:
   enableMigrationOnStartup: true
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false
-  enableDeploymentMonitor: true
+  enableDeploymentMonitor: false
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastQueueStats: false
@@ -349,7 +349,7 @@ thorasWorker:
   enableAstViewCacheRefreshWorker: true
   enableAstViewCacheStateReconcilerWorker: true
   enableMetricIntegrityWorker: true
-  enableDeploymentMonitorWorker: false
+  enableDeploymentMonitorWorker: true
   enableUnifiedAstUtilizationMonitor: true
   forecastJobTimeoutInterval: "2m"
   trainJobTimeoutInterval: "10m"


### PR DESCRIPTION
# What's changing and why?

Enabling the deployment monitor worker by default. This is the final monitor being migrated from the legacy monitor deployment.