### PR TITLE
Default forecaster to generate legacy metric ids instead of using the catalog

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -852,7 +852,7 @@ Default matches snapshot:
                 - name: USE_AST_METRICS_SERIES
                   value: "true"
                 - name: USE_FORECASTER_COMPUTED_METRIC_ID
-                  value: "false"
+                  value: "true"
                 - name: USE_FORECAST_ENRICHMENT
                   value: "false"
                 - name: TRAINING_JITTER_MINUTES

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -312,18 +312,18 @@ tests:
           path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
           content:
             name: USE_FORECASTER_COMPUTED_METRIC_ID
-            value: "false"
+            value: "true"
 
   - it: renders USE_FORECASTER_COMPUTED_METRIC_ID as true when useForecasterComputedMetricId is true
     set:
       thorasForecast:
-        useForecasterComputedMetricId: true
+        useForecasterComputedMetricId: false
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
           content:
             name: USE_FORECASTER_COMPUTED_METRIC_ID
-            value: "true"
+            value: "false"
 
   - it: Should enable request and limit overrides
     set:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -504,7 +504,7 @@ thorasForecast:
   enableDecoupledTraining: true
   trainingJitterMinutes: 0
   useAstMetricsSeries: true
-  useForecasterComputedMetricId: false
+  useForecasterComputedMetricId: true
   useForecastEnrichment: false
   # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
   minLookbackToScale: "3h"


### PR DESCRIPTION
# What's changing and why?

Switching a feature flag to cause the forecaster to generate legacy metric IDs instead of fetching them from the catalog.