### PR TITLE
Add model spec and suggestion status fields to AIScaleTarget CRD

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -559,6 +559,111 @@ spec:
                     - observe
                     - observation
                     type: string
+                  model:
+                    description: |-
+                      Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                      how often forecasts are generated, how far ahead to predict, and how
+                      aggressively to scale.
+                    properties:
+                      forecast_blocks:
+                        default: 15m0s
+                        description: Time duration for how far into the future Thoras
+                          should forecast into.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_buffer_percentage:
+                        default: 0%
+                        description: Percentage, represented as a int between 1 and
+                          100, that Thoras will apply on top of predictions for safety.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_cron:
+                        type: string
+                      forecast_interval:
+                        description: |-
+                          Time duration for the how frequently Thoras forecasts. This provides
+                          control for how often scaling decisions are made. Mutually exclusive with
+                          forecastCron.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      metrics:
+                        additionalProperties:
+                          description: |-
+                            Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                            The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                            because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                            That check is handled by the admission webhook, which has full context.
+                          properties:
+                            forecast_buffer_percentage:
+                              description: Buffer percentage for this metric. Overrides
+                                global forecast_buffer_percentage.
+                              type: string
+                              x-kubernetes-int-or-string: true
+                            mode:
+                              description: Forecast mode for this metric. Overrides
+                                global model.mode.
+                              enum:
+                              - balanced
+                              - cost_optimized
+                              - undershoot
+                              - assurance_optimized
+                              - overshoot
+                              - percentile
+                              type: string
+                            percentile_value:
+                              description: |-
+                                Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                              type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                          x-kubernetes-validations:
+                          - message: percentile_value can only be set when mode is
+                              percentile
+                            rule: '!has(self.mode) || self.mode == ''percentile''
+                              || !has(self.percentile_value)'
+                        description: Per-metric forecast configuration. Overrides
+                          global mode and forecast_buffer_percentage for specific
+                          metrics.
+                        type: object
+                      min_lookback_to_scale:
+                        description: Minimum lookback window before autonomous scaling
+                          is enabled. Autonomous scaling will only occur if historical
+                          data spans at least this duration.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      mode:
+                        description: While Thoras models always bias for reliability,
+                          you have the option to set a "mode" for the model to inform
+                          the level of aggression in scaling.
+                        enum:
+                        - balanced
+                        - cost_optimized
+                        - undershoot
+                        - assurance_optimized
+                        - overshoot
+                        - percentile
+                        type: string
+                      percentile_value:
+                        description: |-
+                          Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                          Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                        type: string
+                        x-kubernetes-int-or-string: true
+                    type: object
+                    x-kubernetes-validations:
+                    - message: forecastCron and forecastInterval are mutually exclusive
+                      rule: '!has(self.forecast_cron) || self.forecast_cron == ''''
+                        || !has(self.forecast_interval) || self.forecast_interval
+                        == '''''
+                    - message: forecastInterval must be less than or equal to forecastBlocks
+                      rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                    - message: percentile_value is required when mode is percentile
+                      rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
+                    - message: percentile_value can only be set when mode is percentile
+                      rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
+                        == ''percentile'')'
                   scaling_behavior:
                     description: Rules for how large a proposed scale event must be
                       before triggering
@@ -741,9 +846,8 @@ spec:
                   rule: '!has(self.forecast_cron) || self.forecast_cron == '''' ||
                     !has(self.forecast_interval) || self.forecast_interval == '''''
                 - message: forecastInterval must be less than or equal to forecastBlocks
-                  rule: '!has(self.forecast_interval) || self.forecast_interval ==
-                    '''' || !has(self.forecast_blocks) || self.forecast_blocks ==
-                    '''' || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                  rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                    || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
                 - message: percentile_value is required when mode is percentile
                   rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
                 - message: percentile_value can only be set when mode is percentile
@@ -947,14 +1051,14 @@ spec:
                     type: array
                   disruption:
                     description: |-
-                      Disruption controls how aggressively Thoras evicts pods when applying
-                      vertical recommendations that require pod recreation.
+                      Disruption controls how aggressively Thoras applies pod changes (in-place
+                      resize or eviction) when applying vertical recommendations.
                     properties:
                       interval:
                         default: 60s
                         description: |-
                           Interval is the minimum duration the operator waits after a batch of
