### PR TITLE
Conditionally drop anti-affinity between forecast workers and the collector

### DIFF
--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -46,6 +46,7 @@ Usage: include "thoras.podAnnotations" (dict "root" . "component" .Values.thoras
 Default affinity for metricsCollector - anti-affinity with forecast-worker
 */}}
 {{- define "thoras.metricsCollector.defaultAffinity" -}}
+{{- if .Values.featureFlags.enableForecastCollectorAntiAffinity }}
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 100
@@ -57,6 +58,7 @@ podAntiAffinity:
           values:
           - thoras-forecast-worker
       topologyKey: kubernetes.io/hostname
+{{- end }}
 {{- end }}
 
 {{/*
@@ -80,8 +82,10 @@ podAntiAffinity:
 Default affinity for thorasForecast - anti-affinity with metrics-collector and self
 */}}
 {{- define "thoras.thorasForecast.defaultAffinity" -}}
+{{- if or .Values.featureFlags.enableForecastCollectorAntiAffinity .Values.thorasForecast.enableSelfAntiAffinity }}
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
+  {{- if .Values.featureFlags.enableForecastCollectorAntiAffinity }}
   - weight: 100
     podAffinityTerm:
       labelSelector:
@@ -91,6 +95,7 @@ podAntiAffinity:
           values:
           - metrics-collector
       topologyKey: kubernetes.io/hostname
+  {{- end }}
   {{- if .Values.thorasForecast.enableSelfAntiAffinity }}
   - weight: 95
     podAffinityTerm:
@@ -102,6 +107,7 @@ podAntiAffinity:
           - thoras-forecast-worker
       topologyKey: kubernetes.io/hostname
   {{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -91,6 +91,7 @@ podAntiAffinity:
           values:
           - metrics-collector
       topologyKey: kubernetes.io/hostname
+  {{- if .Values.thorasForecast.enableSelfAntiAffinity }}
   - weight: 95
     podAffinityTerm:
       labelSelector:
@@ -100,6 +101,7 @@ podAntiAffinity:
           values:
           - thoras-forecast-worker
       topologyKey: kubernetes.io/hostname
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/thoras/tests/affinity_test.yaml
+++ b/charts/thoras/tests/affinity_test.yaml
@@ -34,6 +34,39 @@ tests:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
           value: thoras-forecast-worker
 
+  # Test 1a-ii: forecast-worker self anti-affinity absent when disabled
+  - it: forecast-worker self anti-affinity is absent when disabled
+    templates:
+      - forecast-worker/deployment.yaml
+    set:
+      thorasForecast:
+        enableSelfAntiAffinity: false
+    asserts:
+      - contains:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
+          content:
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - metrics-collector
+              topologyKey: kubernetes.io/hostname
+          any: true
+      - notContains:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
+          content:
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - thoras-forecast-worker
+              topologyKey: kubernetes.io/hostname
+          any: true
+
   # Test 1b: Default - collector has only thoras-specific affinities
   - it: metrics-collector has thoras-specific affinities by default
     templates:

--- a/charts/thoras/tests/affinity_test.yaml
+++ b/charts/thoras/tests/affinity_test.yaml
@@ -42,30 +42,50 @@ tests:
       thorasForecast:
         enableSelfAntiAffinity: false
     asserts:
-      - contains:
+      - equal:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
-          content:
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - metrics-collector
-              topologyKey: kubernetes.io/hostname
-          any: true
-      - notContains:
+          value:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - metrics-collector
+                topologyKey: kubernetes.io/hostname
+
+  # Test 1a-iii: forecast-collector anti-affinity absent on forecast-worker when disabled
+  - it: forecast-collector anti-affinity is absent on forecast-worker when disabled
+    templates:
+      - forecast-worker/deployment.yaml
+    set:
+      featureFlags:
+        enableForecastCollectorAntiAffinity: false
+    asserts:
+      - equal:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
-          content:
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - thoras-forecast-worker
-              topologyKey: kubernetes.io/hostname
-          any: true
+          value:
+            - weight: 95
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - thoras-forecast-worker
+                topologyKey: kubernetes.io/hostname
+
+  # Test 1a-iv: forecast-collector anti-affinity absent on metrics-collector when disabled
+  - it: forecast-collector anti-affinity is absent on metrics-collector when disabled
+    templates:
+      - collector/deployment.yaml
+    set:
+      featureFlags:
+        enableForecastCollectorAntiAffinity: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.affinity
 
   # Test 1b: Default - collector has only thoras-specific affinities
   - it: metrics-collector has thoras-specific affinities by default

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -561,6 +561,8 @@ thorasForecast:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  # Set to false to disable the default self anti-affinity between forecast-worker replicas
+  enableSelfAntiAffinity: true
   extraEgressRules: []
 
 # K8s client max queries per second

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,6 +65,7 @@ featureFlags:
   enableDisruptionSchedulerWorker: false
   enableASTOwnerReference: true
   enableAstRecordMirroring: false
+  enableForecastCollectorAntiAffinity: true
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

With anti-affinities on the forecast worker and metrics collector, we prevent Karpenter consolidation.