### PR TITLE
fix: handle no-match grep exit in versions step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
         id: versions
         shell: bash
         run: |
-          LATEST_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^+thorasVersion:' | sed 's/^+thorasVersion: *"\?\([^"]*\)"\?.*/\1/')
-          PREV_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^-thorasVersion:' | sed 's/^-thorasVersion: *"\?\([^"]*\)"\?.*/\1/')
+          LATEST_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^+thorasVersion:' | sed 's/^+thorasVersion: *"\?\([^"]*\)"\?.*/\1/' || true)
+          PREV_APP=$(git diff HEAD^1..HEAD charts/thoras/values.yaml | grep '^-thorasVersion:' | sed 's/^-thorasVersion: *"\?\([^"]*\)"\?.*/\1/' || true)
 
           # If app version didn't change in this release, use current version for both
           if [ -z "$LATEST_APP" ]; then


### PR DESCRIPTION
# What's changing and why?

Same pipefail + grep no-match issue fixed previously in [version_bump](https://github.com/thoras-ai/helm-charts/pull/775), applied the missing || true to the two thorasVersion grep lines in the  versions step. 