### PR TITLE
feat: consolidate and configure PodDisruptionBudgets

### DIFF
--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -139,3 +139,35 @@ true
 {{ toYaml $out -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+PodDisruptionBudget for a component. Renders nothing when pdb.enabled is falsey.
+Spec precedence: minAvailable wins if set, else maxUnavailable, else defaults to
+maxUnavailable: 1. Uses kindIs "invalid" so an explicit 0 is honored.
+Usage: include "thoras.pdb" (dict "root" . "pdb" .Values.thorasWorker.pdb
+         "name" "thoras-worker" "app" "thoras-worker"
+         "labels" .Values.thorasWorker.labels)
+*/}}
+{{- define "thoras.pdb" -}}
+{{- if .pdb.enabled -}}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .name }}
+  namespace: {{ .root.Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" .root "component" .labels) | nindent 4 }}
+spec:
+  {{- if not (kindIs "invalid" .pdb.minAvailable) }}
+  minAvailable: {{ .pdb.minAvailable }}
+  {{- else if not (kindIs "invalid" .pdb.maxUnavailable) }}
+  maxUnavailable: {{ .pdb.maxUnavailable }}
+  {{- else }}
+  maxUnavailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .app }}
+{{- end -}}
+{{- end -}}

--- a/charts/thoras/templates/api-server-v2/pdb.yaml
+++ b/charts/thoras/templates/api-server-v2/pdb.yaml
@@ -1,13 +1,1 @@
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: thoras-api-server-v2
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasApiServerV2.labels) | nindent 4 }}
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: thoras-api-server-v2
+{{- include "thoras.pdb" (dict "root" . "pdb" .Values.thorasApiServerV2.pdb "name" "thoras-api-server-v2" "app" "thoras-api-server-v2" "labels" .Values.thorasApiServerV2.labels) }}

--- a/charts/thoras/templates/collector/pdb.yaml
+++ b/charts/thoras/templates/collector/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .)) }}
+{{- include "thoras.pdb" (dict "root" . "pdb" .Values.metricsCollector.pdb "name" "metrics-collector" "app" "metrics-collector" "labels" .Values.metricsCollector.labels) }}
+{{- end }}

--- a/charts/thoras/templates/dashboard/pdb.yaml
+++ b/charts/thoras/templates/dashboard/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "thoras.pdb" (dict "root" . "pdb" .Values.thorasDashboard.pdb "name" "thoras-dashboard" "app" "thoras-dashboard" "labels" .Values.thorasDashboard.labels) }}

--- a/charts/thoras/templates/forecast-worker/pdb.yaml
+++ b/charts/thoras/templates/forecast-worker/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "thoras.pdb" (dict "root" . "pdb" .Values.thorasForecast.worker.pdb "name" "thoras-forecast-worker" "app" "thoras-forecast-worker" "labels" .Values.thorasForecast.worker.labels) }}

--- a/charts/thoras/templates/monitor/pdb.yaml
+++ b/charts/thoras/templates/monitor/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.thorasMonitor.enabled }}
+{{- include "thoras.pdb" (dict "root" . "pdb" .Values.thorasMonitor.pdb "name" "thoras-monitor" "app" "thoras-monitor" "labels" .Values.thorasMonitor.labels) }}
+{{- end }}

--- a/charts/thoras/templates/operator/pdb.yaml
+++ b/charts/thoras/templates/operator/pdb.yaml
@@ -1,13 +1,1 @@
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: thoras-operator
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasOperator.labels) | nindent 4 }}
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: thoras-operator
+{{- include "thoras.pdb" (dict "root" . "pdb" .Values.thorasOperator.pdb "name" "thoras-operator" "app" "thoras-operator" "labels" .Values.thorasOperator.labels) }}

--- a/charts/thoras/templates/worker/pdb.yaml
+++ b/charts/thoras/templates/worker/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "thoras.pdb" (dict "root" . "pdb" .Values.thorasWorker.pdb "name" "thoras-worker" "app" "thoras-worker" "labels" .Values.thorasWorker.labels) }}

