### PR TITLE
feat: add USE_FORECAST_ENRICHMENT env var to forecast worker

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -80,6 +80,8 @@ spec:
             value: {{ .Values.thorasForecast.useAstMetricsSeries | ternary "true" "false" | quote }}
           - name: USE_FORECASTER_COMPUTED_METRIC_ID
             value: {{ .Values.thorasForecast.useForecasterComputedMetricId | ternary "true" "false" | quote }}
+          - name: USE_FORECAST_ENRICHMENT
+            value: {{ .Values.thorasForecast.useForecastEnrichment | ternary "true" "false" | quote }}
           - name: TRAINING_JITTER_MINUTES
             value: {{ .Values.thorasForecast.trainingJitterMinutes | quote }}
           - name: AFFINITY_ID

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -853,6 +853,8 @@ Default matches snapshot:
                   value: "true"
                 - name: USE_FORECASTER_COMPUTED_METRIC_ID
                   value: "false"
+                - name: USE_FORECAST_ENRICHMENT
+                  value: "false"
                 - name: TRAINING_JITTER_MINUTES
                   value: "0"
                 - name: AFFINITY_ID

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -325,6 +325,25 @@ tests:
             name: USE_FORECASTER_COMPUTED_METRIC_ID
             value: "true"
 
+  - it: renders USE_FORECAST_ENRICHMENT as false by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
+          content:
+            name: USE_FORECAST_ENRICHMENT
+            value: "false"
+
+  - it: renders USE_FORECAST_ENRICHMENT as true when useForecastEnrichment is true
+    set:
+      thorasForecast:
+        useForecastEnrichment: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
+          content:
+            name: USE_FORECAST_ENRICHMENT
+            value: "true"
+
   - it: Should enable request and limit overrides
     set:
       thorasForecast:

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -325,25 +325,6 @@ tests:
             name: USE_FORECASTER_COMPUTED_METRIC_ID
             value: "true"
 
-  - it: renders USE_FORECAST_ENRICHMENT as false by default
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
-          content:
-            name: USE_FORECAST_ENRICHMENT
-            value: "false"
-
-  - it: renders USE_FORECAST_ENRICHMENT as true when useForecastEnrichment is true
-    set:
-      thorasForecast:
-        useForecastEnrichment: true
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
-          content:
-            name: USE_FORECAST_ENRICHMENT
-            value: "true"
-
   - it: Should enable request and limit overrides
     set:
       thorasForecast:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -507,6 +507,7 @@ thorasForecast:
   trainingJitterMinutes: 0
   useAstMetricsSeries: true
   useForecasterComputedMetricId: false
+  useForecastEnrichment: false
   # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
   minLookbackToScale: "3h"
   worker:


### PR DESCRIPTION
# What's changing and why?

Introducing new `USE_FORECAST_ENRICHMENT` environment variable to the forecast worker, with possible values of `true` and `false`, defaulting to `false`.

This gates per-metric enrichment computations (scalingClassification, burstProfile, evaluation) that run alongside core inference. These signals add latency to the forecast path on every metric for every AST on every cycle. Since they are not yet being acted on by clients, the overhead is not justified. This flag allows the implementation to remain in place while keeping inference fast until they are decoupled completely and ready to use by clients.