### PR TITLE
Update DSA CRD and related feature flag

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -88,7 +88,7 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
 | featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload  |
 | featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component      |
-| featureFlags.enableDaemonSetAutoscaler         | Boolean | false   | If true, DaemonSetAutoscaler are enabled                  |
+| featureFlags.enableDaemonSetAutoscaler         | Boolean | false   | If true, DaemonSetAutoscaler resources are enabled        |
 
 ## Affinity Configuration
 

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -80,15 +80,15 @@ helm install \
 
 The following flags are considered temporary and gate access to specific behaviors that still undergoing testing before general availability.
 
-| Key                                            | Type    | Default | Description                                                     |
-| ---------------------------------------------- | ------- | ------- | --------------------------------------------------------------- |
-| featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                             |
-| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects        |
-| featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations                  |
-| featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations       |
-| featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload        |
-| featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component            |
-| featureFlags.enableDaemonSetVerticalAutoscaler | Boolean | false   | If true, DaemonSetVerticalAutoscaler objects will be reconciled |
+| Key                                            | Type    | Default | Description                                               |
+| ---------------------------------------------- | ------- | ------- | --------------------------------------------------------- |
+| featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                       |
+| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects  |
+| featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
+| featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
+| featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload  |
+| featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component      |
+| featureFlags.enableDaemonSetAutoscaler         | Boolean | false   | If true, DaemonSetAutoscaler are enabled                  |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/crd/daemonsetautoscaler.yaml
+++ b/charts/thoras/templates/crd/daemonsetautoscaler.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.featureFlags.enableDaemonSetAutoscaler }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -141,3 +142,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/thoras/templates/crd/daemonsetautoscaler.yaml
+++ b/charts/thoras/templates/crd/daemonsetautoscaler.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.featureFlags.enableDaemonSetAutoscaler }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -24,8 +23,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: DaemonSetAutoscaler is a resource used to scale daemonsets
-          vertically.
+        description: DaemonSetAutoscaler is a resource used to scale daemonsets vertically.
         properties:
           apiVersion:
             description: |-
@@ -71,6 +69,70 @@ spec:
             x-kubernetes-validations:
             - message: scaleTargetRef must be set
               rule: (has(self.scaleTargetRef))
+          status:
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the DaemonSetAutoscaler's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
         required:
         - metadata
         - spec
@@ -79,4 +141,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}

--- a/charts/thoras/templates/crd/daemonsetautoscaler.yaml
+++ b/charts/thoras/templates/crd/daemonsetautoscaler.yaml
@@ -1,20 +1,20 @@
-{{- if .Values.featureFlags.enableDaemonSetVerticalAutoscaler }}
+{{- if .Values.featureFlags.enableDaemonSetAutoscaler }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
-  name: daemonsetverticalautoscalers.thoras.ai
+  name: daemonsetautoscalers.thoras.ai
 spec:
   group: thoras.ai
   names:
-    kind: DaemonSetVerticalAutoscaler
-    listKind: DaemonSetVerticalAutoscalerList
-    plural: daemonsetverticalautoscalers
+    kind: DaemonSetAutoscaler
+    listKind: DaemonSetAutoscalerList
+    plural: daemonsetautoscalers
     shortNames:
-    - dsva
-    singular: daemonsetverticalautoscaler
+    - dsa
+    singular: daemonsetautoscaler
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -24,7 +24,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: DaemonSetVerticalAutoscaler is a resource used to scale daemonsets
+        description: DaemonSetAutoscaler is a resource used to scale daemonsets
           vertically.
         properties:
           apiVersion:
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DaemonSetVerticalAutoscalerSpec is the spec of a DaemonSetVerticalAutoscaler
+            description: DaemonSetAutoscalerSpec is the spec of a DaemonSetAutoscaler
               resource.
             properties:
               scale_mode:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -217,8 +217,8 @@ spec:
             value: {{ .Values.featureFlags.enableASTOwnerReference | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
             value: {{ .Values.featureFlags.enableAstRecordMirroring | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_DAEMON_SET_VERTICAL_AUTOSCALER_CONTROLLER
-            value: {{ .Values.featureFlags.enableDaemonSetVerticalAutoscaler | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
+            value: {{ .Values.featureFlags.enableDaemonSetAutoscaler | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/operator/rbac.yaml
+++ b/charts/thoras/templates/operator/rbac.yaml
@@ -116,9 +116,9 @@ rules:
   - 'aiscaletargets'
   - 'clusteraiscaletemplates'
   - 'clusteraiscaletemplates/status'
-{{- if .Values.featureFlags.enableDaemonSetVerticalAutoscaler }}
-  - 'daemonsetverticalautoscalers'
-  - 'daemonsetverticalautoscalers/status'
+{{- if .Values.featureFlags.enableDaemonSetAutoscaler }}
+  - 'daemonsetautoscalers'
+  - 'daemonsetautoscalers/status'
 {{- end }}
   verbs:
   - '*'

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -273,6 +273,8 @@ spec:
             value: {{ .Values.thorasForecast.worker.scaler.astsPerReplica | quote }}
           - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
             value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
+          - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
+            value: {{ .Values.featureFlags.enableDaemonSetAutoscaler | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1066,7 +1066,7 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
                   value: "false"
-                - name: SERVICE_ENABLE_DAEMON_SET_VERTICAL_AUTOSCALER_CONTROLLER
+                - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
@@ -1526,6 +1526,8 @@ Default matches snapshot:
                 - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
                   value: "67"
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
+                  value: "false"
+                - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -65,7 +65,7 @@ featureFlags:
   enableASTOwnerReference: true
   enableAstRecordMirroring: false
   enableForecastCollectorAntiAffinity: true
-  enableDaemonSetVerticalAutoscaler: false
+  enableDaemonSetAutoscaler: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

- renaming feature flag `enableDaemonSetVerticalAutoscaler` to `enableDaemonSetAutoscaler` to align with the naming of the DSA
- updating the DSA CRD with status+conditions block
- passing the new flag to the worker