-                          evictions before evicting the next batch. Defaults to 60s.
+                          pod changes (resize or evict) before applying the next batch. Defaults to 60s.
                         type: string
                       max_disrupted:
                         anyOf:
@@ -965,13 +1069,13 @@ spec:
                           MaxDisrupted is the maximum number of pods that may be
                           disrupted at once across the workload. A pod is "disrupted" if it is
                           terminating or its Ready condition is not True. The operator only
-                          evicts up to the remaining headroom in each batch, so prior batches
-                          that haven't finished rolling reduce the next batch's size. After
-                          issuing a batch, the operator waits Interval before issuing the next
-                          batch. Unlike PodDisruptionBudget.maxUnavailable, this cap is enforced
-                          by the operator itself: pods that are unavailable for reasons
-                          unrelated to Thoras (e.g. failing readiness probes) still consume the
-                          budget.
+                          applies pod changes (resize or evict) up to the remaining headroom in
+                          each batch, so prior batches that haven't finished rolling reduce the
+                          next batch's size. After issuing a batch, the operator waits Interval
+                          before issuing the next batch. Unlike PodDisruptionBudget.maxUnavailable,
+                          this cap is enforced by the operator itself: pods that are unavailable
+                          for reasons unrelated to Thoras (e.g. failing readiness probes) still
+                          consume the budget.
 
                           Accepts an absolute integer (e.g. 2) or a percentage of the workload's
                           desired replicas (e.g. "25%"). Defaults to 20%.
@@ -1004,6 +1108,111 @@ spec:
                     - observe
                     - observation
                     type: string
+                  model:
+                    description: |-
+                      Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                      how often forecasts are generated, how far ahead to predict, and how
+                      aggressively to scale.
+                    properties:
+                      forecast_blocks:
+                        default: 15m0s
+                        description: Time duration for how far into the future Thoras
+                          should forecast into.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_buffer_percentage:
+                        default: 0%
+                        description: Percentage, represented as a int between 1 and
+                          100, that Thoras will apply on top of predictions for safety.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_cron:
+                        type: string
+                      forecast_interval:
+                        description: |-
+                          Time duration for the how frequently Thoras forecasts. This provides
+                          control for how often scaling decisions are made. Mutually exclusive with
+                          forecastCron.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      metrics:
+                        additionalProperties:
+                          description: |-
+                            Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                            The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                            because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                            That check is handled by the admission webhook, which has full context.
+                          properties:
+                            forecast_buffer_percentage:
+                              description: Buffer percentage for this metric. Overrides
+                                global forecast_buffer_percentage.
+                              type: string
+                              x-kubernetes-int-or-string: true
+                            mode:
+                              description: Forecast mode for this metric. Overrides
+                                global model.mode.
+                              enum:
+                              - balanced
+                              - cost_optimized
+                              - undershoot
+                              - assurance_optimized
+                              - overshoot
+                              - percentile
+                              type: string
+                            percentile_value:
+                              description: |-
+                                Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                              type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                          x-kubernetes-validations:
+                          - message: percentile_value can only be set when mode is
+                              percentile
+                            rule: '!has(self.mode) || self.mode == ''percentile''
+                              || !has(self.percentile_value)'
+                        description: Per-metric forecast configuration. Overrides
+                          global mode and forecast_buffer_percentage for specific
+                          metrics.
+                        type: object
+                      min_lookback_to_scale:
+                        description: Minimum lookback window before autonomous scaling
+                          is enabled. Autonomous scaling will only occur if historical
+                          data spans at least this duration.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      mode:
+                        description: While Thoras models always bias for reliability,
+                          you have the option to set a "mode" for the model to inform
+                          the level of aggression in scaling.
+                        enum:
+                        - balanced
+                        - cost_optimized
+                        - undershoot
+                        - assurance_optimized
+                        - overshoot
+                        - percentile
+                        type: string
+                      percentile_value:
+                        description: |-
+                          Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                          Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                        type: string
+                        x-kubernetes-int-or-string: true
+                    type: object
+                    x-kubernetes-validations:
+                    - message: forecastCron and forecastInterval are mutually exclusive
+                      rule: '!has(self.forecast_cron) || self.forecast_cron == ''''
+                        || !has(self.forecast_interval) || self.forecast_interval
+                        == '''''
+                    - message: forecastInterval must be less than or equal to forecastBlocks
+                      rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                    - message: percentile_value is required when mode is percentile
+                      rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
+                    - message: percentile_value can only be set when mode is percentile
+                      rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
+                        == ''percentile'')'
                   oom_remediation:
                     description: |-
                       OOMRemediation configures operator-driven memory adjustment during active OOM episodes.
