### PR TITLE
Derive forecast-worker scaler from worker.replicas

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasForecast.worker.labels) | nindent 4 }}
 spec:
-  replicas:  {{ .Values.thorasForecast.worker.replicas }}
+{{- with .Values.thorasForecast.worker.replicas }}
+  replicas: {{ . }}
+{{- end }}
   selector:
     matchLabels:
       app: thoras-forecast-worker

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -258,7 +258,7 @@ spec:
             value: {{ . | quote }}
           {{- end }}
           - name: SERVICE_ENABLE_FORECAST_WORKER_SCALER
-            value: {{ .Values.thorasForecast.worker.scaler.enabled | ternary "true" "false" | quote }}
+            value: {{ not (hasKey .Values.thorasForecast.worker "replicas") | ternary "true" "false" | quote }}
           - name: SERVICE_FORECAST_WORKER_SCALER_INTERVAL
             value: {{ .Values.thorasForecast.worker.scaler.interval | quote }}
           - name: SERVICE_FORECAST_WORKER_DEPLOYMENT_NAME

--- a/charts/thoras/templates/worker/rbac.yaml
+++ b/charts/thoras/templates/worker/rbac.yaml
@@ -107,7 +107,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.thorasWorker.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
-{{- if .Values.thorasForecast.worker.scaler.enabled }}
+{{- if not (hasKey .Values.thorasForecast.worker "replicas") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -791,7 +791,6 @@ Default matches snapshot:
       name: thoras-forecast-worker
       namespace: foo
     spec:
-      replicas: 1
       selector:
         matchLabels:
           app: thoras-forecast-worker

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -94,6 +94,11 @@ tests:
             name: METRICS_PORT
             value: "9101"
 
+  - it: omits spec.replicas when worker.replicas is unset
+    asserts:
+      - notExists:
+          path: spec.replicas
+
   - it: sets RETRAIN_STEADY_STATE_HOURS when value is an integer
     set:
       thorasForecast:

--- a/charts/thoras/tests/worker_deployment_test.yaml
+++ b/charts/thoras/tests/worker_deployment_test.yaml
@@ -116,6 +116,23 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME')].value
           value: "5m"
+  - it: Enables forecast worker scaler when replicas is unset
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_ENABLE_FORECAST_WORKER_SCALER')].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA')].value
+          value: "67"
+  - it: Disables forecast worker scaler when replicas is set
+    set:
+      thorasForecast:
+        worker:
+          replicas: 3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_ENABLE_FORECAST_WORKER_SCALER')].value
+          value: "false"
   - it: Should set default utilization thresholds
     asserts:
       - equal:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -510,7 +510,10 @@ thorasForecast:
   # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
   minLookbackToScale: "3h"
   worker:
-    replicas: 1
+    # Number of forecast-worker replicas. Leave unset to let the scaler manage
+    # the replica count. Set to a fixed number to pin a static count and disable
+    # the scaler.
+    # replicas: 1
     # Resource upperbound used when thorasManageThoras is enabled. Empty means
     # no upperbound. Use K8s resource.Quantity syntax (e.g. "2", "4Gi").
     upperbound:
@@ -548,7 +551,6 @@ thorasForecast:
       memory: 256Mi
     forecastTimeout: 600
     scaler:
-      enabled: true
       interval: "1m"
       minReplicas: 1
       maxReplicas: 100


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

The forecast-worker scaler is now enabled by default. Customers get autonomous replica scaling out of the box, and can opt out by pinning `thorasForecast.worker.replicas` to a fixed count.

## What's changing?

- Derive `SERVICE_ENABLE_FORECAST_WORKER_SCALER` (and its RBAC Role) from whether `worker.replicas` is set, replacing the explicit `scaler.enabled` flag
- Omit `spec.replicas` on the forecast-worker Deployment when `worker.replicas` is unset, letting the scaler own the count
- Default `worker.replicas` to unset (commented out) and remove `scaler.enabled` from values

## How Tested

Added unit tests covering scaler enabled/disabled and `spec.replicas` presence based on `worker.replicas`. All 247 helm-unittest tests pass.