### PR TITLE
Remove always on enableASTOwnerReference

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -148,7 +148,7 @@ All components support `<component>.useGlobalAffinity` (default: `true`) and `<c
 | thorasForecast.ignoreNewPods                 | Boolean  | true                   | Directs forecaster to adjust CPU and memory metrics temporarily for new pods                   |
 | thorasForecast.enableDecoupledTraining       | Boolean  | true                   | Enables async training mode where forecasts report "needs_training" instead of training inline |
 | thorasForecast.useAstMetricsSeries           | Boolean  | false                  | Enables catalog-free training data fetching via the AST metrics series endpoint                |
-| thorasForecast.useForecasterComputedMetricId | Boolean  | false                  | Computes legacy metric IDs locally in Python instead of fetching from the catalog              |
+| thorasForecast.useForecasterComputedMetricId | Boolean  | true                   | Computes legacy metric IDs locally in Python instead of fetching from the catalog              |
 | thorasForecast.worker.podAnnotations         | Object   | {}                     | Pod Annotations for Thoras Forecast                                                            |
 | thorasForecast.worker.labels                 | Object   | {}                     | Pod labels for Thoras Forecast                                                                 |
 | thorasForecast.worker.replicas               | Number   | 1                      | Number of `thoras-forecast-worker` replicas to use                                             |

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -86,7 +86,6 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects  |
 | featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
-| featureFlags.enableASTOwnerReference           | Boolean | true    | If true, sets owner reference on ASTs to target workload  |
 | featureFlags.enableAstRecordMirroring          | Boolean | false   | If true, ASTs are mirrored to the database component      |
 | featureFlags.enableDaemonSetAutoscaler         | Boolean | false   | If true, DaemonSetAutoscaler resources are enabled        |
 

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -191,8 +191,6 @@ spec:
             value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
           - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
             value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
-          - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
-            value: {{ .Values.featureFlags.enableASTOwnerReference | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
             value: {{ .Values.featureFlags.enableAstRecordMirroring | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1059,8 +1059,6 @@ Default matches snapshot:
                   value: "92"
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
                   value: "false"
-                - name: SERVICE_ENABLE_AST_OWNER_REFERENCE
-                  value: "true"
                 - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
                   value: "false"
                 - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -311,7 +311,7 @@ tests:
             name: USE_AST_METRICS_SERIES
             value: "false"
 
-  - it: renders USE_FORECASTER_COMPUTED_METRIC_ID as false by default
+  - it: renders USE_FORECASTER_COMPUTED_METRIC_ID as true by default
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == 'thoras-forecast-worker')].env
@@ -319,7 +319,7 @@ tests:
             name: USE_FORECASTER_COMPUTED_METRIC_ID
             value: "true"
 
-  - it: renders USE_FORECASTER_COMPUTED_METRIC_ID as true when useForecasterComputedMetricId is true
+  - it: renders USE_FORECASTER_COMPUTED_METRIC_ID as false when useForecasterComputedMetricId is false
     set:
       thorasForecast:
         useForecasterComputedMetricId: false

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -62,7 +62,6 @@ featureFlags:
   enableInformersStripManagedFields: true
   enableTypedInformers: true
   enableDisruptionSchedulerWorker: false
-  enableASTOwnerReference: true
   enableAstRecordMirroring: false
   enableForecastCollectorAntiAffinity: true
   enableDaemonSetAutoscaler: false


### PR DESCRIPTION
# What's changing and why?

The `enableASTOwnerReference` is always on and is no longer needed.