### PR TITLE
Add multi-dimensional feature flag

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -86,6 +86,8 @@ spec:
             value: {{ .Values.thorasForecast.useForecastEnrichment | ternary "true" "false" | quote }}
           - name: TRAINING_JITTER_MINUTES
             value: {{ .Values.thorasForecast.trainingJitterMinutes | quote }}
+          - name: MULTI_DIMENSIONAL_ENABLED
+            value: {{ .Values.featureFlags.enableMultiDimensional | ternary "true" "false" | quote }}
           - name: AFFINITY_ID
             valueFrom:
               fieldRef:

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -197,6 +197,8 @@ spec:
             value: {{ .Values.featureFlags.enableAstRecordMirroring | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
             value: {{ .Values.featureFlags.enableDaemonSetAutoscaler | ternary "true" "false" | quote }}
+          - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
+            value: {{ .Values.featureFlags.enableMultiDimensional | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -275,6 +275,8 @@ spec:
             value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
           - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
             value: {{ .Values.featureFlags.enableDaemonSetAutoscaler | ternary "true" "false" | quote }}
+          - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
+            value: {{ .Values.featureFlags.enableMultiDimensional | ternary "true" "false" | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1067,6 +1067,8 @@ Default matches snapshot:
                   value: "false"
                 - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
                   value: "false"
+                - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -854,6 +854,8 @@ Default matches snapshot:
                   value: "false"
                 - name: TRAINING_JITTER_MINUTES
                   value: "0"
+                - name: MULTI_DIMENSIONAL_ENABLED
+                  value: "false"
                 - name: AFFINITY_ID
                   valueFrom:
                     fieldRef:
@@ -1503,6 +1505,8 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
                   value: "false"
                 - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
+                  value: "false"
+                - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -66,6 +66,7 @@ featureFlags:
   enableAstRecordMirroring: false
   enableForecastCollectorAntiAffinity: true
   enableDaemonSetAutoscaler: false
+  enableMultiDimensional: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
## What's changing and why?

Adds a new `enableMultiDimensional` feature flag, wired into the worker and forecast-worker deployments as `SERVICE_MULTI_DIMENSIONAL_ENABLED` / `MULTI_DIMENSIONAL_ENABLED` env vars. Defaults to `false`, keeping current behavior unchanged until enabled.

## How Tested

Updated Helm unit test snapshots to reflect the new env vars; `helm unittest` passes.