### PR TITLE
Fix duplicate deployment monitor worker env var

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -220,8 +220,6 @@ spec:
             value: {{ .Values.featureFlags.enableMonitorActiveSuggestionFromCRD | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_MIGRATION_ON_START
             value: {{ .Values.featureFlags.enableMigrationOnStartup | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
-            value: {{ .Values.featureFlags.enableDeploymentMonitor | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
             value: {{ not .Values.featureFlags.enableForecastQueueStats | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1624,8 +1624,6 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_ENABLE_MIGRATION_ON_START
                   value: "true"
-                - name: SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER
-                  value: "true"
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "true"
                 - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -58,7 +58,6 @@ featureFlags:
   enableMigrationOnStartup: true
   enablePrometheusMetricScraping: false
   enableMonitorActiveSuggestionFromCRD: false
-  enableDeploymentMonitor: true
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastQueueStats: false


### PR DESCRIPTION
# What's changing and why?

## How this helps the customer

Fixes a `helm upgrade` failure. The worker deployment defined the env var `SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER` **twice** with different value sources, so the two entries rendered to conflicting values (`true`/`false`). Because Kubernetes keys env vars on a unique `name`, this broke upgrades with:

```
failed to create patch: The order in patch list ... doesn't match $setElementOrder list
```

(`SERVICE_ENABLE_DEPLOYMENT_MONITOR_WORKER` appears twice in the `$setElementOrder` list.)

## What's changing

- Remove the stale duplicate env entry backed by `featureFlags.enableDeploymentMonitor` (predates PR #749), keeping the canonical `thorasWorker.enableDeploymentMonitorWorker` — which the monitor deployment already uses.
- Drop the now-unused `featureFlags.enableDeploymentMonitor` value from `values.yaml`.

Note: the surviving flag defaults to `false`, so the deployment-monitor worker is now off by default unless `thorasWorker.enableDeploymentMonitorWorker` is set.

## Testing

- `helm unittest ./charts/thoras` — all 238 tests pass (one snapshot updated to drop the duplicate env). Verified the rendered worker manifest now contains a single occurrence.
- Updating minikube now successful