### PR TITLE
gate dashboard API calls via nginx allowlist

### DIFF
--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -22,6 +22,53 @@ data:
 
       include       mime.types;
 
+      # Least-privilege allowlist for dashboard -> API calls.
+      # Deny by default; only routes the dashboard actually uses are allowed.
+      # New dashboard API calls require a matching entry here or they will 403.
+      map $request_method$request_uri $thoras_dashboard_api_allowed {
+        default 0;
+
+        # GET — reads
+        ~*^GET/v1/ast(\?|$)                                                       1;
+        ~*^GET/v1/ast/[^/]+/[^/]+(\?|$)                                           1;
+        ~*^GET/v1/ast/[^/]+/[^/]+/pods(\?|$)                                      1;
+        ~*^GET/v1/ast/[^/]+/[^/]+/metrics/current(\?|$)                           1;
+        ~*^GET/v1/ast/[^/]+/[^/]+/suggestions(\?|$)                               1;
+        ~*^GET/v1/cost-savings/settings(\?|$)                                     1;
+        ~*^GET/v1/export(\?|$)                                                    1;
+        ~*^GET/v1/instance-costs/current(\?|$)                                    1;
+        ~*^GET/v1/system/jobs/status(\?|$)                                        1;
+        ~*^GET/v1/system/namespaces(\?|$)                                         1;
+        ~*^GET/v1/system/status(\?|$)                                             1;
+        ~*^GET/v1/views/asts(\?|$)                                                1;
+        ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
+        ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
+        ~*^GET/v1/views/cost/details(\?|$)                                        1;
+        ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
+        ~*^GET/v1/views/cost/projected(\?|$)                                      1;
+        ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
+        ~*^GET/v1/views/cost/savings-summary/namespaces/[^/]+(\?|$)               1;
+        ~*^GET/v1/views/kpis(\?|$)                                                1;
+        ~*^GET/v1/views/labels(\?|$)                                              1;
+        ~*^GET/v1/views/namespaces/[^/]+/asts(\?|$)                               1;
+        ~*^GET/v1/views/namespaces/[^/]+/kpis(\?|$)                               1;
+        ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
+        ~*^GET/v1/views/node-pools(\?|$)                                          1;
+        ~*^GET/v1/views/nodes(\?|$)                                               1;
+
+        # POST — dashboard-initiated mutations
+        ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
+        ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
+        ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
+        ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+        # PATCH — scale mode toggle
+        ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
+
+        # PUT — pause/resume system-wide scaling
+        ~*^PUT/v1/system/scaling(\?|$)                                            1;
+      }
+
       server {
         listen       {{ .Values.thorasDashboard.containerPort }};
         listen       [::]:{{ .Values.thorasDashboard.containerPort }} ipv6only=on;
@@ -31,6 +78,9 @@ data:
         index  index.html index.htm;
 
         location /v1/ {
+          if ($thoras_dashboard_api_allowed != 1) {
+            return 403;
+          }
           proxy_pass http://thoras-api-server-v2;
           proxy_set_header Host $host;
           proxy_set_header X-Real-IP $remote_addr;

--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -59,8 +59,10 @@ data:
         # POST — dashboard-initiated mutations
         ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
         ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
-        ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
         ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+        # POST — reads that pass a request body (query payloads, not mutations)
+        ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
 
         # PATCH — scale mode toggle
         ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -18,6 +18,53 @@ Should default to v2 port:
 
           include       mime.types;
 
+          # Least-privilege allowlist for dashboard -> API calls.
+          # Deny by default; only routes the dashboard actually uses are allowed.
+          # New dashboard API calls require a matching entry here or they will 403.
+          map $request_method$request_uri $thoras_dashboard_api_allowed {
+            default 0;
+
+            # GET — reads
+            ~*^GET/v1/ast(\?|$)                                                       1;
+            ~*^GET/v1/ast/[^/]+/[^/]+(\?|$)                                           1;
+            ~*^GET/v1/ast/[^/]+/[^/]+/pods(\?|$)                                      1;
+            ~*^GET/v1/ast/[^/]+/[^/]+/metrics/current(\?|$)                           1;
+            ~*^GET/v1/ast/[^/]+/[^/]+/suggestions(\?|$)                               1;
+            ~*^GET/v1/cost-savings/settings(\?|$)                                     1;
+            ~*^GET/v1/export(\?|$)                                                    1;
+            ~*^GET/v1/instance-costs/current(\?|$)                                    1;
+            ~*^GET/v1/system/jobs/status(\?|$)                                        1;
+            ~*^GET/v1/system/namespaces(\?|$)                                         1;
+            ~*^GET/v1/system/status(\?|$)                                             1;
+            ~*^GET/v1/views/asts(\?|$)                                                1;
+            ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
+            ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
+            ~*^GET/v1/views/cost/details(\?|$)                                        1;
+            ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
+            ~*^GET/v1/views/cost/projected(\?|$)                                      1;
+            ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
+            ~*^GET/v1/views/cost/savings-summary/namespaces/[^/]+(\?|$)               1;
+            ~*^GET/v1/views/kpis(\?|$)                                                1;
+            ~*^GET/v1/views/labels(\?|$)                                              1;
+            ~*^GET/v1/views/namespaces/[^/]+/asts(\?|$)                               1;
+            ~*^GET/v1/views/namespaces/[^/]+/kpis(\?|$)                               1;
+            ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
+            ~*^GET/v1/views/node-pools(\?|$)                                          1;
+            ~*^GET/v1/views/nodes(\?|$)                                               1;
+
+            # POST — dashboard-initiated mutations
+            ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
+            ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
+            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
+            ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+            # PATCH — scale mode toggle
+            ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
+
+            # PUT — pause/resume system-wide scaling
+            ~*^PUT/v1/system/scaling(\?|$)                                            1;
+          }
+
           server {
             listen       8080;
             listen       [::]:8080 ipv6only=on;
@@ -27,6 +74,9 @@ Should default to v2 port:
             index  index.html index.htm;
 
             location /v1/ {
+              if ($thoras_dashboard_api_allowed != 1) {
+                return 403;
+              }
               proxy_pass http://thoras-api-server-v2;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
@@ -84,6 +134,53 @@ should set extras in config.json:
 
           include       mime.types;
 
+          # Least-privilege allowlist for dashboard -> API calls.
+          # Deny by default; only routes the dashboard actually uses are allowed.
+          # New dashboard API calls require a matching entry here or they will 403.
+          map $request_method$request_uri $thoras_dashboard_api_allowed {
+            default 0;
+
+            # GET — reads
+            ~*^GET/v1/ast(\?|$)                                                       1;
+            ~*^GET/v1/ast/[^/]+/[^/]+(\?|$)                                           1;
+            ~*^GET/v1/ast/[^/]+/[^/]+/pods(\?|$)                                      1;
+            ~*^GET/v1/ast/[^/]+/[^/]+/metrics/current(\?|$)                           1;
+            ~*^GET/v1/ast/[^/]+/[^/]+/suggestions(\?|$)                               1;
+            ~*^GET/v1/cost-savings/settings(\?|$)                                     1;
+            ~*^GET/v1/export(\?|$)                                                    1;
+            ~*^GET/v1/instance-costs/current(\?|$)                                    1;
+            ~*^GET/v1/system/jobs/status(\?|$)                                        1;
+            ~*^GET/v1/system/namespaces(\?|$)                                         1;
+            ~*^GET/v1/system/status(\?|$)                                             1;
+            ~*^GET/v1/views/asts(\?|$)                                                1;
+            ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
+            ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
+            ~*^GET/v1/views/cost/details(\?|$)                                        1;
+            ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
+            ~*^GET/v1/views/cost/projected(\?|$)                                      1;
+            ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
+            ~*^GET/v1/views/cost/savings-summary/namespaces/[^/]+(\?|$)               1;
+            ~*^GET/v1/views/kpis(\?|$)                                                1;
+            ~*^GET/v1/views/labels(\?|$)                                              1;
+            ~*^GET/v1/views/namespaces/[^/]+/asts(\?|$)                               1;
+            ~*^GET/v1/views/namespaces/[^/]+/kpis(\?|$)                               1;
+            ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
+            ~*^GET/v1/views/node-pools(\?|$)                                          1;
+            ~*^GET/v1/views/nodes(\?|$)                                               1;
+
+            # POST — dashboard-initiated mutations
+            ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
+            ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
+            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
+            ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+            # PATCH — scale mode toggle
+            ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
+
+            # PUT — pause/resume system-wide scaling
+            ~*^PUT/v1/system/scaling(\?|$)                                            1;
+          }
+
           server {
             listen       8080;
             listen       [::]:8080 ipv6only=on;
@@ -93,6 +190,9 @@ should set extras in config.json:
             index  index.html index.htm;
 
             location /v1/ {
+              if ($thoras_dashboard_api_allowed != 1) {
+                return 403;
+              }
               proxy_pass http://thoras-api-server-v2;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -55,8 +55,10 @@ Should default to v2 port:
             # POST — dashboard-initiated mutations
             ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
             ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
-            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
             ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+            # POST — reads that pass a request body (query payloads, not mutations)
+            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
 
             # PATCH — scale mode toggle
             ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
@@ -171,8 +173,10 @@ should set extras in config.json:
             # POST — dashboard-initiated mutations
             ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
             ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
-            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
             ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+            # POST — reads that pass a request body (query payloads, not mutations)
+            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
 
             # PATCH — scale mode toggle
             ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;


### PR DESCRIPTION
Closes https://github.com/thoras-ai/platform/issues/4285

## How does this change deliver value (especially for customers)

This change applies the principle of least privilege at the dashboard's reverse proxy: only the ~31 `{method, path}` combinations the dashboard actually uses are permitted; everything else returns `403`. It is not a full RBAC solution, but it raises the floor materially with no API server changes.

## What's changing?

- `charts/thoras/templates/dashboard/nginx-config-map.yaml` — add a `map $request_method$request_uri $thoras_dashboard_api_allowed` block enumerating allowed routes, and an `if ($thoras_dashboard_api_allowed != 1) { return 403; }` guard at the top of the existing `location /v1/` block. Default is deny.
- Allowlist sourced from a sweep of `dashboard/src` against the `@thoras/thoras-api` generated client plus two direct `axios`/`window.open` calls (`PATCH /v1/ast/.../mode`, `GET /v1/export`).

## How Tested

- `helm template` rendered the ConfigMap and confirmed the `map` block and the `if` guard appear inside `location /v1/`.
- Existing helm chart snapshot tests updated and pass.
- Regression tested by clicking around dashboard; no 403s seen
- From devtools console, verified 403s for API calls not in the allowlist
