### PR TITLE
Add feature flag for enabling DaemonSet Vertical Autoscalers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ The chart includes Custom Resource Definitions (CRDs) for:
 
 - AI Scale Targets (`aiscaletarget.yaml`)
 - Cluster AI Scale Template (`clusteraiscaletemplate.yaml`)
+- DaemonSet Vertical Autoscaler (`daemonsetverticalautoscaler.yaml`)
 
 ## Common Development Tasks
 

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -80,14 +80,15 @@ helm install \
 
 The following flags are considered temporary and gate access to specific behaviors that still undergoing testing before general availability.
 
-| Key                                            | Type    | Default | Description                                               |
-| ---------------------------------------------- | ------- | ------- | --------------------------------------------------------- |
-| featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                       |
-| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects  |
-| featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
-| featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
-| featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload  |
-| featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component      |
+| Key                                            | Type    | Default | Description                                                     |
+| ---------------------------------------------- | ------- | ------- | --------------------------------------------------------------- |
+| featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                             |
+| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects        |
+| featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations                  |
+| featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations       |
+| featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload        |
+| featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component            |
+| featureFlags.enableDaemonSetVerticalAutoscaler | Boolean | false   | If true, DaemonSetVerticalAutoscaler objects will be reconciled |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/crd/daemonsetverticalautoscaler.yaml
+++ b/charts/thoras/templates/crd/daemonsetverticalautoscaler.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.featureFlags.enableDaemonSetVerticalAutoscaler }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: daemonsetverticalautoscalers.thoras.ai
+spec:
+  group: thoras.ai
+  names:
+    kind: DaemonSetVerticalAutoscaler
+    listKind: DaemonSetVerticalAutoscalerList
+    plural: daemonsetverticalautoscalers
+    shortNames:
+    - dsva
+    singular: daemonsetverticalautoscaler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: DaemonSetVerticalAutoscaler is a resource used to scale daemonsets
+          vertically.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DaemonSetVerticalAutoscalerSpec is the spec of a DaemonSetVerticalAutoscaler
+              resource.
+            properties:
+              scale_mode:
+                enum:
+                - autonomous
+                - auto
+                - recommendation
+                - recommend
+                - rec
+                - observe
+                - observation
+                type: string
+              scaleTargetRef:
+                properties:
+                  apiVersion:
+                    type: string
+                  name:
+                    type: string
+                type: object
+            required:
+            - scale_mode
+            type: object
+            x-kubernetes-validations:
+            - message: scaleTargetRef must be set
+              rule: (has(self.scaleTargetRef))
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -217,6 +217,8 @@ spec:
             value: {{ .Values.featureFlags.enableASTOwnerReference | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
             value: {{ .Values.featureFlags.enableAstRecordMirroring | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_DAEMON_SET_VERTICAL_AUTOSCALER_CONTROLLER
+            value: {{ .Values.featureFlags.enableDaemonSetVerticalAutoscaler | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/operator/rbac.yaml
+++ b/charts/thoras/templates/operator/rbac.yaml
@@ -116,6 +116,10 @@ rules:
   - 'aiscaletargets'
   - 'clusteraiscaletemplates'
   - 'clusteraiscaletemplates/status'
+{{- if .Values.featureFlags.enableDaemonSetVerticalAutoscaler }}
+  - 'daemonsetverticalautoscalers'
+  - 'daemonsetverticalautoscalers/status'
+{{- end }}
   verbs:
   - '*'
 ---

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1066,6 +1066,8 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
                   value: "false"
+                - name: SERVICE_ENABLE_DAEMON_SET_VERTICAL_AUTOSCALER_CONTROLLER
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,6 +65,7 @@ featureFlags:
   enableASTOwnerReference: true
   enableAstRecordMirroring: false
   enableForecastCollectorAntiAffinity: true
+  enableDaemonSetVerticalAutoscaler: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

The `DaemonSetVerticalAutoscaler` will allow scaling of daemon sets after it's been QA'd.