@@ -1216,6 +1425,39 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              horizontalSuggestion:
+                properties:
+                  currentReplicas:
+                    format: int32
+                    type: integer
+                  end:
+                    format: date-time
+                    type: string
+                  forecastError:
+                    description: |-
+                      ForecastError is set when a general forecasting error occurred that blocks all scaling.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                    type: string
+                  hasEnoughDataToScale:
+                    description: |-
+                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                    type: boolean
+                  start:
+                    format: date-time
+                    type: string
+                  suggestedReplicas:
+                    format: int32
+                    type: integer
+                  suggestionUID:
+                    type: string
+                required:
+                - currentReplicas
+                - end
+                - hasEnoughDataToScale
+                - start
+                - suggestedReplicas
+                type: object
               labelSelector:
                 type: string
               lastCollectionTime:
@@ -1415,6 +1657,104 @@ spec:
                   Deprecated: Use LatestSuggestion.SuggestedReplicas instead.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              verticalSuggestion:
+                properties:
+                  containers:
+                    description: Containers contains optimal resource requirements
+                      for each container.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This field depends on the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      - resources
+                      type: object
+                    type: array
+                  end:
+                    format: date-time
+                    type: string
+                  forecastError:
+                    description: |-
+                      ForecastError is set when a general forecasting error occurred that blocks all scaling.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                    type: string
+                  hasEnoughDataToScale:
+                    description: |-
+                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                    type: boolean
+                  start:
+                    format: date-time
+                    type: string
+                  suggestionUID:
+                    type: string
+                required:
+                - end
+                - hasEnoughDataToScale
+                - start
+                type: object
             type: object
         required:
         - metadata

--- a/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
+++ b/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
@@ -637,6 +637,115 @@ spec:
                         - observe
                         - observation
                         type: string
