### PR TITLE
Feature gate setting AST owner references

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -88,6 +88,7 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
 | featureFlags.enableMemoryLimit                 | Boolean | true    | If true, enables dynamic GOMEMLIMIT                       |
+| featureFlags.enableASTOwnerReference           | Boolean | false   | If true, sets owner reference on ASTs to target workload  |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -209,6 +209,8 @@ spec:
             value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
           - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
             value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
+            value: {{ .Values.featureFlags.enableASTOwnerReference | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1261,6 +1261,8 @@ Default matches snapshot:
                   value: "92"
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
                   value: "false"
+                - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,6 +65,7 @@ featureFlags:
   enableTypedInformers: true
   enableMemoryLimit: true
   enableDisruptionSchedulerWorker: false
+  enableASTOwnerReference: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

Adding a feature gate around setting the owner reference on AiScaleTargets to their target workload.