### PR TITLE
Release chart 4.126.2 (app 4.103.1)

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.126.1
+version: 4.126.2

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.126.1](https://img.shields.io/badge/Version-4.126.1-informational?style=flat-square) ![AppVersion: 4.103.0](https://img.shields.io/badge/AppVersion-4.103.0-informational?style=flat-square)
+![Version: 4.126.2](https://img.shields.io/badge/Version-4.126.2-informational?style=flat-square) ![AppVersion: 4.103.1](https://img.shields.io/badge/AppVersion-4.103.1-informational?style=flat-square)
 
 # Installs
 
@@ -52,7 +52,7 @@ helm install \
 
 | Key                                | Type    | Default                                          | Description                                                                                                          |
 | ---------------------------------- | ------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| thorasVersion                      | String  | 4.103.0                                          | Thoras app version                                                                                                   |
+| thorasVersion                      | String  | 4.103.1                                          | Thoras app version                                                                                                   |
 | imageCredentials.registry          | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                                                                              |
 | imageCredentials.username          | String  | \_json_key_base64                                | Container registry username                                                                                          |
 | imageCredentials.password          | String  | ""                                               | Container registry auth string                                                                                       |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "4.103.0"
+thorasVersion: "4.103.1"
 cluster:
   name: ""
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Releases Thoras app version 4.103.1 to customers via the Helm chart, delivering the latest platform updates.

## What's changing?

- Bump chart version 4.126.1 → 4.126.2 (`Chart.yaml`)
- Bump `thorasVersion` 4.103.0 → 4.103.1 (`values.yaml`)
- Update version badges and table in `README.md`

## How Tested

Version-only bump; no template logic changed. CI runs Helm unit tests on the PR.