### PR TITLE
release 4.128.1

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.128.0
+version: 4.128.1

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.128.0](https://img.shields.io/badge/Version-4.128.0-informational?style=flat-square) ![AppVersion: 4.105.1](https://img.shields.io/badge/AppVersion-4.105.1-informational?style=flat-square)
+![Version: 4.128.1](https://img.shields.io/badge/Version-4.128.1-informational?style=flat-square) ![AppVersion: 4.105.1](https://img.shields.io/badge/AppVersion-4.105.1-informational?style=flat-square)
 
 # Installs
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Ships the 4.128.1 chart release so customers can install the latest Thoras platform via Helm.

## What's changing?

- Bump chart version `4.128.0` → `4.128.1` in `Chart.yaml`
- Update version badge in `README.md`

## How Tested

Version-only bump; CI runs Helm unit tests and pre-commit hooks. No template changes.