+                      model:
+                        description: |-
+                          Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                          how often forecasts are generated, how far ahead to predict, and how
+                          aggressively to scale.
+                        properties:
+                          forecast_blocks:
+                            default: 15m0s
+                            description: Time duration for how far into the future
+                              Thoras should forecast into.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          forecast_buffer_percentage:
+                            default: 0%
+                            description: Percentage, represented as a int between
+                              1 and 100, that Thoras will apply on top of predictions
+                              for safety.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          forecast_cron:
+                            type: string
+                          forecast_interval:
+                            description: |-
+                              Time duration for the how frequently Thoras forecasts. This provides
+                              control for how often scaling decisions are made. Mutually exclusive with
+                              forecastCron.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          metrics:
+                            additionalProperties:
+                              description: |-
+                                Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                                The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                                because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                                That check is handled by the admission webhook, which has full context.
+                              properties:
+                                forecast_buffer_percentage:
+                                  description: Buffer percentage for this metric.
+                                    Overrides global forecast_buffer_percentage.
+                                  type: string
+                                  x-kubernetes-int-or-string: true
+                                mode:
+                                  description: Forecast mode for this metric. Overrides
+                                    global model.mode.
+                                  enum:
+                                  - balanced
+                                  - cost_optimized
+                                  - undershoot
+                                  - assurance_optimized
+                                  - overshoot
+                                  - percentile
+                                  type: string
+                                percentile_value:
+                                  description: |-
+                                    Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                    Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                                  type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                              x-kubernetes-validations:
+                              - message: percentile_value can only be set when mode
+                                  is percentile
+                                rule: '!has(self.mode) || self.mode == ''percentile''
+                                  || !has(self.percentile_value)'
+                            description: Per-metric forecast configuration. Overrides
+                              global mode and forecast_buffer_percentage for specific
+                              metrics.
+                            type: object
+                          min_lookback_to_scale:
+                            description: Minimum lookback window before autonomous
+                              scaling is enabled. Autonomous scaling will only occur
+                              if historical data spans at least this duration.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          mode:
+                            description: While Thoras models always bias for reliability,
+                              you have the option to set a "mode" for the model to
+                              inform the level of aggression in scaling.
+                            enum:
+                            - balanced
+                            - cost_optimized
+                            - undershoot
+                            - assurance_optimized
+                            - overshoot
+                            - percentile
+                            type: string
+                          percentile_value:
+                            description: |-
+                              Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                              Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                            type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                        x-kubernetes-validations:
+                        - message: forecastCron and forecastInterval are mutually
+                            exclusive
+                          rule: '!has(self.forecast_cron) || self.forecast_cron ==
+                            '''' || !has(self.forecast_interval) || self.forecast_interval
+                            == '''''
+                        - message: forecastInterval must be less than or equal to
+                            forecastBlocks
+                          rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                            || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                        - message: percentile_value is required when mode is percentile
+                          rule: '!has(self.mode) || self.mode != ''percentile'' ||
+                            has(self.percentile_value)'
+                        - message: percentile_value can only be set when mode is percentile
+                          rule: '!has(self.percentile_value) || (has(self.mode) &&
+                            self.mode == ''percentile'')'
                       scaling_behavior:
                         description: Rules for how large a proposed scale event must
                           be before triggering