--- a/charts/thoras/tests/pdb_test.yaml
+++ b/charts/thoras/tests/pdb_test.yaml
@@ -1,0 +1,189 @@
+suite: PodDisruptionBudgets
+templates:
+  - operator/pdb.yaml
+  - api-server-v2/pdb.yaml
+  - worker/pdb.yaml
+  - dashboard/pdb.yaml
+  - forecast-worker/pdb.yaml
+  - monitor/pdb.yaml
+  - collector/pdb.yaml
+tests:
+  ############################
+  # Default behavior
+  ############################
+  - it: operator PDB renders by default with maxUnavailable 1
+    template: operator/pdb.yaml
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: thoras-operator
+
+  - it: api-server-v2 PDB renders by default with maxUnavailable 1
+    template: api-server-v2/pdb.yaml
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: thoras-api-server-v2
+
+  - it: worker PDB is not rendered by default
+    template: worker/pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: dashboard PDB is not rendered by default
+    template: dashboard/pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: forecast-worker PDB is not rendered by default
+    template: forecast-worker/pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: monitor PDB is not rendered by default
+    template: monitor/pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  ############################
+  # enabled flag
+  ############################
+  - it: worker PDB renders when enabled with default maxUnavailable 1
+    template: worker/pdb.yaml
+    set:
+      thorasWorker:
+        pdb:
+          enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: thoras-worker
+
+  - it: operator PDB is not rendered when disabled
+    template: operator/pdb.yaml
+    set:
+      thorasOperator:
+        pdb:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: forecast-worker PDB renders when enabled
+    template: forecast-worker/pdb.yaml
+    set:
+      thorasForecast:
+        worker:
+          pdb:
+            enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: thoras-forecast-worker
+
+  ############################
+  # minAvailable / maxUnavailable precedence
+  ############################
+  - it: minAvailable override renders minAvailable and drops maxUnavailable
+    template: api-server-v2/pdb.yaml
+    set:
+      thorasApiServerV2:
+        pdb:
+          minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: maxUnavailable override is honored
+    template: api-server-v2/pdb.yaml
+    set:
+      thorasApiServerV2:
+        pdb:
+          maxUnavailable: 3
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 3
+      - notExists:
+          path: spec.minAvailable
+
+  - it: minAvailable takes precedence when both are set
+    template: api-server-v2/pdb.yaml
+    set:
+      thorasApiServerV2:
+        pdb:
+          minAvailable: 2
+          maxUnavailable: 5
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: minAvailable of 0 is honored and not treated as unset
+    template: api-server-v2/pdb.yaml
+    set:
+      thorasApiServerV2:
+        pdb:
+          minAvailable: 0
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 0
+      - notExists:
+          path: spec.maxUnavailable
+
+  ############################
+  # Gated components
+  ############################
+  - it: monitor PDB renders when both monitor and pdb are enabled
+    template: monitor/pdb.yaml
+    set:
+      thorasMonitor:
+        enabled: true
+        pdb:
+          enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: thoras-monitor
+
+  - it: monitor PDB is not rendered when pdb enabled but monitor disabled
+    template: monitor/pdb.yaml
+    set:
+      thorasMonitor:
+        enabled: false
+        pdb:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -153,6 +153,12 @@ thorasOperator:
     name: thoras-operator
   podAnnotations: {}
   labels: {}
+  # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is set
+  # below. minAvailable takes precedence if both are set.
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+    # minAvailable:
   service:
     annotations: {}
   # Specify the complete resources block (takes precedence if set)
@@ -223,6 +229,12 @@ metricsCollector:
     pvcStorageRequestSize: "3Gi"
   podAnnotations: {}
   labels: {}
+  # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is set
+  # below. minAvailable takes precedence if both are set.
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    # minAvailable:
   service:
     annotations: {}
   serviceAccount:
@@ -306,6 +318,12 @@ thorasApiServerV2:
   containerPort: 8080
   podAnnotations: {}
   labels: {}
+  # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is set
+  # below. minAvailable takes precedence if both are set.
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+    # minAvailable:
   service:
     annotations: {}
   replicas: 1
@@ -356,6 +374,12 @@ thorasWorker:
     name: thoras-worker
   podAnnotations: {}
   labels: {}
+  # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is set
+  # below. minAvailable takes precedence if both are set.
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    # minAvailable:
   service:
     annotations: {}
   replicas: 1
@@ -410,6 +434,12 @@ thorasDashboard:
     create: true
   podAnnotations: {}
   labels: {}
+  # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is set
+  # below. minAvailable takes precedence if both are set.
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    # minAvailable:
   containerPort: 8080
   # Specify the complete resources block (takes precedence if set)
   resources: {}
@@ -490,6 +520,13 @@ thorasMonitor:
     memory: "64Mi"
   podAnnotations: {}
   labels: {}
+  # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is set
+  # below. minAvailable takes precedence if both are set. Only rendered when
+  # thorasMonitor.enabled is also true.
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    # minAvailable:
   config: |
   # Set to true to apply global affinity rules to this component
   useGlobalAffinity: true
@@ -531,6 +568,12 @@ thorasForecast:
     retrainOverrideHours: ""
     maxTimeseriesMetricCacheSizeMb: 1000
     labels: {}
+    # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is
+    # set below. minAvailable takes precedence if both are set.
+    pdb:
+      enabled: false
+      maxUnavailable: 1
+      # minAvailable:
     # Specify the complete resources block (takes precedence if set)
     resources: {}
     # Legacy field for backward compatibility (used if resources is empty)


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Customers can now enable, disable, and tune a PodDisruptionBudget per component (`minAvailable`/`maxUnavailable`) instead of being stuck with hardcoded defaults. New PDB coverage for worker, dashboard, forecast-worker, monitor, and collector lets operators protect availability during node drains and upgrades.

## What's changing?

- Add reusable `thoras.pdb` helper; precedence is `minAvailable` > `maxUnavailable` > default `maxUnavailable: 1` (explicit `0` honored via `kindIs`)
- Replace the two hardcoded PDBs (operator, api-server-v2) with the helper; add PDBs for 5 more components, each gated on `pdb.enabled`
- Collector/monitor PDBs reuse their deployments' render gates so a PDB never targets a missing workload
- **Behavior change:** operator & api-server-v2 PDB default flips from `minAvailable: 1` to `maxUnavailable: 1`. On single-replica deploys this unblocks voluntary node drains (the old default blocked them) — intentional, but worth noting on upgrade.

## How Tested

Added a 15-case unit suite (`tests/pdb_test.yaml`) covering default rendering, enable/disable, min/max precedence, explicit-`0`, and double-gating for monitor. Full suite green (255 tests). Spot-checked edge renders (both fields null → falls back to `maxUnavailable: 1`).