### PR TITLE
Remove obsolete feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -252,7 +252,6 @@ must be pre-installed and managed externally.
 | thorasWorker.prometheus.port                         | Number  | 9102          | Port for the prometheus metric exporter                      |
 | thorasWorker.enableMetricIntegrityWorker             | Boolean | true          | Enable metric integrity worker                               |
 | thorasWorker.enableDeploymentMonitorWorker           | Boolean | true          | Enable deployment monitor worker                             |
-| thorasWorker.enableMonitorActiveSuggestionFromCRD    | Boolean | false         | Enable monitoring active suggestions using the AST           |
 | thorasWorker.maxTimeseriesMetricCacheSizeMb          | Number  | 1000          | Configure cache size that triggers LRU eviction              |
 | thorasWorker.enableUnifiedAstUtilizationMonitor      | Boolean | false         | Enable the unified AST utilization monitor                   |
 | thorasWorker.enableAstViewCacheStateReconcilerWorker | Boolean | true          | Enable view cache state reconciler jobs                      |

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -163,8 +163,6 @@ spec:
             value: {{ .Values.featureFlags.enableNodeDetailsCollector | ternary "true" "false" | quote}}
           - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
             value: "true"
-          - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
-            value: {{ .Values.featureFlags.enableMonitorActiveSuggestionFromCRD | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
             value: {{ not .Values.featureFlags.enableForecastQueueStats | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1652,8 +1652,6 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_CHECK_DATABASE_HEALTH
                   value: "true"
-                - name: SERVICE_ENABLE_MONITOR_ACTIVE_SUGGESTION_FROM_CRD
-                  value: "false"
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "true"
                 - name: SERVICE_FORECAST_JOB_TIMEOUT_INTERVAL

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -56,7 +56,6 @@ featureFlags:
       # Forecast once per hour by default
       forecastCron: "17 * * * *"
   enablePrometheusMetricScraping: false
-  enableMonitorActiveSuggestionFromCRD: false
   enablePgLargeObjectStorage: true
   enableNoBlobApiServer: false
   enableForecastQueueStats: false


### PR DESCRIPTION
# What's changing and why?

The `thorasWorker.enableMonitorActiveSuggestionFromCRD` is dead code and no longer in use.