### PR TITLE
ci: trigger release notes generation on helm chart release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,45 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Extract versions for release notes
+        if: steps.version_bump.outputs.is_bump == 'true'
+        id: versions
+        shell: bash
+        run: |
+          LATEST_HELM=$(git diff HEAD^1..HEAD charts/thoras/Chart.yaml | grep '^+version:' | sed 's/^+version: *//')
+          PREV_HELM=$(git diff HEAD^1..HEAD charts/thoras/Chart.yaml | grep '^-version:' | sed 's/^-version: *//')
+
+          LATEST_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^+thorasVersion:' | sed 's/^+thorasVersion: *"\?\([^"]*\)"\?.*/\1/')
+          PREV_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^-thorasVersion:' | sed 's/^-thorasVersion: *"\?\([^"]*\)"\?.*/\1/')
+
+          # If app version didn't change in this release, use current version for both
+          if [ -z "$LATEST_APP" ]; then
+            CURRENT_APP=$(grep '^thorasVersion:' charts/thoras/values.yaml | sed 's/^thorasVersion: *"\?\([^"]*\)"\?.*/\1/')
+            LATEST_APP="$CURRENT_APP"
+            PREV_APP="$CURRENT_APP"
+          fi
+
+          echo "latest_helm=$LATEST_HELM" >> $GITHUB_OUTPUT
+          echo "prev_helm=$PREV_HELM" >> $GITHUB_OUTPUT
+          echo "latest_app=$LATEST_APP" >> $GITHUB_OUTPUT
+          echo "prev_app=$PREV_APP" >> $GITHUB_OUTPUT
+
+      - name: Trigger release notes generation
+        if: steps.version_bump.outputs.is_bump == 'true'
+        shell: bash
+        env:
+          PLATFORM_DISPATCH_TOKEN: ${{ secrets.PLATFORM_DISPATCH_TOKEN }}
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg prev_helm "${{ steps.versions.outputs.prev_helm }}" \
+            --arg latest_helm "${{ steps.versions.outputs.latest_helm }}" \
+            --arg prev_app "${{ steps.versions.outputs.prev_app }}" \
+            --arg latest_app "${{ steps.versions.outputs.latest_app }}" \
+            '{event_type: "generate-release-notes", client_payload: {prev_helm: $prev_helm, latest_helm: $latest_helm, prev_app: $prev_app, latest_app: $latest_app}}')
+
+          curl -f --max-time 30 -X POST \
+            -H "Authorization: token $PLATFORM_DISPATCH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/thoras-ai/platform/dispatches \
+            -d "$PAYLOAD"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,13 @@ jobs:
         id: version_bump
         run: |
           # Diff HEAD against pre-merge state and look for version bump
-          if git diff $(git rev-parse HEAD^1)..HEAD charts/*/Chart.yaml | grep -E '^\+version:'; then
+          DIFF=$(git diff $(git rev-parse HEAD^1)..HEAD charts/*/Chart.yaml)
+          LATEST_HELM=$(echo "$DIFF" | grep -E '^\+version:' | sed 's/^+version: *//')
+          if [ -n "$LATEST_HELM" ]; then
+            PREV_HELM=$(echo "$DIFF" | grep -E '^\-version:' | sed 's/^-version: *//')
             echo "is_bump=true" >> $GITHUB_OUTPUT
+            echo "latest_helm=$LATEST_HELM" >> $GITHUB_OUTPUT
+            echo "prev_helm=$PREV_HELM" >> $GITHUB_OUTPUT
           else
             echo "is_bump=false" >> $GITHUB_OUTPUT
           fi
@@ -46,9 +51,6 @@ jobs:
         id: versions
         shell: bash
         run: |
-          LATEST_HELM=$(git diff HEAD^1..HEAD charts/thoras/Chart.yaml | grep '^+version:' | sed 's/^+version: *//')
-          PREV_HELM=$(git diff HEAD^1..HEAD charts/thoras/Chart.yaml | grep '^-version:' | sed 's/^-version: *//')
-
           LATEST_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^+thorasVersion:' | sed 's/^+thorasVersion: *"\?\([^"]*\)"\?.*/\1/')
           PREV_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^-thorasVersion:' | sed 's/^-thorasVersion: *"\?\([^"]*\)"\?.*/\1/')
 
@@ -59,8 +61,6 @@ jobs:
             PREV_APP="$CURRENT_APP"
           fi
 
-          echo "latest_helm=$LATEST_HELM" >> $GITHUB_OUTPUT
-          echo "prev_helm=$PREV_HELM" >> $GITHUB_OUTPUT
           echo "latest_app=$LATEST_APP" >> $GITHUB_OUTPUT
           echo "prev_app=$PREV_APP" >> $GITHUB_OUTPUT
 
@@ -71,8 +71,8 @@ jobs:
           PLATFORM_DISPATCH_TOKEN: ${{ secrets.PLATFORM_DISPATCH_TOKEN }}
         run: |
           PAYLOAD=$(jq -n \
-            --arg prev_helm "${{ steps.versions.outputs.prev_helm }}" \
-            --arg latest_helm "${{ steps.versions.outputs.latest_helm }}" \
+            --arg prev_helm "${{ steps.version_bump.outputs.prev_helm }}" \
+            --arg latest_helm "${{ steps.version_bump.outputs.latest_helm }}" \
             --arg prev_app "${{ steps.versions.outputs.prev_app }}" \
             --arg latest_app "${{ steps.versions.outputs.latest_app }}" \
             '{event_type: "generate-release-notes", client_payload: {prev_helm: $prev_helm, latest_helm: $latest_helm, prev_app: $prev_app, latest_app: $latest_app}}')


### PR DESCRIPTION
# What's changing and why?

Adds two steps to the Release Charts workflow that fire after `chart-releaser` runs on a version bump.                                                   

The first step extracts the helm chart and platform versions from the diff automatically, no manual input needed. 
The second fires a `repository_dispatch` event to our private platform repository, which kicks off an internal workflow that generates a draft of the release notes for engineering review.                                                                                                                                    
                  
This requires a `PLATFORM_DISPATCH_TOKEN` secret in this repo, a fine-grained PAT scoped to `thoras-ai/platform` with Actions write permission, owned by the `thoras-ai org`. This has already been added to the repo secrets.
                                                                                                                                                         
The release process itself is unaffected. These steps run after `chart-releaser` completes, so a failure here has no impact on the release.