### PR TITLE
Bump max connections to 20 from 10

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -41,7 +41,7 @@ Default matches snapshot:
                 - name: SERVICE_POSTGRESQL_DSN
                   value: $(DATABASE_HOST)/thoras
                 - name: SERVICE_POSTGRESQL_MAX_CONNS
-                  value: "10"
+                  value: "20"
                 - name: SERVICE_POSTGRESQL_MAX_CONN_IDLE_TIME
                   value: 5m
                 - name: SERVICE_POSTGRESQL_MAX_CONN_LIFETIME
@@ -1241,7 +1241,7 @@ Default matches snapshot:
                 - name: SERVICE_POSTGRESQL_DSN
                   value: $(DATABASE_HOST)/thoras
                 - name: SERVICE_POSTGRESQL_MAX_CONNS
-                  value: "10"
+                  value: "20"
                 - name: SERVICE_POSTGRESQL_MAX_CONN_IDLE_TIME
                   value: 5m
                 - name: SERVICE_POSTGRESQL_MAX_CONN_LIFETIME
@@ -1587,7 +1587,7 @@ Default matches snapshot:
                 - name: SERVICE_POSTGRESQL_DSN
                   value: $(DATABASE_HOST)/thoras
                 - name: SERVICE_POSTGRESQL_MAX_CONNS
-                  value: "10"
+                  value: "20"
                 - name: SERVICE_POSTGRESQL_MAX_CONN_IDLE_TIME
                   value: 5m
                 - name: SERVICE_POSTGRESQL_MAX_CONN_LIFETIME

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -119,7 +119,7 @@ externalTimescale:
 # `postgresql` block.
 postgresql:
   # Maximum number of connections in the pool.
-  maxConns: 10
+  maxConns: 20
   # Maximum amount of time a connection may sit idle before being closed.
   maxConnIdleTime: 5m
   # Maximum amount of time a connection may be reused before being closed.


### PR DESCRIPTION
# What's changing and why?

Bump default connections from 10 to 20 to give more default headroom to postgres pooling.