### PR TITLE
Remove always on enableMemoryLimit

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -86,7 +86,6 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects  |
 | featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
-| featureFlags.enableMemoryLimit                 | Boolean | true    | If true, enables dynamic GOMEMLIMIT                       |
 | featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload  |
 | featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component      |
 

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -172,8 +172,6 @@ spec:
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS
             value: {{ .Values.featureFlags.enableTypedInformers | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_MEMORY_LIMIT
-            value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           - name: SERVICE_OVERPROVISIONED_THRESHOLD
             value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
           - name: SERVICE_UNDERPROVISIONED_THRESHOLD

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -207,8 +207,6 @@ spec:
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS
             value: {{ .Values.featureFlags.enableTypedInformers | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_MEMORY_LIMIT
-            value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           - name: SERVICE_OVERPROVISIONED_THRESHOLD
             value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
           - name: SERVICE_UNDERPROVISIONED_THRESHOLD

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -181,8 +181,6 @@ spec:
             value: {{ .Values.featureFlags.enableInformersStripManagedFields | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_TYPED_INFORMERS
             value: {{ .Values.featureFlags.enableTypedInformers | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_MEMORY_LIMIT
-            value: {{ .Values.featureFlags.enableMemoryLimit | ternary "true" "false" | quote }}
           - name: SERVICE_OVERPROVISIONED_THRESHOLD
             value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
           - name: SERVICE_UNDERPROVISIONED_THRESHOLD

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -110,8 +110,6 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
                   value: "true"
-                - name: SERVICE_ENABLE_MEMORY_LIMIT
-                  value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD
                   value: "60"
                 - name: SERVICE_UNDERPROVISIONED_THRESHOLD
@@ -1058,8 +1056,6 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
                   value: "true"
-                - name: SERVICE_ENABLE_MEMORY_LIMIT
-                  value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD
                   value: "60"
                 - name: SERVICE_UNDERPROVISIONED_THRESHOLD
@@ -1460,8 +1456,6 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
-                  value: "true"
-                - name: SERVICE_ENABLE_MEMORY_LIMIT
                   value: "true"
                 - name: SERVICE_OVERPROVISIONED_THRESHOLD
                   value: "60"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -61,7 +61,6 @@ featureFlags:
   enableForecastQueueStats: false
   enableInformersStripManagedFields: true
   enableTypedInformers: true
-  enableMemoryLimit: true
   enableDisruptionSchedulerWorker: false
   enableASTOwnerReference: true
   enableAstRecordMirroring: false


### PR DESCRIPTION
# What's changing and why?

Removing always on `enableMemoryLimit` feature flag.