### PR TITLE
Add feature flag for mirroring ASTs to the database

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -88,6 +88,7 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
 | featureFlags.enableMemoryLimit                 | Boolean | true    | If true, enables dynamic GOMEMLIMIT                       |
 | featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload  |
+| featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component      |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -217,6 +217,8 @@ spec:
             value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
             value: {{ .Values.featureFlags.enableASTOwnerReference | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
+            value: {{ .Values.featureFlags.enableAstRecordMirroring | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1068,6 +1068,8 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
                   value: "true"
+                - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -64,6 +64,7 @@ featureFlags:
   enableMemoryLimit: true
   enableDisruptionSchedulerWorker: false
   enableASTOwnerReference: true
+  enableAstRecordMirroring: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

Adding a feature flag to gate mirroring of ASTs to the database