### PR TITLE
feat: allow extraContainers on thorasDashboard

### DIFF
--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -84,6 +84,9 @@ spec:
           - name: nginx-config
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+      {{- if .Values.thorasDashboard.extraContainers }}
+      {{- toYaml .Values.thorasDashboard.extraContainers | nindent 6 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/thoras/tests/dashboard_deployment_test.yaml
+++ b/charts/thoras/tests/dashboard_deployment_test.yaml
@@ -54,6 +54,27 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.tolerations
+  - it: Should add extra containers if specified
+    set:
+      thorasDashboard:
+        unittesting: true
+        extraContainers:
+          - name: sidecar
+            image: example/sidecar:latest
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: sidecar
+            image: example/sidecar:latest
+  - it: Should not add extra containers if not specified
+    set:
+      thorasDashboard:
+        unittesting: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
   - it: Can override resources block
     set:
       thorasDashboard:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -490,6 +490,7 @@ thorasDashboard:
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
   extraEgressRules: []
+  extraContainers: []
 
 thorasMonitor:
   unittesting: false


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Lets operators attach sidecar containers (e.g. log shippers, proxies) to the dashboard pod without forking the chart.

## What's changing?

- Add `thorasDashboard.extraContainers` to render additional containers in the dashboard deployment
- Default to `[]` (no behavior change when unset)

## How Tested

Added unit tests covering both the extra-container and default (no extra containers) cases.
