### PR TITLE
feat: allowlist CSV export endpoint in dashboard nginx

### DIFF
--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -44,6 +44,7 @@ data:
         ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
         ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
         ~*^GET/v1/views/cost/details(\?|$)                                        1;
+        ~*^GET/v1/views/cost/details/export(\?|$)                                 1;
         ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
         ~*^GET/v1/views/cost/projected(\?|$)                                      1;
         ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -40,6 +40,7 @@ Should default to v2 port:
             ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
             ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
             ~*^GET/v1/views/cost/details(\?|$)                                        1;
+            ~*^GET/v1/views/cost/details/export(\?|$)                                 1;
             ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
             ~*^GET/v1/views/cost/projected(\?|$)                                      1;
             ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
@@ -158,6 +159,7 @@ should set extras in config.json:
             ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
             ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
             ~*^GET/v1/views/cost/details(\?|$)                                        1;
+            ~*^GET/v1/views/cost/details/export(\?|$)                                 1;
             ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
             ~*^GET/v1/views/cost/projected(\?|$)                                      1;
             ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;


### PR DESCRIPTION
# What's changing and why?

Adds GET /v1/views/cost/details/export to the dashboard nginx allowlist. This endpoint was added to support CSV export of cost analysis data. Without this entry, the request is blocked with a 403 in deployed environments.