### PR TITLE
v4.130.0

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.129.2
+version: 4.130.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.129.2](https://img.shields.io/badge/Version-4.129.2-informational?style=flat-square) ![AppVersion: 4.106.2](https://img.shields.io/badge/AppVersion-4.106.2-informational?style=flat-square)
+![Version: 4.130.0](https://img.shields.io/badge/Version-4.130.0-informational?style=flat-square) ![AppVersion: 4.106.2](https://img.shields.io/badge/AppVersion-4.106.2-informational?style=flat-square)
 
 # Installs
 


### PR DESCRIPTION
# What's changing and why?

Bump chart version to 4.130.0 for release, per the repo's trunk-based release workflow (release branch cut from main, version bump in `Chart.yaml`).