### PR TITLE
Upgrade timescale to 2.28.2

### DIFF
--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -8,7 +8,7 @@ Default containers should match snapshots:
             name: thoras-timescale-password
       - name: PGDATA
         value: /var/lib/share/postgresql
-    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.27.0-pg16
+    image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.28.2-pg16
     imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -105,7 +105,7 @@ Default matches snapshot:
                 - name: SERVICE_SHOULD_MIGRATE_ON_START
                   value: "true"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.27.0
+                  value: 2.28.2
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -421,7 +421,7 @@ Default matches snapshot:
                       name: thoras-timescale-password
                 - name: PGDATA
                   value: /var/lib/share/postgresql
-              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.27.0-pg16
+              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.28.2-pg16
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -1048,7 +1048,7 @@ Default matches snapshot:
                 - name: SERVICE_SHOULD_MIGRATE_ON_START
                   value: "true"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.27.0
+                  value: 2.28.2
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS
@@ -1429,7 +1429,7 @@ Default matches snapshot:
                 - name: SERVICE_SHOULD_MIGRATE_ON_START
                   value: "true"
                 - name: SERVICE_TIMESCALE_EXTENSION_VERSION
-                  value: 2.27.0
+                  value: 2.28.2
                 - name: SERVICE_ENABLE_INFORMERS_STRIP_MANAGED_FIELDS
                   value: "true"
                 - name: SERVICE_ENABLE_TYPED_INFORMERS

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: metrics-collector
       - equal:
           path: spec.template.spec.containers[?(@.name == 'timescaledb')].image
-          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.27.0-pg16
+          value: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.28.2-pg16
   - it: Default containers should match snapshots
     chart:
       version: "4.50.0"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -252,8 +252,8 @@ metricsCollector:
       memory: "32Mi"
   timescale:
     image: "timescaledb"
-    imageTag: "2.27.0-pg16"
-    extensionVersion: "2.27.0"
+    imageTag: "2.28.2-pg16"
+    extensionVersion: "2.28.2"
     name: timescale
     containerPort: 5432
     # Specify the complete resources block (takes precedence if set)


### PR DESCRIPTION
# What's changing and why?

Upgrading to the latest timescale image, 2.82.2-pg16