### PR TITLE
RBAC to allow events from the operator

### DIFF
--- a/charts/thoras/templates/operator/rbac.yaml
+++ b/charts/thoras/templates/operator/rbac.yaml
@@ -56,6 +56,14 @@ rules:
   verbs:
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1457,6 +1457,14 @@ Default matches snapshot:
         verbs:
           - patch
       - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
           - coordination.k8s.io
         resources:
           - leases


### PR DESCRIPTION
# What's changing and why?

The operator attempts to emit events around leader election (and possibly other) events. This resolves errors like the following:

`"Server rejected event (will not retry!)" err="events is forbidden: User \"system:serviceaccount:thoras:thoras-operator\" cannot create resource \"events\" in API group \"\" in the namespace \"thoras\"" event="&Event{ObjectMeta:{thoras-operator-lock.18b58c34cf0509ea  thoras    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:Lease,Namespace:thoras,Name:thoras-operator-lock...`