### PR TITLE
Enable AST owner references for all customers

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -88,7 +88,7 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
 | featureFlags.enableMemoryLimit                 | Boolean | true    | If true, enables dynamic GOMEMLIMIT                       |
-| featureFlags.enableASTOwnerReference           | Boolean | false   | If true, sets owner reference on ASTs to target workload  |
+| featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload  |
 
 ## Affinity Configuration
 

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1262,7 +1262,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
                   value: "false"
                 - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
-                  value: "false"
+                  value: "true"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,7 +65,7 @@ featureFlags:
   enableTypedInformers: true
   enableMemoryLimit: true
   enableDisruptionSchedulerWorker: false
-  enableASTOwnerReference: false
+  enableASTOwnerReference: true
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

Enable automatically setting the owner reference on ASTs that reference their target workload.