@@ -825,9 +934,8 @@ spec:
                         || !has(self.forecast_interval) || self.forecast_interval
                         == '''''
                     - message: forecastInterval must be less than or equal to forecastBlocks
-                      rule: '!has(self.forecast_interval) || self.forecast_interval
-                        == '''' || !has(self.forecast_blocks) || self.forecast_blocks
-                        == '''' || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                      rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
                     - message: percentile_value is required when mode is percentile
                       rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
                     - message: percentile_value can only be set when mode is percentile
@@ -971,14 +1079,14 @@ spec:
                         type: array
                       disruption:
                         description: |-
-                          Disruption controls how aggressively Thoras evicts pods when applying
-                          vertical recommendations that require pod recreation.
+                          Disruption controls how aggressively Thoras applies pod changes (in-place
+                          resize or eviction) when applying vertical recommendations.
                         properties:
                           interval:
                             default: 60s
                             description: |-
                               Interval is the minimum duration the operator waits after a batch of
-                              evictions before evicting the next batch. Defaults to 60s.
+                              pod changes (resize or evict) before applying the next batch. Defaults to 60s.
                             type: string
                           max_disrupted:
                             anyOf:
@@ -989,13 +1097,13 @@ spec:
                               MaxDisrupted is the maximum number of pods that may be
                               disrupted at once across the workload. A pod is "disrupted" if it is
                               terminating or its Ready condition is not True. The operator only
-                              evicts up to the remaining headroom in each batch, so prior batches
-                              that haven't finished rolling reduce the next batch's size. After
-                              issuing a batch, the operator waits Interval before issuing the next
-                              batch. Unlike PodDisruptionBudget.maxUnavailable, this cap is enforced
-                              by the operator itself: pods that are unavailable for reasons
-                              unrelated to Thoras (e.g. failing readiness probes) still consume the
-                              budget.
+                              applies pod changes (resize or evict) up to the remaining headroom in
+                              each batch, so prior batches that haven't finished rolling reduce the
+                              next batch's size. After issuing a batch, the operator waits Interval
+                              before issuing the next batch. Unlike PodDisruptionBudget.maxUnavailable,
+                              this cap is enforced by the operator itself: pods that are unavailable
+                              for reasons unrelated to Thoras (e.g. failing readiness probes) still
+                              consume the budget.
 
                               Accepts an absolute integer (e.g. 2) or a percentage of the workload's
                               desired replicas (e.g. "25%"). Defaults to 20%.
@@ -1029,6 +1137,115 @@ spec:
                         - observe
                         - observation
                         type: string
+                      model:
+                        description: |-
+                          Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                          how often forecasts are generated, how far ahead to predict, and how
+                          aggressively to scale.
+                        properties:
+                          forecast_blocks:
+                            default: 15m0s
+                            description: Time duration for how far into the future
+                              Thoras should forecast into.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          forecast_buffer_percentage:
+                            default: 0%
+                            description: Percentage, represented as a int between
+                              1 and 100, that Thoras will apply on top of predictions
+                              for safety.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          forecast_cron:
+                            type: string
+                          forecast_interval:
+                            description: |-
+                              Time duration for the how frequently Thoras forecasts. This provides
+                              control for how often scaling decisions are made. Mutually exclusive with
+                              forecastCron.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          metrics:
+                            additionalProperties:
+                              description: |-
+                                Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                                The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                                because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                                That check is handled by the admission webhook, which has full context.
+                              properties:
+                                forecast_buffer_percentage:
+                                  description: Buffer percentage for this metric.
+                                    Overrides global forecast_buffer_percentage.
+                                  type: string
+                                  x-kubernetes-int-or-string: true
+                                mode:
+                                  description: Forecast mode for this metric. Overrides
+                                    global model.mode.
+                                  enum:
+                                  - balanced
+                                  - cost_optimized
+                                  - undershoot
+                                  - assurance_optimized
+                                  - overshoot
+                                  - percentile
+                                  type: string
+                                percentile_value:
+                                  description: |-
+                                    Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                    Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                                  type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                              x-kubernetes-validations:
+                              - message: percentile_value can only be set when mode
+                                  is percentile
+                                rule: '!has(self.mode) || self.mode == ''percentile''
+                                  || !has(self.percentile_value)'
+                            description: Per-metric forecast configuration. Overrides
+                              global mode and forecast_buffer_percentage for specific
+                              metrics.
+                            type: object
+                          min_lookback_to_scale:
+                            description: Minimum lookback window before autonomous
+                              scaling is enabled. Autonomous scaling will only occur
+                              if historical data spans at least this duration.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          mode:
+                            description: While Thoras models always bias for reliability,
+                              you have the option to set a "mode" for the model to
+                              inform the level of aggression in scaling.
+                            enum:
+                            - balanced
+                            - cost_optimized
+                            - undershoot
+                            - assurance_optimized
+                            - overshoot
+                            - percentile
+                            type: string
+                          percentile_value:
+                            description: |-
+                              Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                              Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                            type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                        x-kubernetes-validations:
+                        - message: forecastCron and forecastInterval are mutually
+                            exclusive
+                          rule: '!has(self.forecast_cron) || self.forecast_cron ==
+                            '''' || !has(self.forecast_interval) || self.forecast_interval
+                            == '''''
+                        - message: forecastInterval must be less than or equal to
+                            forecastBlocks
+                          rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                            || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                        - message: percentile_value is required when mode is percentile
+                          rule: '!has(self.mode) || self.mode != ''percentile'' ||
+                            has(self.percentile_value)'
+                        - message: percentile_value can only be set when mode is percentile
+                          rule: '!has(self.percentile_value) || (has(self.mode) &&
+                            self.mode == ''percentile'')'
                       oom_remediation:
                         description: |-
                           OOMRemediation configures operator-driven memory adjustment during active OOM episodes.


### PR DESCRIPTION
## What's changing and why?

Adds the `spec.model` block to the AIScaleTarget CRD for configuring forecasting and scaling behavior — `forecast_blocks`, `forecast_interval`/`forecast_cron`, `forecast_buffer_percentage`, `mode`, `percentile_value`, `min_lookback_to_scale`, and per-metric overrides — with CEL validation for mutual exclusivity and percentile constraints.

Also adds `status.horizontalSuggestion` and `status.verticalSuggestion` to expose forecast window, replica/resource recommendations, and data-sufficiency to consumers, and clarifies `disruption` docs to reflect that pod changes can be in-place resizes, not just evictions.

## How Tested

Ran `helm unittest ./charts/thoras` against the updated CRD schema.