### PR TITLE
Validation requiring cpu or memory for containers

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -12,1266 +12,796 @@ spec:
     listKind: AIScaleTargetList
     plural: aiscaletargets
     shortNames:
-      - ast
+    - ast
     singular: aiscaletarget
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.model.mode
-          name: Model
-          type: string
-        - jsonPath: .spec.horizontal.mode
-          name: Horizontal
-          type: string
-        - jsonPath: .spec.vertical.mode
-          name: Vertical
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: AIScaleTarget is a AIScaleTarget resource.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: AiScaleTargetSpec is the spec of a AiScaleTarget resource.
-              properties:
-                horizontal:
-                  properties:
-                    additional_metrics:
-                      description:
-                        Metrics to scale off of in addition to the metrics
-                        defined in HPA
-                      items:
-                        description: |-
-                          MetricSpec specifies how to scale based on a single metric
-                          (only `type` and one other matching field should be set at once).
-                        properties:
-                          containerResource:
-                            description: |-
-                              containerResource refers to a resource metric (such as those specified in
-                              requests and limits) known to Kubernetes describing a single container in
-                              each pod of the current scale target (e.g. CPU or memory). Such metrics are
-                              built in to Kubernetes, and have special scaling options on top of those
-                              available to normal per-pod metrics using the "pods" source.
-                            properties:
-                              container:
-                                description:
-                                  container is the name of the container
-                                  in the pods of the scaling target
-                                type: string
-                              name:
-                                description: name is the name of the resource in question.
-                                type: string
-                              target:
-                                description:
-                                  target specifies the target value for the
-                                  given metric
-                                properties:
-                                  averageUtilization:
-                                    description: |-
-                                      averageUtilization is the target value of the average of the
-                                      resource metric across all relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source type
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: |-
-                                      averageValue is the target value of the average of the
-                                      metric across all relevant pods (as a quantity)
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type:
-                                    description:
-                                      type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
-                                    type: string
-                                  value:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      value is the target value of the metric
-                                      (as a quantity).
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - type
-                                type: object
-                            required:
-                              - container
-                              - name
-                              - target
-                            type: object
-                          external:
-                            description: |-
-                              external refers to a global metric that is not associated
-                              with any Kubernetes object. It allows autoscaling based on information
-                              coming from components running outside of cluster
-                              (for example length of queue in cloud messaging service, or
-                              QPS from loadbalancer running outside of cluster).
-                            properties:
-                              metric:
-                                description:
-                                  metric identifies the target metric by
-                                  name and selector
-                                properties:
-                                  name:
-                                    description: name is the name of the given metric
-                                    type: string
-                                  selector:
-                                    description: |-
-                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
-                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
-                                      When unset, just the metricName will be used to gather metrics.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                required:
-                                  - name
-                                type: object
-                              target:
-                                description:
-                                  target specifies the target value for the
-                                  given metric
-                                properties:
-                                  averageUtilization:
-                                    description: |-
-                                      averageUtilization is the target value of the average of the
-                                      resource metric across all relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source type
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: |-
-                                      averageValue is the target value of the average of the
-                                      metric across all relevant pods (as a quantity)
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type:
-                                    description:
-                                      type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
-                                    type: string
-                                  value:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      value is the target value of the metric
-                                      (as a quantity).
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - type
-                                type: object
-                            required:
-                              - metric
-                              - target
-                            type: object
-                          object:
-                            description: |-
-                              object refers to a metric describing a single kubernetes object
-                              (for example, hits-per-second on an Ingress object).
-                            properties:
-                              describedObject:
-                                description:
-                                  describedObject specifies the descriptions
-                                  of a object,such as kind,name apiVersion
-                                properties:
-                                  apiVersion:
-                                    description:
-                                      apiVersion is the API version of the
-                                      referent
-                                    type: string
-                                  kind:
-                                    description:
-                                      "kind is the kind of the referent;
-                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-                                    type: string
-                                  name:
-                                    description:
-                                      "name is the name of the referent;
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
-                                    type: string
-                                required:
-                                  - kind
-                                  - name
-                                type: object
-                              metric:
-                                description:
-                                  metric identifies the target metric by
-                                  name and selector
-                                properties:
-                                  name:
-                                    description: name is the name of the given metric
-                                    type: string
-                                  selector:
-                                    description: |-
-                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
-                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
-                                      When unset, just the metricName will be used to gather metrics.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                required:
-                                  - name
-                                type: object
-                              target:
-                                description:
-                                  target specifies the target value for the
-                                  given metric
-                                properties:
-                                  averageUtilization:
-                                    description: |-
-                                      averageUtilization is the target value of the average of the
-                                      resource metric across all relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source type
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: |-
-                                      averageValue is the target value of the average of the
-                                      metric across all relevant pods (as a quantity)
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type:
-                                    description:
-                                      type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
-                                    type: string
-                                  value:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      value is the target value of the metric
-                                      (as a quantity).
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - type
-                                type: object
-                            required:
-                              - describedObject
-                              - metric
-                              - target
-                            type: object
-                          pods:
-                            description: |-
-                              pods refers to a metric describing each pod in the current scale target
-                              (for example, transactions-processed-per-second).  The values will be
-                              averaged together before being compared to the target value.
-                            properties:
-                              metric:
-                                description:
-                                  metric identifies the target metric by
-                                  name and selector
-                                properties:
-                                  name:
-                                    description: name is the name of the given metric
-                                    type: string
-                                  selector:
-                                    description: |-
-                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
-                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
-                                      When unset, just the metricName will be used to gather metrics.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                required:
-                                  - name
-                                type: object
-                              target:
-                                description:
-                                  target specifies the target value for the
-                                  given metric
-                                properties:
-                                  averageUtilization:
-                                    description: |-
-                                      averageUtilization is the target value of the average of the
-                                      resource metric across all relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source type
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: |-
-                                      averageValue is the target value of the average of the
-                                      metric across all relevant pods (as a quantity)
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type:
-                                    description:
-                                      type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
-                                    type: string
-                                  value:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      value is the target value of the metric
-                                      (as a quantity).
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - type
-                                type: object
-                            required:
-                              - metric
-                              - target
-                            type: object
-                          resource:
-                            description: |-
-                              resource refers to a resource metric (such as those specified in
-                              requests and limits) known to Kubernetes describing each pod in the
-                              current scale target (e.g. CPU or memory). Such metrics are built in to
-                              Kubernetes, and have special scaling options on top of those available
-                              to normal per-pod metrics using the "pods" source.
-                            properties:
-                              name:
-                                description: name is the name of the resource in question.
-                                type: string
-                              target:
-                                description:
-                                  target specifies the target value for the
-                                  given metric
-                                properties:
-                                  averageUtilization:
-                                    description: |-
-                                      averageUtilization is the target value of the average of the
-                                      resource metric across all relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source type
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: |-
-                                      averageValue is the target value of the average of the
-                                      metric across all relevant pods (as a quantity)
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type:
-                                    description:
-                                      type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
-                                    type: string
-                                  value:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      value is the target value of the metric
-                                      (as a quantity).
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - type
-                                type: object
-                            required:
-                              - name
-                              - target
-                            type: object
-                          type:
-                            description: |-
-                              type is the type of metric source.  It should be one of "ContainerResource", "External",
-                              "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-                            type: string
-                        required:
-                          - type
-                        type: object
-                      type: array
-                    exclude_metrics:
-                      description: Metrics from HPA for thoras to ignore
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          type:
-                            type: string
-                        required:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.model.mode
+      name: Model
+      type: string
+    - jsonPath: .spec.horizontal.mode
+      name: Horizontal
+      type: string
+    - jsonPath: .spec.vertical.mode
+      name: Vertical
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AIScaleTarget is a AIScaleTarget resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AiScaleTargetSpec is the spec of a AiScaleTarget resource.
+            properties:
+              horizontal:
+                properties:
+                  additional_metrics:
+                    description: Metrics to scale off of in addition to the metrics
+                      defined in HPA
+                    items:
+                      description: |-
+                        MetricSpec specifies how to scale based on a single metric
+                        (only `type` and one other matching field should be set at once).
+                      properties:
+                        containerResource:
+                          description: |-
+                            containerResource refers to a resource metric (such as those specified in
+                            requests and limits) known to Kubernetes describing a single container in
+                            each pod of the current scale target (e.g. CPU or memory). Such metrics are
+                            built in to Kubernetes, and have special scaling options on top of those
+                            available to normal per-pod metrics using the "pods" source.
+                          properties:
+                            container:
+                              description: container is the name of the container
+                                in the pods of the scaling target
+                              type: string
+                            name:
+                              description: name is the name of the resource in question.
+                              type: string
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - container
                           - name
-                          - type
-                        type: object
-                      type: array
-                    maxReplicas:
-                      description: |-
-                        maxReplicas is the upper limit for the number of replicas to which the Thoras
-                        can scale up.
-                        If not set, Thoras will use the MaxReplicas value from the target's HPA if available.
-                      format: int32
-                      minimum: 0
-                      type: integer
-                    minReplicas:
-                      description: |-
-                        minReplicas is the lower limit for the number of replicas to which the Thoras
-                        can scale down.
-                        If not set, Thoras will use the MinReplicas value from the target's HPA if available.
-                      format: int32
-                      minimum: 0
-                      type: integer
-                    mode:
-                      enum:
-                        - autonomous
-                        - auto
-                        - recommendation
-                        - recommend
-                        - rec
-                        - observe
-                        - observation
-                      type: string
-                    model:
-                      description: |-
-                        Defines the forecasting and scaling behavior for an AIScaleTarget, including
-                        how often forecasts are generated, how far ahead to predict, and how
-                        aggressively to scale.
-                      properties:
-                        forecast_blocks:
-                          default: 15m0s
-                          description:
-                            Time duration for how far into the future Thoras
-                            should forecast into.
-                          type: string
-                          x-kubernetes-int-or-string: true
-                        forecast_buffer_percentage:
-                          default: 0%
-                          description:
-                            Percentage, represented as a int between 1 and
-                            100, that Thoras will apply on top of predictions for safety.
-                          type: string
-                          x-kubernetes-int-or-string: true
-                        forecast_cron:
-                          type: string
-                        forecast_interval:
-                          description: |-
-                            Time duration for the how frequently Thoras forecasts. This provides
-                            control for how often scaling decisions are made. Mutually exclusive with
-                            forecastCron.
-                          type: string
-                          x-kubernetes-int-or-string: true
-                        metrics:
-                          additionalProperties:
-                            description: |-
-                              Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
-                              The "required" direction (mode: percentile without percentile_value) is intentionally omitted
-                              because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
-                              That check is handled by the admission webhook, which has full context.
-                            properties:
-                              forecast_buffer_percentage:
-                                description:
-                                  Buffer percentage for this metric. Overrides
-                                  global forecast_buffer_percentage.
-                                type: string
-                                x-kubernetes-int-or-string: true
-                              mode:
-                                description:
-                                  Forecast mode for this metric. Overrides
-                                  global model.mode.
-                                enum:
-                                  - balanced
-                                  - cost_optimized
-                                  - undershoot
-                                  - assurance_optimized
-                                  - overshoot
-                                  - percentile
-                                type: string
-                              percentile_value:
-                                description: |-
-                                  Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                                  Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                                type: string
-                                x-kubernetes-int-or-string: true
-                            type: object
-                            x-kubernetes-validations:
-                              - message:
-                                  percentile_value can only be set when mode is
-                                  percentile
-                                rule:
-                                  "!has(self.mode) || self.mode == 'percentile'
-                                  || !has(self.percentile_value)"
-                          description:
-                            Per-metric forecast configuration. Overrides
-                            global mode and forecast_buffer_percentage for specific
-                            metrics.
+                          - target
                           type: object
-                        min_lookback_to_scale:
-                          description:
-                            Minimum lookback window before autonomous scaling
-                            is enabled. Autonomous scaling will only occur if historical
-                            data spans at least this duration.
-                          type: string
-                          x-kubernetes-int-or-string: true
-                        mode:
-                          description:
-                            While Thoras models always bias for reliability,
-                            you have the option to set a "mode" for the model to inform
-                            the level of aggression in scaling.
-                          enum:
-                            - balanced
-                            - cost_optimized
-                            - undershoot
-                            - assurance_optimized
-                            - overshoot
-                            - percentile
-                          type: string
-                        percentile_value:
+                        external:
                           description: |-
-                            Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                            Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                          type: string
-                          x-kubernetes-int-or-string: true
-                      type: object
-                      x-kubernetes-validations:
-                        - message: forecastCron and forecastInterval are mutually exclusive
-                          rule:
-                            "!has(self.forecast_cron) || self.forecast_cron == ''
-                            || !has(self.forecast_interval) || self.forecast_interval
-                            == ''"
-                        - message: forecastInterval must be less than or equal to forecastBlocks
-                          rule:
-                            "!has(self.forecast_interval) || !has(self.forecast_blocks)
-                            || duration(self.forecast_interval) <= duration(self.forecast_blocks)"
-                        - message: percentile_value is required when mode is percentile
-                          rule: "!has(self.mode) || self.mode != 'percentile' || has(self.percentile_value)"
-                        - message: percentile_value can only be set when mode is percentile
-                          rule:
-                            "!has(self.percentile_value) || (has(self.mode) && self.mode
-                            == 'percentile')"
-                    scaling_behavior:
-                      description:
-                        Rules for how large a proposed scale event must be
-                        before triggering
-                      properties:
-                        scale_down:
+                            external refers to a global metric that is not associated
+                            with any Kubernetes object. It allows autoscaling based on information
+                            coming from components running outside of cluster
+                            (for example length of queue in cloud messaging service, or
+                            QPS from loadbalancer running outside of cluster).
                           properties:
-                            absolute:
-                              additionalProperties:
-                                anyOf:
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
                                   - type: integer
                                   - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: |-
-                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                                For vertical scaling: Use "memory" and "cpu" resource names.
-                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                  these absolute values to trigger scaling, regardless of current usage percentage.
-                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
-                              type: object
-                            percent:
-                              description: |-
-                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                              format: int32
-                              minimum: 0
-                              type: integer
-                            type:
-                              enum:
-                                - percent
-                                - absolute
-                              type: string
-                          required:
-                            - type
-                          type: object
-                          x-kubernetes-validations:
-                            - message: percent must be set when type is percent
-                              rule: "self.type == 'percent' ? has(self.percent) : true"
-                            - message: absolute must be set when type is absolute
-                              rule:
-                                "self.type == 'absolute' ? has(self.absolute) :
-                                true"
-                        scale_up:
-                          properties:
-                            absolute:
-                              additionalProperties:
-                                anyOf:
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
                                   - type: integer
                                   - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: |-
-                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                                For vertical scaling: Use "memory" and "cpu" resource names.
-                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                  these absolute values to trigger scaling, regardless of current usage percentage.
-                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
                               type: object
-                            percent:
-                              description: |-
-                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                              format: int32
-                              minimum: 0
-                              type: integer
-                            type:
-                              enum:
-                                - percent
-                                - absolute
-                              type: string
                           required:
-                            - type
+                          - metric
+                          - target
                           type: object
-                          x-kubernetes-validations:
-                            - message: percent must be set when type is percent
-                              rule: "self.type == 'percent' ? has(self.percent) : true"
-                            - message: absolute must be set when type is absolute
-                              rule:
-                                "self.type == 'absolute' ? has(self.absolute) :
-                                true"
+                        object:
+                          description: |-
+                            object refers to a metric describing a single kubernetes object
+                            (for example, hits-per-second on an Ingress object).
+                          properties:
+                            describedObject:
+                              description: describedObject specifies the descriptions
+                                of a object,such as kind,name apiVersion
+                              properties:
+                                apiVersion:
+                                  description: apiVersion is the API version of the
+                                    referent
+                                  type: string
+                                kind:
+                                  description: 'kind is the kind of the referent;
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'name is the name of the referent;
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - describedObject
+                          - metric
+                          - target
+                          type: object
+                        pods:
+                          description: |-
+                            pods refers to a metric describing each pod in the current scale target
+                            (for example, transactions-processed-per-second).  The values will be
+                            averaged together before being compared to the target value.
+                          properties:
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - metric
+                          - target
+                          type: object
+                        resource:
+                          description: |-
+                            resource refers to a resource metric (such as those specified in
+                            requests and limits) known to Kubernetes describing each pod in the
+                            current scale target (e.g. CPU or memory). Such metrics are built in to
+                            Kubernetes, and have special scaling options on top of those available
+                            to normal per-pod metrics using the "pods" source.
+                          properties:
+                            name:
+                              description: name is the name of the resource in question.
+                              type: string
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - target
+                          type: object
+                        type:
+                          description: |-
+                            type is the type of metric source.  It should be one of "ContainerResource", "External",
+                            "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+                          type: string
+                      required:
+                      - type
                       type: object
-                  required:
-                    - mode
-                  type: object
-                  x-kubernetes-validations:
-                    - message: minReplicas must not be greater than maxReplicas
-                      rule:
-                        "!has(self.minReplicas) || !has(self.maxReplicas) || self.minReplicas
-                        <= self.maxReplicas"
-                model:
-                  description: |-
-                    Defines the forecasting and scaling behavior for an AIScaleTarget, including
-                    how often forecasts are generated, how far ahead to predict, and how
-                    aggressively to scale.
-                  properties:
-                    forecast_blocks:
-                      default: 15m0s
-                      description:
-                        Time duration for how far into the future Thoras
-                        should forecast into.
-                      type: string
-                      x-kubernetes-int-or-string: true
-                    forecast_buffer_percentage:
-                      default: 0%
-                      description:
-                        Percentage, represented as a int between 1 and 100,
-                        that Thoras will apply on top of predictions for safety.
-                      type: string
-                      x-kubernetes-int-or-string: true
-                    forecast_cron:
-                      type: string
-                    forecast_interval:
-                      description: |-
-                        Time duration for the how frequently Thoras forecasts. This provides
-                        control for how often scaling decisions are made. Mutually exclusive with
-                        forecastCron.
-                      type: string
-                      x-kubernetes-int-or-string: true
-                    metrics:
-                      additionalProperties:
+                    type: array
+                  exclude_metrics:
+                    description: Metrics from HPA for thoras to ignore
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  maxReplicas:
+                    description: |-
+                      maxReplicas is the upper limit for the number of replicas to which the Thoras
+                      can scale up.
+                      If not set, Thoras will use the MaxReplicas value from the target's HPA if available.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  minReplicas:
+                    description: |-
+                      minReplicas is the lower limit for the number of replicas to which the Thoras
+                      can scale down.
+                      If not set, Thoras will use the MinReplicas value from the target's HPA if available.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  mode:
+                    enum:
+                    - autonomous
+                    - auto
+                    - recommendation
+                    - recommend
+                    - rec
+                    - observe
+                    - observation
+                    type: string
+                  model:
+                    description: |-
+                      Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                      how often forecasts are generated, how far ahead to predict, and how
+                      aggressively to scale.
+                    properties:
+                      forecast_blocks:
+                        default: 15m0s
+                        description: Time duration for how far into the future Thoras
+                          should forecast into.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_buffer_percentage:
+                        default: 0%
+                        description: Percentage, represented as a int between 1 and
+                          100, that Thoras will apply on top of predictions for safety.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_cron:
+                        type: string
+                      forecast_interval:
                         description: |-
-                          Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
-                          The "required" direction (mode: percentile without percentile_value) is intentionally omitted
-                          because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
-                          That check is handled by the admission webhook, which has full context.
-                        properties:
-                          forecast_buffer_percentage:
-                            description:
-                              Buffer percentage for this metric. Overrides
-                              global forecast_buffer_percentage.
-                            type: string
-                            x-kubernetes-int-or-string: true
-                          mode:
-                            description:
-                              Forecast mode for this metric. Overrides global
-                              model.mode.
-                            enum:
+                          Time duration for the how frequently Thoras forecasts. This provides
+                          control for how often scaling decisions are made. Mutually exclusive with
+                          forecastCron.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      metrics:
+                        additionalProperties:
+                          description: |-
+                            Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                            The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                            because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                            That check is handled by the admission webhook, which has full context.
+                          properties:
+                            forecast_buffer_percentage:
+                              description: Buffer percentage for this metric. Overrides
+                                global forecast_buffer_percentage.
+                              type: string
+                              x-kubernetes-int-or-string: true
+                            mode:
+                              description: Forecast mode for this metric. Overrides
+                                global model.mode.
+                              enum:
                               - balanced
                               - cost_optimized
                               - undershoot
                               - assurance_optimized
                               - overshoot
                               - percentile
-                            type: string
-                          percentile_value:
-                            description: |-
-                              Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                              Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                            type: string
-                            x-kubernetes-int-or-string: true
+                              type: string
+                            percentile_value:
+                              description: |-
+                                Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                              type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                          x-kubernetes-validations:
+                          - message: percentile_value can only be set when mode is
+                              percentile
+                            rule: '!has(self.mode) || self.mode == ''percentile''
+                              || !has(self.percentile_value)'
+                        description: Per-metric forecast configuration. Overrides
+                          global mode and forecast_buffer_percentage for specific
+                          metrics.
                         type: object
-                        x-kubernetes-validations:
-                          - message: percentile_value can only be set when mode is percentile
-                            rule: "!has(self.mode) || self.mode == 'percentile' || !has(self.percentile_value)"
-                      description:
-                        Per-metric forecast configuration. Overrides global
-                        mode and forecast_buffer_percentage for specific metrics.
-                      type: object
-                    min_lookback_to_scale:
-                      description:
-                        Minimum lookback window before autonomous scaling
-                        is enabled. Autonomous scaling will only occur if historical
-                        data spans at least this duration.
-                      type: string
-                      x-kubernetes-int-or-string: true
-                    mode:
-                      description:
-                        While Thoras models always bias for reliability,
-                        you have the option to set a "mode" for the model to inform
-                        the level of aggression in scaling.
-                      enum:
+                      min_lookback_to_scale:
+                        description: Minimum lookback window before autonomous scaling
+                          is enabled. Autonomous scaling will only occur if historical
+                          data spans at least this duration.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      mode:
+                        description: While Thoras models always bias for reliability,
+                          you have the option to set a "mode" for the model to inform
+                          the level of aggression in scaling.
+                        enum:
                         - balanced
                         - cost_optimized
                         - undershoot
                         - assurance_optimized
                         - overshoot
                         - percentile
-                      type: string
-                    percentile_value:
-                      description: |-
-                        Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                        Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                      type: string
-                      x-kubernetes-int-or-string: true
-                  type: object
-                  x-kubernetes-validations:
-                    - message: forecastCron and forecastInterval are mutually exclusive
-                      rule:
-                        "!has(self.forecast_cron) || self.forecast_cron == '' ||
-                        !has(self.forecast_interval) || self.forecast_interval == ''"
-                    - message: forecastInterval must be less than or equal to forecastBlocks
-                      rule:
-                        "!has(self.forecast_interval) || !has(self.forecast_blocks)
-                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)"
-                    - message: percentile_value is required when mode is percentile
-                      rule: "!has(self.mode) || self.mode != 'percentile' || has(self.percentile_value)"
-                    - message: percentile_value can only be set when mode is percentile
-                      rule:
-                        "!has(self.percentile_value) || (has(self.mode) && self.mode
-                        == 'percentile')"
-                scaleTargetRef:
-                  properties:
-                    apiVersion:
-                      type: string
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                    namespace:
-                      type: string
-                  type: object
-                selector:
-                  description: |-
-                    A label selector is a label query over a set of resources. The result of matchLabels and
-                    matchExpressions are ANDed. An empty label selector matches all objects. A null
-                    label selector matches no objects.
-                  properties:
-                    matchExpressions:
-                      description:
-                        matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
-                        properties:
-                          key:
-                            description:
-                              key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    matchLabels:
-                      additionalProperties:
                         type: string
-                      description: |-
-                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                  x-kubernetes-map-type: atomic
-                vertical:
-                  properties:
-                    containers:
-                      items:
+                      percentile_value:
+                        description: |-
+                          Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                          Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                        type: string
+                        x-kubernetes-int-or-string: true
+                    type: object
+                    x-kubernetes-validations:
+                    - message: forecastCron and forecastInterval are mutually exclusive
+                      rule: '!has(self.forecast_cron) || self.forecast_cron == ''''
+                        || !has(self.forecast_interval) || self.forecast_interval
+                        == '''''
+                    - message: forecastInterval must be less than or equal to forecastBlocks
+                      rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                    - message: percentile_value is required when mode is percentile
+                      rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
+                    - message: percentile_value can only be set when mode is percentile
+                      rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
+                        == ''percentile'')'
+                  scaling_behavior:
+                    description: Rules for how large a proposed scale event must be
+                      before triggering
+                    properties:
+                      scale_down:
                         properties:
-                          cpu:
-                            properties:
-                              limit:
-                                properties:
-                                  ratio:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - ratio
-                                type: object
-                              lowerbound:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              upperbound:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - lowerbound
-                            type: object
-                          jvm_options:
+                          absolute:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: |-
-                              JVMOptions configures automatic JVM heap sizing.
-                              The calculation flow is:
-                               1. Xmx = max(heap_forecast, heap_current) * (1 + XmxBuffer)
-                               2. Apply XmxBounds clamping to Xmx
-                               3. Xms = Xmx * XmsRatio
-                               4. Container Memory = (Xmx + nonheap) * (1 + MemoryBuffer)
-                            properties:
-                              enable_auto_heap_size:
-                                description:
-                                  Enable automatic JVM heap size adjustment
-                                  based on memory requests.
-                                type: boolean
-                              memory_buffer:
-                                default: 10%
-                                description: |-
-                                  MemoryBuffer specifies the buffer percentage to add above total JVM memory (heap + non-heap) when setting container memory limits.
-                                  This accounts for non-heap memory regions such as metaspace, thread stacks, and native memory allocations.
-                                  Valid range: 0%-100%. Defaults to 10%.
-                                type: string
-                              xms_ratio:
-                                default: 80%
-                                description: |-
-                                  XmsRatio specifies the ratio of the initial heap size (Xms) relative to the maximum heap size (Xmx).
-                                  This determines how much memory is allocated to the JVM heap at startup.
-                                  Valid range: 0%-100%. Defaults to 80%.
-                                type: string
-                              xmx_bounds:
-                                properties:
-                                  limit:
-                                    properties:
-                                      ratio:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - ratio
-                                    type: object
-                                  lowerbound:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  upperbound:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - lowerbound
-                                type: object
-                              xmx_buffer:
-                                default: 10%
-                                description: |-
-                                  XmxBuffer specifies the buffer percentage to add above observed heap memory usage when setting Xmx.
-                                  This provides headroom for heap allocation to prevent out-of-memory errors.
-                                  Valid range: 0%-100%. Defaults to 10%.
-                                type: string
+                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                              For vertical scaling: Use "memory" and "cpu" resource names.
+                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                these absolute values to trigger scaling, regardless of current usage percentage.
+                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
                             type: object
-                          memory:
-                            properties:
-                              limit:
-                                properties:
-                                  ratio:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - ratio
-                                type: object
-                              lowerbound:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              upperbound:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - lowerbound
-                            type: object
-                          name:
-                            description: name of container to scale
+                          percent:
+                            description: |-
+                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          type:
+                            enum:
+                            - percent
+                            - absolute
                             type: string
-                            x-kubernetes-validations:
-                              - message: name must not be empty
-                                rule: size(self) > 0
                         required:
-                          - name
+                        - type
                         type: object
                         x-kubernetes-validations:
-                          - message:
-                              EnableAutoHeapSize can only be true if memory.limit
-                              is set
-                            rule:
-                              "!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
-                              || (has(self.memory) && has(self.memory.limit))"
-                          - message: At least one of cpu or memory must be specified
-                            rule: has(self.cpu) || has(self.memory)
-                      type: array
-                      x-kubernetes-validations:
-                        - message: at least one container must be specified
-                          rule: self.size() > 0
-                    disruption:
-                      description: |-
-                        Disruption controls how aggressively Thoras applies pod changes (in-place
-                        resize or eviction) when applying vertical recommendations.
-                      properties:
-                        interval:
-                          default: 60s
-                          description: |-
-                            Interval is the minimum duration the operator waits after a batch of
-                            pod changes (resize or evict) before applying the next batch. Defaults to 60s.
-                          type: string
-                        max_disrupted:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          default: 20%
-                          description: |-
-                            MaxDisrupted is the maximum number of pods that may be
-                            disrupted at once across the workload. A pod is "disrupted" if it is
-                            terminating or its Ready condition is not True. The operator only
-                            applies pod changes (resize or evict) up to the remaining headroom in
-                            each batch, so prior batches that haven't finished rolling reduce the
-                            next batch's size. After issuing a batch, the operator waits Interval
-                            before issuing the next batch. Unlike PodDisruptionBudget.maxUnavailable,
-                            this cap is enforced by the operator itself: pods that are unavailable
-                            for reasons unrelated to Thoras (e.g. failing readiness probes) still
-                            consume the budget.
-
-                            Accepts an absolute integer (e.g. 2) or a percentage of the workload's
-                            desired replicas (e.g. "25%"). Defaults to 20%.
-                          x-kubernetes-int-or-string: true
-                      type: object
-                      x-kubernetes-validations:
-                        - message:
-                            max_disrupted must be a positive integer or a percentage
-                            between 1% and 100%
-                          rule:
-                            "!has(self.max_disrupted) || (type(self.max_disrupted)
-                            == int ? self.max_disrupted >= 1 : self.max_disrupted.matches('^([1-9][0-9]?|100)%$'))"
-                        - message: interval must be a positive duration
-                          rule: "!has(self.interval) || duration(self.interval) > duration('0s')"
-                    in_place_resizing:
-                      description: |-
-                        Deprecated: Use UpdatePolicy instead.
-                        When InPlaceResizing is not specified and UpdatePolicy is not specified, the default behavior is UpdatePolicy{UpdateMode: "recreate", RecreateResources: ["memory"]}.
-                      properties:
-                        allow_restart_on_memory_limit_decrease:
-                          type: boolean
-                        enabled:
-                          type: boolean
-                      type: object
-                    mode:
-                      enum:
-                        - autonomous
-                        - auto
-                        - recommendation
-                        - recommend
-                        - rec
-                        - observe
-                        - observation
-                      type: string
-                    model:
-                      description: |-
-                        Defines the forecasting and scaling behavior for an AIScaleTarget, including
-                        how often forecasts are generated, how far ahead to predict, and how
-                        aggressively to scale.
-                      properties:
-                        forecast_blocks:
-                          default: 15m0s
-                          description:
-                            Time duration for how far into the future Thoras
-                            should forecast into.
-                          type: string
-                          x-kubernetes-int-or-string: true
-                        forecast_buffer_percentage:
-                          default: 0%
-                          description:
-                            Percentage, represented as a int between 1 and
-                            100, that Thoras will apply on top of predictions for safety.
-                          type: string
-                          x-kubernetes-int-or-string: true
-                        forecast_cron:
-                          type: string
-                        forecast_interval:
-                          description: |-
-                            Time duration for the how frequently Thoras forecasts. This provides
-                            control for how often scaling decisions are made. Mutually exclusive with
-                            forecastCron.
-                          type: string
-                          x-kubernetes-int-or-string: true
-                        metrics:
-                          additionalProperties:
+                        - message: percent must be set when type is percent
+                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
+                        - message: absolute must be set when type is absolute
+                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
+                            true'
+                      scale_up:
+                        properties:
+                          absolute:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: |-
-                              Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
-                              The "required" direction (mode: percentile without percentile_value) is intentionally omitted
-                              because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
-                              That check is handled by the admission webhook, which has full context.
-                            properties:
-                              forecast_buffer_percentage:
-                                description:
-                                  Buffer percentage for this metric. Overrides
-                                  global forecast_buffer_percentage.
-                                type: string
-                                x-kubernetes-int-or-string: true
-                              mode:
-                                description:
-                                  Forecast mode for this metric. Overrides
-                                  global model.mode.
-                                enum:
-                                  - balanced
-                                  - cost_optimized
-                                  - undershoot
-                                  - assurance_optimized
-                                  - overshoot
-                                  - percentile
-                                type: string
-                              percentile_value:
-                                description: |-
-                                  Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                                  Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                                type: string
-                                x-kubernetes-int-or-string: true
+                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                              For vertical scaling: Use "memory" and "cpu" resource names.
+                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                these absolute values to trigger scaling, regardless of current usage percentage.
+                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
                             type: object
-                            x-kubernetes-validations:
-                              - message:
-                                  percentile_value can only be set when mode is
-                                  percentile
-                                rule:
-                                  "!has(self.mode) || self.mode == 'percentile'
-                                  || !has(self.percentile_value)"
-                          description:
-                            Per-metric forecast configuration. Overrides
-                            global mode and forecast_buffer_percentage for specific
-                            metrics.
-                          type: object
-                        min_lookback_to_scale:
-                          description:
-                            Minimum lookback window before autonomous scaling
-                            is enabled. Autonomous scaling will only occur if historical
-                            data spans at least this duration.
+                          percent:
+                            description: |-
+                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          type:
+                            enum:
+                            - percent
+                            - absolute
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: percent must be set when type is percent
+                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
+                        - message: absolute must be set when type is absolute
+                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
+                            true'
+                    type: object
+                required:
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: minReplicas must not be greater than maxReplicas
+                  rule: '!has(self.minReplicas) || !has(self.maxReplicas) || self.minReplicas
+                    <= self.maxReplicas'
+              model:
+                description: |-
+                  Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                  how often forecasts are generated, how far ahead to predict, and how
+                  aggressively to scale.
+                properties:
+                  forecast_blocks:
+                    default: 15m0s
+                    description: Time duration for how far into the future Thoras
+                      should forecast into.
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  forecast_buffer_percentage:
+                    default: 0%
+                    description: Percentage, represented as a int between 1 and 100,
+                      that Thoras will apply on top of predictions for safety.
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  forecast_cron:
+                    type: string
+                  forecast_interval:
+                    description: |-
+                      Time duration for the how frequently Thoras forecasts. This provides
+                      control for how often scaling decisions are made. Mutually exclusive with
+                      forecastCron.
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  metrics:
+                    additionalProperties:
+                      description: |-
+                        Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                        The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                        because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                        That check is handled by the admission webhook, which has full context.
+                      properties:
+                        forecast_buffer_percentage:
+                          description: Buffer percentage for this metric. Overrides
+                            global forecast_buffer_percentage.
                           type: string
                           x-kubernetes-int-or-string: true
                         mode:
-                          description:
-                            While Thoras models always bias for reliability,
-                            you have the option to set a "mode" for the model to inform
-                            the level of aggression in scaling.
+                          description: Forecast mode for this metric. Overrides global
+                            model.mode.
                           enum:
-                            - balanced
-                            - cost_optimized
-                            - undershoot
-                            - assurance_optimized
-                            - overshoot
-                            - percentile
+                          - balanced
+                          - cost_optimized
+                          - undershoot
+                          - assurance_optimized
+                          - overshoot
+                          - percentile
                           type: string
                         percentile_value:
                           description: |-
@@ -1281,600 +811,960 @@ spec:
                           x-kubernetes-int-or-string: true
                       type: object
                       x-kubernetes-validations:
-                        - message: forecastCron and forecastInterval are mutually exclusive
-                          rule:
-                            "!has(self.forecast_cron) || self.forecast_cron == ''
-                            || !has(self.forecast_interval) || self.forecast_interval
-                            == ''"
-                        - message: forecastInterval must be less than or equal to forecastBlocks
-                          rule:
-                            "!has(self.forecast_interval) || !has(self.forecast_blocks)
-                            || duration(self.forecast_interval) <= duration(self.forecast_blocks)"
-                        - message: percentile_value is required when mode is percentile
-                          rule: "!has(self.mode) || self.mode != 'percentile' || has(self.percentile_value)"
-                        - message: percentile_value can only be set when mode is percentile
-                          rule:
-                            "!has(self.percentile_value) || (has(self.mode) && self.mode
-                            == 'percentile')"
-                    oom_remediation:
+                      - message: percentile_value can only be set when mode is percentile
+                        rule: '!has(self.mode) || self.mode == ''percentile'' || !has(self.percentile_value)'
+                    description: Per-metric forecast configuration. Overrides global
+                      mode and forecast_buffer_percentage for specific metrics.
+                    type: object
+                  min_lookback_to_scale:
+                    description: Minimum lookback window before autonomous scaling
+                      is enabled. Autonomous scaling will only occur if historical
+                      data spans at least this duration.
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  mode:
+                    description: While Thoras models always bias for reliability,
+                      you have the option to set a "mode" for the model to inform
+                      the level of aggression in scaling.
+                    enum:
+                    - balanced
+                    - cost_optimized
+                    - undershoot
+                    - assurance_optimized
+                    - overshoot
+                    - percentile
+                    type: string
+                  percentile_value:
+                    description: |-
+                      Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                      Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                    type: string
+                    x-kubernetes-int-or-string: true
+                type: object
+                x-kubernetes-validations:
+                - message: forecastCron and forecastInterval are mutually exclusive
+                  rule: '!has(self.forecast_cron) || self.forecast_cron == '''' ||
+                    !has(self.forecast_interval) || self.forecast_interval == '''''
+                - message: forecastInterval must be less than or equal to forecastBlocks
+                  rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                    || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                - message: percentile_value is required when mode is percentile
+                  rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
+                - message: percentile_value can only be set when mode is percentile
+                  rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
+                    == ''percentile'')'
+              scaleTargetRef:
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+              selector:
+                description: |-
+                  A label selector is a label query over a set of resources. The result of matchLabels and
+                  matchExpressions are ANDed. An empty label selector matches all objects. A null
+                  label selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
                       description: |-
-                        OOMRemediation configures operator-driven memory adjustment during active OOM episodes.
-                        When nil or Enabled is false, no automatic adjustment is applied.
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
-                        enabled:
-                          description:
-                            Enabled activates automatic memory adjustment
-                            when OOM kills are detected.
-                          type: boolean
-                        stabilization_window:
-                          description: |-
-                            StabilizationWindow is the minimum time the workload must run without a new OOM before the
-                            operator allows a forecast to lower memory below the OOM-adjusted value. The floor
-                            resets on each new OOM. When nil, defaults to max(forecast_interval, 1h).
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
-                      type: object
-                    scaling_behavior:
-                      description:
-                        Rules for how large a proposed scale event must be
-                        before triggering
-                      properties:
-                        scale_down:
-                          properties:
-                            absolute:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: |-
-                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                                For vertical scaling: Use "memory" and "cpu" resource names.
-                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                  these absolute values to trigger scaling, regardless of current usage percentage.
-                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
-                              type: object
-                            percent:
-                              description: |-
-                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                              format: int32
-                              minimum: 0
-                              type: integer
-                            type:
-                              enum:
-                                - percent
-                                - absolute
-                              type: string
-                          required:
-                            - type
-                          type: object
-                          x-kubernetes-validations:
-                            - message: percent must be set when type is percent
-                              rule: "self.type == 'percent' ? has(self.percent) : true"
-                            - message: absolute must be set when type is absolute
-                              rule:
-                                "self.type == 'absolute' ? has(self.absolute) :
-                                true"
-                        scale_up:
-                          properties:
-                            absolute:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: |-
-                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                                For vertical scaling: Use "memory" and "cpu" resource names.
-                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                  these absolute values to trigger scaling, regardless of current usage percentage.
-                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
-                              type: object
-                            percent:
-                              description: |-
-                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                              format: int32
-                              minimum: 0
-                              type: integer
-                            type:
-                              enum:
-                                - percent
-                                - absolute
-                              type: string
-                          required:
-                            - type
-                          type: object
-                          x-kubernetes-validations:
-                            - message: percent must be set when type is percent
-                              rule: "self.type == 'percent' ? has(self.percent) : true"
-                            - message: absolute must be set when type is absolute
-                              rule:
-                                "self.type == 'absolute' ? has(self.absolute) :
-                                true"
-                      type: object
-                    update_policy:
-                      description:
-                        'UpdatePolicy defines how pod updates are handled.
-                        If not specified, defaults to UpdatePolicy{UpdateMode: "recreate",
-                        RecreateResources: ["memory"]}.'
-                      properties:
-                        recreate_resources:
-                          default:
-                            - memory
+                        operator:
                           description: |-
-                            RecreateResources lists which resource types should trigger pod recreation when changed.
-                            Defaults to ["memory"] if not set.
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
-                        update_mode:
-                          default: recreate
-                          description:
-                            UpdateMode specifies the update strategy. Defaults
-                            to "recreate" if not set.
-                          enum:
-                            - initial
-                            - recreate
-                            - in_place_or_recreate
-                            - in_place
-                          type: string
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
                       type: object
-                  required:
-                    - containers
-                    - mode
-                  type: object
-                  x-kubernetes-validations:
-                    - message:
-                        when in_place_resizing.enabled is true, update_policy.update_mode
-                        must be either 'in_place' or 'in_place_or_recreate'
-                      rule:
-                        "!has(self.in_place_resizing) || !has(self.in_place_resizing.enabled)
-                        || !self.in_place_resizing.enabled || !has(self.update_policy)
-                        || self.update_policy.update_mode == 'in_place' || self.update_policy.update_mode
-                        == 'in_place_or_recreate'"
-                    - message:
-                        when in_place_resizing.enabled is false, update_policy.update_mode
-                        cannot be 'in_place' or 'in_place_or_recreate'
-                      rule:
-                        "!has(self.in_place_resizing) || self.in_place_resizing.enabled
-                        || !has(self.update_policy) || (self.update_policy.update_mode
-                        != 'in_place' && self.update_policy.update_mode != 'in_place_or_recreate')"
-              required:
-                - model
-              type: object
-              x-kubernetes-validations:
-                - message: exactly one of scaleTargetRef or selector must be set
-                  rule:
-                    (has(self.scaleTargetRef) && !has(self.selector)) || (!has(self.scaleTargetRef)
-                    && has(self.selector))
-                - message:
-                    cannot have both horizontal and vertical scaling in autonomous
-                    mode
-                  rule:
-                    "!(has(self.horizontal) && has(self.vertical) && self.horizontal.mode.startsWith('auto')
-                    && self.vertical.mode.startsWith('auto'))"
-            status:
-              properties:
-                conditions:
-                  description:
-                    Conditions represent the latest available observations
-                    of the AIScaleTarget's state
-                  items:
-                    description:
-                      Condition contains details for one aspect of the current
-                      state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                horizontalSuggestion:
-                  properties:
-                    currentReplicas:
-                      format: int32
-                      type: integer
-                    end:
-                      format: date-time
-                      type: string
-                    forecastError:
-                      description: |-
-                        ForecastError is set when a general forecasting error occurred that blocks all scaling.
-                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                      type: string
-                    hasEnoughDataToScale:
-                      description: |-
-                        HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
-                        When false, scaling actions may be skipped to prevent decisions based on incomplete data.
-                      type: boolean
-                    start:
-                      format: date-time
-                      type: string
-                    suggestedReplicas:
-                      format: int32
-                      type: integer
-                    suggestionUID:
-                      type: string
-                  required:
-                    - currentReplicas
-                    - end
-                    - hasEnoughDataToScale
-                    - start
-                    - suggestedReplicas
-                  type: object
-                labelSelector:
-                  type: string
-                lastCollectionTime:
-                  description:
-                    LastCollectionTime is the last time metrics were successfully
-                    collected for this AIScaleTarget
-                  format: date-time
-                  type: string
-                lastOOMMemoryAdjusted:
-                  description: |-
-                    LastOOMMemoryAdjusted is when the operator last applied an OOM memory adjustment.
-                    Used to enforce the cooldown between successive adjustments.
-                  format: date-time
-                  type: string
-                lastOOMTime:
-                  description: |-
-                    LastOOMTime is the most recent collection time at which OOM kills were observed.
-                    Used to determine when the episode is over.
-                  format: date-time
-                  type: string
-                lastProcessedSuggestionUID:
-                  description: |-
-                    LastProcessedSuggestionUID is the SuggestionUID of the last suggestion the operator
-                    fully processed (PrepareAction → execute → audit written). Used to prevent reprocessing
-                    the same suggestion on every reconcile.
-                  type: string
-                latestSuggestion:
-                  description:
-                    LatestSuggestion contains the most recent scaling recommendations
-                    from Thoras AI
-                  properties:
-                    currentReplicas:
-                      description: |-
-                        CurrentReplicas is the number of replicas at the time this suggestion was generated.
-                        NB: This does not reflect the current replica count, just the count at suggestion time.
-
-                        replica count rather than a snapshot from when the forecaster created the suggestion.
-                      format: int32
-                      type: integer
-                    end:
-                      format: date-time
-                      type: string
-                    forecastErrorGeneral:
-                      description: |-
-                        ForecastErrorGeneral is set when a general forecasting error occurred that blocks all scaling.
-                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                      type: string
-                    forecastErrorHorizontal:
-                      description: |-
-                        ForecastErrorHorizontal is set when a horizontal-specific forecasting error occurred.
-                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                      type: string
-                    forecastErrorVertical:
-                      description: |-
-                        ForecastErrorVertical is set when a vertical-specific forecasting error occurred.
-                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                      type: string
-                    forecastedTotals:
-                      description:
-                        ForecastedTotals contains predicted resource usage
-                        metrics.
-                      items:
-                        description:
-                          ForecastMetric represents a predicted resource
-                          usage value for a specific metric.
-                        properties:
-                          metric:
-                            description:
-                              Metric name - can be "cpu", "memory", "heap",
-                              "non-heap", etc.
-                            type: string
-                          metricType:
-                            description: |-
-                              MetricType indicates the aggregation type of the metric
-                              Values: "average" (per-pod) or "total" (deployment-wide)
-                            type: string
-                          targetName:
-                            description:
-                              TargetName is the name of the deployment or
-                              container this metric applies to
-                            type: string
-                          targetType:
-                            description: |-
-                              TargetType indicates whether this is a deployment-level or container-level metric
-                              Values: "deployment" or "container"
-                            type: string
-                          value:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description:
-                              Value is the forecasted value in Kubernetes
-                              resource format (e.g., "11m" for CPU, "24Mi" for memory)
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                        required:
-                          - metric
-                          - targetName
-                          - targetType
-                          - value
-                        type: object
-                      type: array
-                    hasEnoughDataToScale:
-                      description: |-
-                        HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
-                        When false, scaling actions may be skipped to prevent decisions based on incomplete data.
-                      type: boolean
-                    resourceRecommendations:
-                      description:
-                        ResourceRecommendations contains optimal resource
-                        requests for each container.
-                      items:
-                        description:
-                          ContainerRecommendation contains optimal resource
-                          allocation recommendations for a single container.
-                        properties:
-                          container:
-                            description: Container name
-                            type: string
-                          recommendations:
-                            description: Resource recommendations for this container
-                            items:
-                              description:
-                                ResourceRecommendation represents an optimal
-                                resource allocation for a specific resource type.
+                type: object
+                x-kubernetes-map-type: atomic
+              vertical:
+                properties:
+                  containers:
+                    items:
+                      properties:
+                        cpu:
+                          properties:
+                            limit:
                               properties:
-                                resource:
-                                  description: Resource type - "cpu" or "memory"
-                                  type: string
-                                value:
+                                ratio:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
-                                  description:
-                                    Value in Kubernetes resource format (e.g.,
-                                    "12m" for CPU, "256Mi" for memory)
+                                  - type: integer
+                                  - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               required:
-                                - resource
-                                - value
+                              - ratio
                               type: object
-                            type: array
-                        required:
-                          - container
-                          - recommendations
-                        type: object
-                      type: array
-                    start:
-                      description: Time window for this suggestion
-                      format: date-time
-                      type: string
-                    suggestedReplicas:
-                      description:
-                        SuggestedReplicas is the recommended number of pod
-                        replicas for horizontal scaling.
-                      format: int32
-                      type: integer
-                    suggestionUID:
-                      description:
-                        SuggestionUID is the stable UID assigned to this
-                        suggestion by proxySuggestionsRepository.
-                      type: string
-                  required:
-                    - currentReplicas
-                    - end
-                    - hasEnoughDataToScale
-                    - start
-                    - suggestedReplicas
-                  type: object
-                oomAdjustedMemory:
-                  description: |-
-                    OOMAdjustedMemory holds the per-container memory adjustments set by the operator
-                    during an active OOM episode. Keyed by container name. The admission webhook applies
-                    the adjusted request (floor on max(suggestion, floor)) and, when Limit is non-nil,
-                    applies the adjusted limit. Cleared when oomStabilizationWindowExpiry passes.
-
-                    The value type accepts both the legacy bare-Quantity form (request only, Limit nil)
-                    and the struct form {request, limit} via OOMContainerMemoryAdjustment.UnmarshalJSON.
-                  x-kubernetes-preserve-unknown-fields: true
-                oomKilledContainers:
-                  description: |-
-                    OOMKilledContainers is the set of container names that had OOM kills in the most recent
-                    collection cycle. Replaced on every cycle: set to containers with kills when OOMs are
-                    observed, cleared when no kills are observed. The operator uses this to scope memory
-                    adjustments to only containers that actually OOMed.
-                  items:
-                    type: string
-                  type: array
-                oomStabilizationWindowExpiry:
-                  description: |-
-                    OOMStabilizationWindowExpiry is the time after which the OOM memory floor expires and forecasts are
-                    allowed to lower memory freely. Reset to now+StabilizationWindow on each new OOM adjustment.
-                  format: date-time
-                  type: string
-                previousVerticalMode:
-                  type: string
-                replicas:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                thorasSuggestedReplicas:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  description: |-
-                    ThorasSuggestedReplicas is the latest recommended replica count.
-                    Deprecated: Use LatestSuggestion.SuggestedReplicas instead.
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                verticalSuggestion:
-                  properties:
-                    containers:
-                      description:
-                        Containers contains optimal resource requirements
-                        for each container.
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          resources:
-                            description:
-                              ResourceRequirements describes the compute
-                              resource requirements.
-                            properties:
-                              claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-                                  This field depends on the
-                                  DynamicResourceAllocation feature gate.
-
-                                  This field is immutable. It can only be set for containers.
-                                items:
-                                  description:
-                                    ResourceClaim references one entry in
-                                    PodSpec.ResourceClaims.
+                            lowerbound:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            upperbound:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - lowerbound
+                          type: object
+                        jvm_options:
+                          description: |-
+                            JVMOptions configures automatic JVM heap sizing.
+                            The calculation flow is:
+                             1. Xmx = max(heap_forecast, heap_current) * (1 + XmxBuffer)
+                             2. Apply XmxBounds clamping to Xmx
+                             3. Xms = Xmx * XmsRatio
+                             4. Container Memory = (Xmx + nonheap) * (1 + MemoryBuffer)
+                          properties:
+                            enable_auto_heap_size:
+                              description: Enable automatic JVM heap size adjustment
+                                based on memory requests.
+                              type: boolean
+                            memory_buffer:
+                              default: 10%
+                              description: |-
+                                MemoryBuffer specifies the buffer percentage to add above total JVM memory (heap + non-heap) when setting container memory limits.
+                                This accounts for non-heap memory regions such as metaspace, thread stacks, and native memory allocations.
+                                Valid range: 0%-100%. Defaults to 10%.
+                              type: string
+                            xms_ratio:
+                              default: 80%
+                              description: |-
+                                XmsRatio specifies the ratio of the initial heap size (Xms) relative to the maximum heap size (Xmx).
+                                This determines how much memory is allocated to the JVM heap at startup.
+                                Valid range: 0%-100%. Defaults to 80%.
+                              type: string
+                            xmx_bounds:
+                              properties:
+                                limit:
                                   properties:
-                                    name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
-                                      type: string
-                                    request:
-                                      description: |-
-                                        Request is the name chosen for a request in the referenced claim.
-                                        If empty, everything from the claim is made available, otherwise
-                                        only the result of this request.
-                                      type: string
+                                    ratio:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
                                   required:
-                                    - name
+                                  - ratio
                                   type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                  - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
+                                lowerbound:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                              requests:
-                                additionalProperties:
+                                upperbound:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                            type: object
-                        required:
-                          - name
-                          - resources
+                              required:
+                              - lowerbound
+                              type: object
+                            xmx_buffer:
+                              default: 10%
+                              description: |-
+                                XmxBuffer specifies the buffer percentage to add above observed heap memory usage when setting Xmx.
+                                This provides headroom for heap allocation to prevent out-of-memory errors.
+                                Valid range: 0%-100%. Defaults to 10%.
+                              type: string
+                          type: object
+                        memory:
+                          properties:
+                            limit:
+                              properties:
+                                ratio:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - ratio
+                              type: object
+                            lowerbound:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            upperbound:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - lowerbound
+                          type: object
+                        name:
+                          description: name of container to scale
+                          type: string
+                          x-kubernetes-validations:
+                          - message: name must not be empty
+                            rule: size(self) > 0
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-validations:
+                      - message: EnableAutoHeapSize can only be true if memory.limit
+                          is set
+                        rule: '!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
+                          || (has(self.memory) && has(self.memory.limit))'
+                      - message: At least one of cpu or memory must be specified
+                        rule: has(self.cpu) || has(self.memory)
+                    type: array
+                    x-kubernetes-validations:
+                    - message: at least one container must be specified
+                      rule: self.size() > 0
+                  disruption:
+                    description: |-
+                      Disruption controls how aggressively Thoras applies pod changes (in-place
+                      resize or eviction) when applying vertical recommendations.
+                    properties:
+                      interval:
+                        default: 60s
+                        description: |-
+                          Interval is the minimum duration the operator waits after a batch of
+                          pod changes (resize or evict) before applying the next batch. Defaults to 60s.
+                        type: string
+                      max_disrupted:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 20%
+                        description: |-
+                          MaxDisrupted is the maximum number of pods that may be
+                          disrupted at once across the workload. A pod is "disrupted" if it is
+                          terminating or its Ready condition is not True. The operator only
+                          applies pod changes (resize or evict) up to the remaining headroom in
+                          each batch, so prior batches that haven't finished rolling reduce the
+                          next batch's size. After issuing a batch, the operator waits Interval
+                          before issuing the next batch. Unlike PodDisruptionBudget.maxUnavailable,
+                          this cap is enforced by the operator itself: pods that are unavailable
+                          for reasons unrelated to Thoras (e.g. failing readiness probes) still
+                          consume the budget.
+
+                          Accepts an absolute integer (e.g. 2) or a percentage of the workload's
+                          desired replicas (e.g. "25%"). Defaults to 20%.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                    x-kubernetes-validations:
+                    - message: max_disrupted must be a positive integer or a percentage
+                        between 1% and 100%
+                      rule: '!has(self.max_disrupted) || (type(self.max_disrupted)
+                        == int ? self.max_disrupted >= 1 : self.max_disrupted.matches(''^([1-9][0-9]?|100)%$''))'
+                    - message: interval must be a positive duration
+                      rule: '!has(self.interval) || duration(self.interval) > duration(''0s'')'
+                  in_place_resizing:
+                    description: |-
+                      Deprecated: Use UpdatePolicy instead.
+                      When InPlaceResizing is not specified and UpdatePolicy is not specified, the default behavior is UpdatePolicy{UpdateMode: "recreate", RecreateResources: ["memory"]}.
+                    properties:
+                      allow_restart_on_memory_limit_decrease:
+                        type: boolean
+                      enabled:
+                        type: boolean
+                    type: object
+                  mode:
+                    enum:
+                    - autonomous
+                    - auto
+                    - recommendation
+                    - recommend
+                    - rec
+                    - observe
+                    - observation
+                    type: string
+                  model:
+                    description: |-
+                      Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                      how often forecasts are generated, how far ahead to predict, and how
+                      aggressively to scale.
+                    properties:
+                      forecast_blocks:
+                        default: 15m0s
+                        description: Time duration for how far into the future Thoras
+                          should forecast into.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_buffer_percentage:
+                        default: 0%
+                        description: Percentage, represented as a int between 1 and
+                          100, that Thoras will apply on top of predictions for safety.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      forecast_cron:
+                        type: string
+                      forecast_interval:
+                        description: |-
+                          Time duration for the how frequently Thoras forecasts. This provides
+                          control for how often scaling decisions are made. Mutually exclusive with
+                          forecastCron.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      metrics:
+                        additionalProperties:
+                          description: |-
+                            Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                            The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                            because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                            That check is handled by the admission webhook, which has full context.
+                          properties:
+                            forecast_buffer_percentage:
+                              description: Buffer percentage for this metric. Overrides
+                                global forecast_buffer_percentage.
+                              type: string
+                              x-kubernetes-int-or-string: true
+                            mode:
+                              description: Forecast mode for this metric. Overrides
+                                global model.mode.
+                              enum:
+                              - balanced
+                              - cost_optimized
+                              - undershoot
+                              - assurance_optimized
+                              - overshoot
+                              - percentile
+                              type: string
+                            percentile_value:
+                              description: |-
+                                Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                              type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                          x-kubernetes-validations:
+                          - message: percentile_value can only be set when mode is
+                              percentile
+                            rule: '!has(self.mode) || self.mode == ''percentile''
+                              || !has(self.percentile_value)'
+                        description: Per-metric forecast configuration. Overrides
+                          global mode and forecast_buffer_percentage for specific
+                          metrics.
                         type: object
-                      type: array
-                    end:
+                      min_lookback_to_scale:
+                        description: Minimum lookback window before autonomous scaling
+                          is enabled. Autonomous scaling will only occur if historical
+                          data spans at least this duration.
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      mode:
+                        description: While Thoras models always bias for reliability,
+                          you have the option to set a "mode" for the model to inform
+                          the level of aggression in scaling.
+                        enum:
+                        - balanced
+                        - cost_optimized
+                        - undershoot
+                        - assurance_optimized
+                        - overshoot
+                        - percentile
+                        type: string
+                      percentile_value:
+                        description: |-
+                          Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                          Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                        type: string
+                        x-kubernetes-int-or-string: true
+                    type: object
+                    x-kubernetes-validations:
+                    - message: forecastCron and forecastInterval are mutually exclusive
+                      rule: '!has(self.forecast_cron) || self.forecast_cron == ''''
+                        || !has(self.forecast_interval) || self.forecast_interval
+                        == '''''
+                    - message: forecastInterval must be less than or equal to forecastBlocks
+                      rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
+                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
+                    - message: percentile_value is required when mode is percentile
+                      rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
+                    - message: percentile_value can only be set when mode is percentile
+                      rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
+                        == ''percentile'')'
+                  oom_remediation:
+                    description: |-
+                      OOMRemediation configures operator-driven memory adjustment during active OOM episodes.
+                      When nil or Enabled is false, no automatic adjustment is applied.
+                    properties:
+                      enabled:
+                        description: Enabled activates automatic memory adjustment
+                          when OOM kills are detected.
+                        type: boolean
+                      stabilization_window:
+                        description: |-
+                          StabilizationWindow is the minimum time the workload must run without a new OOM before the
+                          operator allows a forecast to lower memory below the OOM-adjusted value. The floor
+                          resets on each new OOM. When nil, defaults to max(forecast_interval, 1h).
+                        type: string
+                    type: object
+                  scaling_behavior:
+                    description: Rules for how large a proposed scale event must be
+                      before triggering
+                    properties:
+                      scale_down:
+                        properties:
+                          absolute:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                              For vertical scaling: Use "memory" and "cpu" resource names.
+                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                these absolute values to trigger scaling, regardless of current usage percentage.
+                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
+                            type: object
+                          percent:
+                            description: |-
+                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          type:
+                            enum:
+                            - percent
+                            - absolute
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: percent must be set when type is percent
+                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
+                        - message: absolute must be set when type is absolute
+                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
+                            true'
+                      scale_up:
+                        properties:
+                          absolute:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                              For vertical scaling: Use "memory" and "cpu" resource names.
+                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                these absolute values to trigger scaling, regardless of current usage percentage.
+                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
+                            type: object
+                          percent:
+                            description: |-
+                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          type:
+                            enum:
+                            - percent
+                            - absolute
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: percent must be set when type is percent
+                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
+                        - message: absolute must be set when type is absolute
+                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
+                            true'
+                    type: object
+                  update_policy:
+                    description: 'UpdatePolicy defines how pod updates are handled.
+                      If not specified, defaults to UpdatePolicy{UpdateMode: "recreate",
+                      RecreateResources: ["memory"]}.'
+                    properties:
+                      recreate_resources:
+                        default:
+                        - memory
+                        description: |-
+                          RecreateResources lists which resource types should trigger pod recreation when changed.
+                          Defaults to ["memory"] if not set.
+                        items:
+                          type: string
+                        type: array
+                      update_mode:
+                        default: recreate
+                        description: UpdateMode specifies the update strategy. Defaults
+                          to "recreate" if not set.
+                        enum:
+                        - initial
+                        - recreate
+                        - in_place_or_recreate
+                        - in_place
+                        type: string
+                    type: object
+                required:
+                - containers
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: when in_place_resizing.enabled is true, update_policy.update_mode
+                    must be either 'in_place' or 'in_place_or_recreate'
+                  rule: '!has(self.in_place_resizing) || !has(self.in_place_resizing.enabled)
+                    || !self.in_place_resizing.enabled || !has(self.update_policy)
+                    || self.update_policy.update_mode == ''in_place'' || self.update_policy.update_mode
+                    == ''in_place_or_recreate'''
+                - message: when in_place_resizing.enabled is false, update_policy.update_mode
+                    cannot be 'in_place' or 'in_place_or_recreate'
+                  rule: '!has(self.in_place_resizing) || self.in_place_resizing.enabled
+                    || !has(self.update_policy) || (self.update_policy.update_mode
+                    != ''in_place'' && self.update_policy.update_mode != ''in_place_or_recreate'')'
+            required:
+            - model
+            type: object
+            x-kubernetes-validations:
+            - message: exactly one of scaleTargetRef or selector must be set
+              rule: (has(self.scaleTargetRef) && !has(self.selector)) || (!has(self.scaleTargetRef)
+                && has(self.selector))
+          status:
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the AIScaleTarget's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
-                    forecastError:
+                    message:
                       description: |-
-                        ForecastError is set when a general forecasting error occurred that blocks all scaling.
-                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
-                    hasEnoughDataToScale:
+                    observedGeneration:
                       description: |-
-                        HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
-                        When false, scaling actions may be skipped to prevent decisions based on incomplete data.
-                      type: boolean
-                    start:
-                      format: date-time
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                    suggestionUID:
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - end
-                    - hasEnoughDataToScale
-                    - start
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              horizontalSuggestion:
+                properties:
+                  currentReplicas:
+                    format: int32
+                    type: integer
+                  end:
+                    format: date-time
+                    type: string
+                  forecastError:
+                    description: |-
+                      ForecastError is set when a general forecasting error occurred that blocks all scaling.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                    type: string
+                  hasEnoughDataToScale:
+                    description: |-
+                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                    type: boolean
+                  start:
+                    format: date-time
+                    type: string
+                  suggestedReplicas:
+                    format: int32
+                    type: integer
+                  suggestionUID:
+                    type: string
+                required:
+                - currentReplicas
+                - end
+                - hasEnoughDataToScale
+                - start
+                - suggestedReplicas
+                type: object
+              labelSelector:
+                type: string
+              lastCollectionTime:
+                description: LastCollectionTime is the last time metrics were successfully
+                  collected for this AIScaleTarget
+                format: date-time
+                type: string
+              lastOOMMemoryAdjusted:
+                description: |-
+                  LastOOMMemoryAdjusted is when the operator last applied an OOM memory adjustment.
+                  Used to enforce the cooldown between successive adjustments.
+                format: date-time
+                type: string
+              lastOOMTime:
+                description: |-
+                  LastOOMTime is the most recent collection time at which OOM kills were observed.
+                  Used to determine when the episode is over.
+                format: date-time
+                type: string
+              lastProcessedSuggestionUID:
+                description: |-
+                  LastProcessedSuggestionUID is the SuggestionUID of the last suggestion the operator
+                  fully processed (PrepareAction → execute → audit written). Used to prevent reprocessing
+                  the same suggestion on every reconcile.
+                type: string
+              latestSuggestion:
+                description: LatestSuggestion contains the most recent scaling recommendations
+                  from Thoras AI
+                properties:
+                  currentReplicas:
+                    description: |-
+                      CurrentReplicas is the number of replicas at the time this suggestion was generated.
+                      NB: This does not reflect the current replica count, just the count at suggestion time.
+
+                      replica count rather than a snapshot from when the forecaster created the suggestion.
+                    format: int32
+                    type: integer
+                  end:
+                    format: date-time
+                    type: string
+                  forecastErrorGeneral:
+                    description: |-
+                      ForecastErrorGeneral is set when a general forecasting error occurred that blocks all scaling.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                    type: string
+                  forecastErrorHorizontal:
+                    description: |-
+                      ForecastErrorHorizontal is set when a horizontal-specific forecasting error occurred.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                    type: string
+                  forecastErrorVertical:
+                    description: |-
+                      ForecastErrorVertical is set when a vertical-specific forecasting error occurred.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                    type: string
+                  forecastedTotals:
+                    description: ForecastedTotals contains predicted resource usage
+                      metrics.
+                    items:
+                      description: ForecastMetric represents a predicted resource
+                        usage value for a specific metric.
+                      properties:
+                        metric:
+                          description: Metric name - can be "cpu", "memory", "heap",
+                            "non-heap", etc.
+                          type: string
+                        metricType:
+                          description: |-
+                            MetricType indicates the aggregation type of the metric
+                            Values: "average" (per-pod) or "total" (deployment-wide)
+                          type: string
+                        targetName:
+                          description: TargetName is the name of the deployment or
+                            container this metric applies to
+                          type: string
+                        targetType:
+                          description: |-
+                            TargetType indicates whether this is a deployment-level or container-level metric
+                            Values: "deployment" or "container"
+                          type: string
+                        value:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Value is the forecasted value in Kubernetes
+                            resource format (e.g., "11m" for CPU, "24Mi" for memory)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - metric
+                      - targetName
+                      - targetType
+                      - value
+                      type: object
+                    type: array
+                  hasEnoughDataToScale:
+                    description: |-
+                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                    type: boolean
+                  resourceRecommendations:
+                    description: ResourceRecommendations contains optimal resource
+                      requests for each container.
+                    items:
+                      description: ContainerRecommendation contains optimal resource
+                        allocation recommendations for a single container.
+                      properties:
+                        container:
+                          description: Container name
+                          type: string
+                        recommendations:
+                          description: Resource recommendations for this container
+                          items:
+                            description: ResourceRecommendation represents an optimal
+                              resource allocation for a specific resource type.
+                            properties:
+                              resource:
+                                description: Resource type - "cpu" or "memory"
+                                type: string
+                              value:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Value in Kubernetes resource format (e.g.,
+                                  "12m" for CPU, "256Mi" for memory)
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - resource
+                            - value
+                            type: object
+                          type: array
+                      required:
+                      - container
+                      - recommendations
+                      type: object
+                    type: array
+                  start:
+                    description: Time window for this suggestion
+                    format: date-time
+                    type: string
+                  suggestedReplicas:
+                    description: SuggestedReplicas is the recommended number of pod
+                      replicas for horizontal scaling.
+                    format: int32
+                    type: integer
+                  suggestionUID:
+                    description: SuggestionUID is the stable UID assigned to this
+                      suggestion by proxySuggestionsRepository.
+                    type: string
+                required:
+                - currentReplicas
+                - end
+                - hasEnoughDataToScale
+                - start
+                - suggestedReplicas
+                type: object
+              oomAdjustedMemory:
+                description: |-
+                  OOMAdjustedMemory holds the per-container memory adjustments set by the operator
+                  during an active OOM episode. Keyed by container name. The admission webhook applies
+                  the adjusted request (floor on max(suggestion, floor)) and, when Limit is non-nil,
+                  applies the adjusted limit. Cleared when oomStabilizationWindowExpiry passes.
+
+                  The value type accepts both the legacy bare-Quantity form (request only, Limit nil)
+                  and the struct form {request, limit} via OOMContainerMemoryAdjustment.UnmarshalJSON.
+                x-kubernetes-preserve-unknown-fields: true
+              oomKilledContainers:
+                description: |-
+                  OOMKilledContainers is the set of container names that had OOM kills in the most recent
+                  collection cycle. Replaced on every cycle: set to containers with kills when OOMs are
+                  observed, cleared when no kills are observed. The operator uses this to scope memory
+                  adjustments to only containers that actually OOMed.
+                items:
+                  type: string
+                type: array
+              oomStabilizationWindowExpiry:
+                description: |-
+                  OOMStabilizationWindowExpiry is the time after which the OOM memory floor expires and forecasts are
+                  allowed to lower memory freely. Reset to now+StabilizationWindow on each new OOM adjustment.
+                format: date-time
+                type: string
+              previousVerticalMode:
+                type: string
+              replicas:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              thorasSuggestedReplicas:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  ThorasSuggestedReplicas is the latest recommended replica count.
+                  Deprecated: Use LatestSuggestion.SuggestedReplicas instead.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              verticalSuggestion:
+                properties:
+                  containers:
+                    description: Containers contains optimal resource requirements
+                      for each container.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This field depends on the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      - resources
+                      type: object
+                    type: array
+                  end:
+                    format: date-time
+                    type: string
+                  forecastError:
+                    description: |-
+                      ForecastError is set when a general forecasting error occurred that blocks all scaling.
+                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                    type: string
+                  hasEnoughDataToScale:
+                    description: |-
+                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                    type: boolean
+                  start:
+                    format: date-time
+                    type: string
+                  suggestionUID:
+                    type: string
+                required:
+                - end
+                - hasEnoughDataToScale
+                - start
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -12,796 +12,676 @@ spec:
     listKind: AIScaleTargetList
     plural: aiscaletargets
     shortNames:
-    - ast
+      - ast
     singular: aiscaletarget
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.model.mode
-      name: Model
-      type: string
-    - jsonPath: .spec.horizontal.mode
-      name: Horizontal
-      type: string
-    - jsonPath: .spec.vertical.mode
-      name: Vertical
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: AIScaleTarget is a AIScaleTarget resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AiScaleTargetSpec is the spec of a AiScaleTarget resource.
-            properties:
-              horizontal:
-                properties:
-                  additional_metrics:
-                    description: Metrics to scale off of in addition to the metrics
-                      defined in HPA
-                    items:
-                      description: |-
-                        MetricSpec specifies how to scale based on a single metric
-                        (only `type` and one other matching field should be set at once).
-                      properties:
-                        containerResource:
-                          description: |-
-                            containerResource refers to a resource metric (such as those specified in
-                            requests and limits) known to Kubernetes describing a single container in
-                            each pod of the current scale target (e.g. CPU or memory). Such metrics are
-                            built in to Kubernetes, and have special scaling options on top of those
-                            available to normal per-pod metrics using the "pods" source.
-                          properties:
-                            container:
-                              description: container is the name of the container
-                                in the pods of the scaling target
-                              type: string
-                            name:
-                              description: name is the name of the resource in question.
-                              type: string
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: |-
-                                    averageUtilization is the target value of the average of the
-                                    resource metric across all relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: |-
-                                    averageValue is the target value of the average of the
-                                    metric across all relevant pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - container
-                          - name
-                          - target
-                          type: object
-                        external:
-                          description: |-
-                            external refers to a global metric that is not associated
-                            with any Kubernetes object. It allows autoscaling based on information
-                            coming from components running outside of cluster
-                            (for example length of queue in cloud messaging service, or
-                            QPS from loadbalancer running outside of cluster).
-                          properties:
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: |-
-                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
-                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
-                                    When unset, just the metricName will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: |-
-                                    averageUtilization is the target value of the average of the
-                                    resource metric across all relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: |-
-                                    averageValue is the target value of the average of the
-                                    metric across all relevant pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - metric
-                          - target
-                          type: object
-                        object:
-                          description: |-
-                            object refers to a metric describing a single kubernetes object
-                            (for example, hits-per-second on an Ingress object).
-                          properties:
-                            describedObject:
-                              description: describedObject specifies the descriptions
-                                of a object,such as kind,name apiVersion
-                              properties:
-                                apiVersion:
-                                  description: apiVersion is the API version of the
-                                    referent
-                                  type: string
-                                kind:
-                                  description: 'kind is the kind of the referent;
-                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                  type: string
-                                name:
-                                  description: 'name is the name of the referent;
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                              required:
-                              - kind
-                              - name
-                              type: object
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: |-
-                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
-                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
-                                    When unset, just the metricName will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: |-
-                                    averageUtilization is the target value of the average of the
-                                    resource metric across all relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: |-
-                                    averageValue is the target value of the average of the
-                                    metric across all relevant pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - describedObject
-                          - metric
-                          - target
-                          type: object
-                        pods:
-                          description: |-
-                            pods refers to a metric describing each pod in the current scale target
-                            (for example, transactions-processed-per-second).  The values will be
-                            averaged together before being compared to the target value.
-                          properties:
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: |-
-                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
-                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
-                                    When unset, just the metricName will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: |-
-                                    averageUtilization is the target value of the average of the
-                                    resource metric across all relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: |-
-                                    averageValue is the target value of the average of the
-                                    metric across all relevant pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - metric
-                          - target
-                          type: object
-                        resource:
-                          description: |-
-                            resource refers to a resource metric (such as those specified in
-                            requests and limits) known to Kubernetes describing each pod in the
-                            current scale target (e.g. CPU or memory). Such metrics are built in to
-                            Kubernetes, and have special scaling options on top of those available
-                            to normal per-pod metrics using the "pods" source.
-                          properties:
-                            name:
-                              description: name is the name of the resource in question.
-                              type: string
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: |-
-                                    averageUtilization is the target value of the average of the
-                                    resource metric across all relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: |-
-                                    averageValue is the target value of the average of the
-                                    metric across all relevant pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - name
-                          - target
-                          type: object
-                        type:
-                          description: |-
-                            type is the type of metric source.  It should be one of "ContainerResource", "External",
-                            "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-                          type: string
-                      required:
-                      - type
-                      type: object
-                    type: array
-                  exclude_metrics:
-                    description: Metrics from HPA for thoras to ignore
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        type:
-                          type: string
-                      required:
-                      - name
-                      - type
-                      type: object
-                    type: array
-                  maxReplicas:
-                    description: |-
-                      maxReplicas is the upper limit for the number of replicas to which the Thoras
-                      can scale up.
-                      If not set, Thoras will use the MaxReplicas value from the target's HPA if available.
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  minReplicas:
-                    description: |-
-                      minReplicas is the lower limit for the number of replicas to which the Thoras
-                      can scale down.
-                      If not set, Thoras will use the MinReplicas value from the target's HPA if available.
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  mode:
-                    enum:
-                    - autonomous
-                    - auto
-                    - recommendation
-                    - recommend
-                    - rec
-                    - observe
-                    - observation
-                    type: string
-                  model:
-                    description: |-
-                      Defines the forecasting and scaling behavior for an AIScaleTarget, including
-                      how often forecasts are generated, how far ahead to predict, and how
-                      aggressively to scale.
-                    properties:
-                      forecast_blocks:
-                        default: 15m0s
-                        description: Time duration for how far into the future Thoras
-                          should forecast into.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      forecast_buffer_percentage:
-                        default: 0%
-                        description: Percentage, represented as a int between 1 and
-                          100, that Thoras will apply on top of predictions for safety.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      forecast_cron:
-                        type: string
-                      forecast_interval:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.model.mode
+          name: Model
+          type: string
+        - jsonPath: .spec.horizontal.mode
+          name: Horizontal
+          type: string
+        - jsonPath: .spec.vertical.mode
+          name: Vertical
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: AIScaleTarget is a AIScaleTarget resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AiScaleTargetSpec is the spec of a AiScaleTarget resource.
+              properties:
+                horizontal:
+                  properties:
+                    additional_metrics:
+                      description:
+                        Metrics to scale off of in addition to the metrics
+                        defined in HPA
+                      items:
                         description: |-
-                          Time duration for the how frequently Thoras forecasts. This provides
-                          control for how often scaling decisions are made. Mutually exclusive with
-                          forecastCron.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      metrics:
-                        additionalProperties:
-                          description: |-
-                            Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
-                            The "required" direction (mode: percentile without percentile_value) is intentionally omitted
-                            because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
-                            That check is handled by the admission webhook, which has full context.
-                          properties:
-                            forecast_buffer_percentage:
-                              description: Buffer percentage for this metric. Overrides
-                                global forecast_buffer_percentage.
-                              type: string
-                              x-kubernetes-int-or-string: true
-                            mode:
-                              description: Forecast mode for this metric. Overrides
-                                global model.mode.
-                              enum:
-                              - balanced
-                              - cost_optimized
-                              - undershoot
-                              - assurance_optimized
-                              - overshoot
-                              - percentile
-                              type: string
-                            percentile_value:
-                              description: |-
-                                Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                                Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                              type: string
-                              x-kubernetes-int-or-string: true
-                          type: object
-                          x-kubernetes-validations:
-                          - message: percentile_value can only be set when mode is
-                              percentile
-                            rule: '!has(self.mode) || self.mode == ''percentile''
-                              || !has(self.percentile_value)'
-                        description: Per-metric forecast configuration. Overrides
-                          global mode and forecast_buffer_percentage for specific
-                          metrics.
-                        type: object
-                      min_lookback_to_scale:
-                        description: Minimum lookback window before autonomous scaling
-                          is enabled. Autonomous scaling will only occur if historical
-                          data spans at least this duration.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      mode:
-                        description: While Thoras models always bias for reliability,
-                          you have the option to set a "mode" for the model to inform
-                          the level of aggression in scaling.
-                        enum:
-                        - balanced
-                        - cost_optimized
-                        - undershoot
-                        - assurance_optimized
-                        - overshoot
-                        - percentile
-                        type: string
-                      percentile_value:
-                        description: |-
-                          Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                          Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                        type: string
-                        x-kubernetes-int-or-string: true
-                    type: object
-                    x-kubernetes-validations:
-                    - message: forecastCron and forecastInterval are mutually exclusive
-                      rule: '!has(self.forecast_cron) || self.forecast_cron == ''''
-                        || !has(self.forecast_interval) || self.forecast_interval
-                        == '''''
-                    - message: forecastInterval must be less than or equal to forecastBlocks
-                      rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
-                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
-                    - message: percentile_value is required when mode is percentile
-                      rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
-                    - message: percentile_value can only be set when mode is percentile
-                      rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
-                        == ''percentile'')'
-                  scaling_behavior:
-                    description: Rules for how large a proposed scale event must be
-                      before triggering
-                    properties:
-                      scale_down:
+                          MetricSpec specifies how to scale based on a single metric
+                          (only `type` and one other matching field should be set at once).
                         properties:
-                          absolute:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                          containerResource:
                             description: |-
-                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                              For vertical scaling: Use "memory" and "cpu" resource names.
-                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                these absolute values to trigger scaling, regardless of current usage percentage.
-                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
+                              containerResource refers to a resource metric (such as those specified in
+                              requests and limits) known to Kubernetes describing a single container in
+                              each pod of the current scale target (e.g. CPU or memory). Such metrics are
+                              built in to Kubernetes, and have special scaling options on top of those
+                              available to normal per-pod metrics using the "pods" source.
+                            properties:
+                              container:
+                                description:
+                                  container is the name of the container
+                                  in the pods of the scaling target
+                                type: string
+                              name:
+                                description: name is the name of the resource in question.
+                                type: string
+                              target:
+                                description:
+                                  target specifies the target value for the
+                                  given metric
+                                properties:
+                                  averageUtilization:
+                                    description: |-
+                                      averageUtilization is the target value of the average of the
+                                      resource metric across all relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source type
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      averageValue is the target value of the average of the
+                                      metric across all relevant pods (as a quantity)
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description:
+                                      type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description:
+                                      value is the target value of the metric
+                                      (as a quantity).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - container
+                              - name
+                              - target
                             type: object
-                          percent:
+                          external:
                             description: |-
-                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                            format: int32
-                            minimum: 0
-                            type: integer
+                              external refers to a global metric that is not associated
+                              with any Kubernetes object. It allows autoscaling based on information
+                              coming from components running outside of cluster
+                              (for example length of queue in cloud messaging service, or
+                              QPS from loadbalancer running outside of cluster).
+                            properties:
+                              metric:
+                                description:
+                                  metric identifies the target metric by
+                                  name and selector
+                                properties:
+                                  name:
+                                    description: name is the name of the given metric
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                      When unset, just the metricName will be used to gather metrics.
+                                    properties:
+                                      matchExpressions:
+                                        description:
+                                          matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description:
+                                                key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                  - name
+                                type: object
+                              target:
+                                description:
+                                  target specifies the target value for the
+                                  given metric
+                                properties:
+                                  averageUtilization:
+                                    description: |-
+                                      averageUtilization is the target value of the average of the
+                                      resource metric across all relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source type
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      averageValue is the target value of the average of the
+                                      metric across all relevant pods (as a quantity)
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description:
+                                      type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description:
+                                      value is the target value of the metric
+                                      (as a quantity).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - metric
+                              - target
+                            type: object
+                          object:
+                            description: |-
+                              object refers to a metric describing a single kubernetes object
+                              (for example, hits-per-second on an Ingress object).
+                            properties:
+                              describedObject:
+                                description:
+                                  describedObject specifies the descriptions
+                                  of a object,such as kind,name apiVersion
+                                properties:
+                                  apiVersion:
+                                    description:
+                                      apiVersion is the API version of the
+                                      referent
+                                    type: string
+                                  kind:
+                                    description:
+                                      "kind is the kind of the referent;
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                                    type: string
+                                  name:
+                                    description:
+                                      "name is the name of the referent;
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              metric:
+                                description:
+                                  metric identifies the target metric by
+                                  name and selector
+                                properties:
+                                  name:
+                                    description: name is the name of the given metric
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                      When unset, just the metricName will be used to gather metrics.
+                                    properties:
+                                      matchExpressions:
+                                        description:
+                                          matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description:
+                                                key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                  - name
+                                type: object
+                              target:
+                                description:
+                                  target specifies the target value for the
+                                  given metric
+                                properties:
+                                  averageUtilization:
+                                    description: |-
+                                      averageUtilization is the target value of the average of the
+                                      resource metric across all relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source type
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      averageValue is the target value of the average of the
+                                      metric across all relevant pods (as a quantity)
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description:
+                                      type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description:
+                                      value is the target value of the metric
+                                      (as a quantity).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - describedObject
+                              - metric
+                              - target
+                            type: object
+                          pods:
+                            description: |-
+                              pods refers to a metric describing each pod in the current scale target
+                              (for example, transactions-processed-per-second).  The values will be
+                              averaged together before being compared to the target value.
+                            properties:
+                              metric:
+                                description:
+                                  metric identifies the target metric by
+                                  name and selector
+                                properties:
+                                  name:
+                                    description: name is the name of the given metric
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                      When unset, just the metricName will be used to gather metrics.
+                                    properties:
+                                      matchExpressions:
+                                        description:
+                                          matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description:
+                                                key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                  - name
+                                type: object
+                              target:
+                                description:
+                                  target specifies the target value for the
+                                  given metric
+                                properties:
+                                  averageUtilization:
+                                    description: |-
+                                      averageUtilization is the target value of the average of the
+                                      resource metric across all relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source type
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      averageValue is the target value of the average of the
+                                      metric across all relevant pods (as a quantity)
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description:
+                                      type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description:
+                                      value is the target value of the metric
+                                      (as a quantity).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - metric
+                              - target
+                            type: object
+                          resource:
+                            description: |-
+                              resource refers to a resource metric (such as those specified in
+                              requests and limits) known to Kubernetes describing each pod in the
+                              current scale target (e.g. CPU or memory). Such metrics are built in to
+                              Kubernetes, and have special scaling options on top of those available
+                              to normal per-pod metrics using the "pods" source.
+                            properties:
+                              name:
+                                description: name is the name of the resource in question.
+                                type: string
+                              target:
+                                description:
+                                  target specifies the target value for the
+                                  given metric
+                                properties:
+                                  averageUtilization:
+                                    description: |-
+                                      averageUtilization is the target value of the average of the
+                                      resource metric across all relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source type
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      averageValue is the target value of the average of the
+                                      metric across all relevant pods (as a quantity)
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description:
+                                      type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description:
+                                      value is the target value of the metric
+                                      (as a quantity).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - name
+                              - target
+                            type: object
                           type:
-                            enum:
-                            - percent
-                            - absolute
+                            description: |-
+                              type is the type of metric source.  It should be one of "ContainerResource", "External",
+                              "Object", "Pods" or "Resource", each mapping to a matching field in the object.
                             type: string
                         required:
-                        - type
+                          - type
                         type: object
-                        x-kubernetes-validations:
-                        - message: percent must be set when type is percent
-                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
-                        - message: absolute must be set when type is absolute
-                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
-                            true'
-                      scale_up:
+                      type: array
+                    exclude_metrics:
+                      description: Metrics from HPA for thoras to ignore
+                      items:
                         properties:
-                          absolute:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                              For vertical scaling: Use "memory" and "cpu" resource names.
-                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                these absolute values to trigger scaling, regardless of current usage percentage.
-                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
-                            type: object
-                          percent:
-                            description: |-
-                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                            format: int32
-                            minimum: 0
-                            type: integer
+                          name:
+                            type: string
                           type:
-                            enum:
-                            - percent
-                            - absolute
                             type: string
                         required:
-                        - type
+                          - name
+                          - type
                         type: object
-                        x-kubernetes-validations:
-                        - message: percent must be set when type is percent
-                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
-                        - message: absolute must be set when type is absolute
-                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
-                            true'
-                    type: object
-                required:
-                - mode
-                type: object
-                x-kubernetes-validations:
-                - message: minReplicas must not be greater than maxReplicas
-                  rule: '!has(self.minReplicas) || !has(self.maxReplicas) || self.minReplicas
-                    <= self.maxReplicas'
-              model:
-                description: |-
-                  Defines the forecasting and scaling behavior for an AIScaleTarget, including
-                  how often forecasts are generated, how far ahead to predict, and how
-                  aggressively to scale.
-                properties:
-                  forecast_blocks:
-                    default: 15m0s
-                    description: Time duration for how far into the future Thoras
-                      should forecast into.
-                    type: string
-                    x-kubernetes-int-or-string: true
-                  forecast_buffer_percentage:
-                    default: 0%
-                    description: Percentage, represented as a int between 1 and 100,
-                      that Thoras will apply on top of predictions for safety.
-                    type: string
-                    x-kubernetes-int-or-string: true
-                  forecast_cron:
-                    type: string
-                  forecast_interval:
-                    description: |-
-                      Time duration for the how frequently Thoras forecasts. This provides
-                      control for how often scaling decisions are made. Mutually exclusive with
-                      forecastCron.
-                    type: string
-                    x-kubernetes-int-or-string: true
-                  metrics:
-                    additionalProperties:
+                      type: array
+                    maxReplicas:
                       description: |-
-                        Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
-                        The "required" direction (mode: percentile without percentile_value) is intentionally omitted
-                        because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
-                        That check is handled by the admission webhook, which has full context.
+                        maxReplicas is the upper limit for the number of replicas to which the Thoras
+                        can scale up.
+                        If not set, Thoras will use the MaxReplicas value from the target's HPA if available.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    minReplicas:
+                      description: |-
+                        minReplicas is the lower limit for the number of replicas to which the Thoras
+                        can scale down.
+                        If not set, Thoras will use the MinReplicas value from the target's HPA if available.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    mode:
+                      enum:
+                        - autonomous
+                        - auto
+                        - recommendation
+                        - recommend
+                        - rec
+                        - observe
+                        - observation
+                      type: string
+                    model:
+                      description: |-
+                        Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                        how often forecasts are generated, how far ahead to predict, and how
+                        aggressively to scale.
                       properties:
+                        forecast_blocks:
+                          default: 15m0s
+                          description:
+                            Time duration for how far into the future Thoras
+                            should forecast into.
+                          type: string
+                          x-kubernetes-int-or-string: true
                         forecast_buffer_percentage:
-                          description: Buffer percentage for this metric. Overrides
-                            global forecast_buffer_percentage.
+                          default: 0%
+                          description:
+                            Percentage, represented as a int between 1 and
+                            100, that Thoras will apply on top of predictions for safety.
+                          type: string
+                          x-kubernetes-int-or-string: true
+                        forecast_cron:
+                          type: string
+                        forecast_interval:
+                          description: |-
+                            Time duration for the how frequently Thoras forecasts. This provides
+                            control for how often scaling decisions are made. Mutually exclusive with
+                            forecastCron.
+                          type: string
+                          x-kubernetes-int-or-string: true
+                        metrics:
+                          additionalProperties:
+                            description: |-
+                              Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                              The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                              because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                              That check is handled by the admission webhook, which has full context.
+                            properties:
+                              forecast_buffer_percentage:
+                                description:
+                                  Buffer percentage for this metric. Overrides
+                                  global forecast_buffer_percentage.
+                                type: string
+                                x-kubernetes-int-or-string: true
+                              mode:
+                                description:
+                                  Forecast mode for this metric. Overrides
+                                  global model.mode.
+                                enum:
+                                  - balanced
+                                  - cost_optimized
+                                  - undershoot
+                                  - assurance_optimized
+                                  - overshoot
+                                  - percentile
+                                type: string
+                              percentile_value:
+                                description: |-
+                                  Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                  Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                                type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                            x-kubernetes-validations:
+                              - message:
+                                  percentile_value can only be set when mode is
+                                  percentile
+                                rule:
+                                  "!has(self.mode) || self.mode == 'percentile'
+                                  || !has(self.percentile_value)"
+                          description:
+                            Per-metric forecast configuration. Overrides
+                            global mode and forecast_buffer_percentage for specific
+                            metrics.
+                          type: object
+                        min_lookback_to_scale:
+                          description:
+                            Minimum lookback window before autonomous scaling
+                            is enabled. Autonomous scaling will only occur if historical
+                            data spans at least this duration.
                           type: string
                           x-kubernetes-int-or-string: true
                         mode:
-                          description: Forecast mode for this metric. Overrides global
-                            model.mode.
+                          description:
+                            While Thoras models always bias for reliability,
+                            you have the option to set a "mode" for the model to inform
+                            the level of aggression in scaling.
                           enum:
-                          - balanced
-                          - cost_optimized
-                          - undershoot
-                          - assurance_optimized
-                          - overshoot
-                          - percentile
+                            - balanced
+                            - cost_optimized
+                            - undershoot
+                            - assurance_optimized
+                            - overshoot
+                            - percentile
                           type: string
                         percentile_value:
                           description: |-
@@ -811,956 +691,1190 @@ spec:
                           x-kubernetes-int-or-string: true
                       type: object
                       x-kubernetes-validations:
-                      - message: percentile_value can only be set when mode is percentile
-                        rule: '!has(self.mode) || self.mode == ''percentile'' || !has(self.percentile_value)'
-                    description: Per-metric forecast configuration. Overrides global
-                      mode and forecast_buffer_percentage for specific metrics.
-                    type: object
-                  min_lookback_to_scale:
-                    description: Minimum lookback window before autonomous scaling
-                      is enabled. Autonomous scaling will only occur if historical
-                      data spans at least this duration.
-                    type: string
-                    x-kubernetes-int-or-string: true
-                  mode:
-                    description: While Thoras models always bias for reliability,
-                      you have the option to set a "mode" for the model to inform
-                      the level of aggression in scaling.
-                    enum:
-                    - balanced
-                    - cost_optimized
-                    - undershoot
-                    - assurance_optimized
-                    - overshoot
-                    - percentile
-                    type: string
-                  percentile_value:
-                    description: |-
-                      Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                      Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                    type: string
-                    x-kubernetes-int-or-string: true
-                type: object
-                x-kubernetes-validations:
-                - message: forecastCron and forecastInterval are mutually exclusive
-                  rule: '!has(self.forecast_cron) || self.forecast_cron == '''' ||
-                    !has(self.forecast_interval) || self.forecast_interval == '''''
-                - message: forecastInterval must be less than or equal to forecastBlocks
-                  rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
-                    || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
-                - message: percentile_value is required when mode is percentile
-                  rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
-                - message: percentile_value can only be set when mode is percentile
-                  rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
-                    == ''percentile'')'
-              scaleTargetRef:
-                properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                type: object
-              selector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
+                        - message: forecastCron and forecastInterval are mutually exclusive
+                          rule:
+                            "!has(self.forecast_cron) || self.forecast_cron == ''
+                            || !has(self.forecast_interval) || self.forecast_interval
+                            == ''"
+                        - message: forecastInterval must be less than or equal to forecastBlocks
+                          rule:
+                            "!has(self.forecast_interval) || !has(self.forecast_blocks)
+                            || duration(self.forecast_interval) <= duration(self.forecast_blocks)"
+                        - message: percentile_value is required when mode is percentile
+                          rule: "!has(self.mode) || self.mode != 'percentile' || has(self.percentile_value)"
+                        - message: percentile_value can only be set when mode is percentile
+                          rule:
+                            "!has(self.percentile_value) || (has(self.mode) && self.mode
+                            == 'percentile')"
+                    scaling_behavior:
+                      description:
+                        Rules for how large a proposed scale event must be
+                        before triggering
                       properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                          type: string
-                        values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
-              vertical:
-                properties:
-                  containers:
-                    items:
-                      properties:
-                        cpu:
+                        scale_down:
                           properties:
-                            limit:
-                              properties:
-                                ratio:
-                                  anyOf:
+                            absolute:
+                              additionalProperties:
+                                anyOf:
                                   - type: integer
                                   - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - ratio
-                              type: object
-                            lowerbound:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            upperbound:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          required:
-                          - lowerbound
-                          type: object
-                        jvm_options:
-                          description: |-
-                            JVMOptions configures automatic JVM heap sizing.
-                            The calculation flow is:
-                             1. Xmx = max(heap_forecast, heap_current) * (1 + XmxBuffer)
-                             2. Apply XmxBounds clamping to Xmx
-                             3. Xms = Xmx * XmsRatio
-                             4. Container Memory = (Xmx + nonheap) * (1 + MemoryBuffer)
-                          properties:
-                            enable_auto_heap_size:
-                              description: Enable automatic JVM heap size adjustment
-                                based on memory requests.
-                              type: boolean
-                            memory_buffer:
-                              default: 10%
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               description: |-
-                                MemoryBuffer specifies the buffer percentage to add above total JVM memory (heap + non-heap) when setting container memory limits.
-                                This accounts for non-heap memory regions such as metaspace, thread stacks, and native memory allocations.
-                                Valid range: 0%-100%. Defaults to 10%.
-                              type: string
-                            xms_ratio:
-                              default: 80%
-                              description: |-
-                                XmsRatio specifies the ratio of the initial heap size (Xms) relative to the maximum heap size (Xmx).
-                                This determines how much memory is allocated to the JVM heap at startup.
-                                Valid range: 0%-100%. Defaults to 80%.
-                              type: string
-                            xmx_bounds:
-                              properties:
-                                limit:
-                                  properties:
-                                    ratio:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - ratio
-                                  type: object
-                                lowerbound:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                upperbound:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - lowerbound
+                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                                For vertical scaling: Use "memory" and "cpu" resource names.
+                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                  these absolute values to trigger scaling, regardless of current usage percentage.
+                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
                               type: object
-                            xmx_buffer:
-                              default: 10%
+                            percent:
                               description: |-
-                                XmxBuffer specifies the buffer percentage to add above observed heap memory usage when setting Xmx.
-                                This provides headroom for heap allocation to prevent out-of-memory errors.
-                                Valid range: 0%-100%. Defaults to 10%.
-                              type: string
-                          type: object
-                        memory:
-                          properties:
-                            limit:
-                              properties:
-                                ratio:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - ratio
-                              type: object
-                            lowerbound:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            upperbound:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          required:
-                          - lowerbound
-                          type: object
-                        name:
-                          description: name of container to scale
-                          type: string
-                      required:
-                      - name
-                      type: object
-                      x-kubernetes-validations:
-                      - message: EnableAutoHeapSize can only be true if memory.limit
-                          is set
-                        rule: '!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
-                          || (has(self.memory) && has(self.memory.limit))'
-                    type: array
-                  disruption:
-                    description: |-
-                      Disruption controls how aggressively Thoras applies pod changes (in-place
-                      resize or eviction) when applying vertical recommendations.
-                    properties:
-                      interval:
-                        default: 60s
-                        description: |-
-                          Interval is the minimum duration the operator waits after a batch of
-                          pod changes (resize or evict) before applying the next batch. Defaults to 60s.
-                        type: string
-                      max_disrupted:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        default: 20%
-                        description: |-
-                          MaxDisrupted is the maximum number of pods that may be
-                          disrupted at once across the workload. A pod is "disrupted" if it is
-                          terminating or its Ready condition is not True. The operator only
-                          applies pod changes (resize or evict) up to the remaining headroom in
-                          each batch, so prior batches that haven't finished rolling reduce the
-                          next batch's size. After issuing a batch, the operator waits Interval
-                          before issuing the next batch. Unlike PodDisruptionBudget.maxUnavailable,
-                          this cap is enforced by the operator itself: pods that are unavailable
-                          for reasons unrelated to Thoras (e.g. failing readiness probes) still
-                          consume the budget.
-
-                          Accepts an absolute integer (e.g. 2) or a percentage of the workload's
-                          desired replicas (e.g. "25%"). Defaults to 20%.
-                        x-kubernetes-int-or-string: true
-                    type: object
-                    x-kubernetes-validations:
-                    - message: max_disrupted must be a positive integer or a percentage
-                        between 1% and 100%
-                      rule: '!has(self.max_disrupted) || (type(self.max_disrupted)
-                        == int ? self.max_disrupted >= 1 : self.max_disrupted.matches(''^([1-9][0-9]?|100)%$''))'
-                    - message: interval must be a positive duration
-                      rule: '!has(self.interval) || duration(self.interval) > duration(''0s'')'
-                  in_place_resizing:
-                    description: |-
-                      Deprecated: Use UpdatePolicy instead.
-                      When InPlaceResizing is not specified and UpdatePolicy is not specified, the default behavior is UpdatePolicy{UpdateMode: "recreate", RecreateResources: ["memory"]}.
-                    properties:
-                      allow_restart_on_memory_limit_decrease:
-                        type: boolean
-                      enabled:
-                        type: boolean
-                    type: object
-                  mode:
-                    enum:
-                    - autonomous
-                    - auto
-                    - recommendation
-                    - recommend
-                    - rec
-                    - observe
-                    - observation
-                    type: string
-                  model:
-                    description: |-
-                      Defines the forecasting and scaling behavior for an AIScaleTarget, including
-                      how often forecasts are generated, how far ahead to predict, and how
-                      aggressively to scale.
-                    properties:
-                      forecast_blocks:
-                        default: 15m0s
-                        description: Time duration for how far into the future Thoras
-                          should forecast into.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      forecast_buffer_percentage:
-                        default: 0%
-                        description: Percentage, represented as a int between 1 and
-                          100, that Thoras will apply on top of predictions for safety.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      forecast_cron:
-                        type: string
-                      forecast_interval:
-                        description: |-
-                          Time duration for the how frequently Thoras forecasts. This provides
-                          control for how often scaling decisions are made. Mutually exclusive with
-                          forecastCron.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      metrics:
-                        additionalProperties:
-                          description: |-
-                            Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
-                            The "required" direction (mode: percentile without percentile_value) is intentionally omitted
-                            because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
-                            That check is handled by the admission webhook, which has full context.
-                          properties:
-                            forecast_buffer_percentage:
-                              description: Buffer percentage for this metric. Overrides
-                                global forecast_buffer_percentage.
-                              type: string
-                              x-kubernetes-int-or-string: true
-                            mode:
-                              description: Forecast mode for this metric. Overrides
-                                global model.mode.
+                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type:
                               enum:
+                                - percent
+                                - absolute
+                              type: string
+                          required:
+                            - type
+                          type: object
+                          x-kubernetes-validations:
+                            - message: percent must be set when type is percent
+                              rule: "self.type == 'percent' ? has(self.percent) : true"
+                            - message: absolute must be set when type is absolute
+                              rule:
+                                "self.type == 'absolute' ? has(self.absolute) :
+                                true"
+                        scale_up:
+                          properties:
+                            absolute:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                                For vertical scaling: Use "memory" and "cpu" resource names.
+                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                  these absolute values to trigger scaling, regardless of current usage percentage.
+                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
+                              type: object
+                            percent:
+                              description: |-
+                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type:
+                              enum:
+                                - percent
+                                - absolute
+                              type: string
+                          required:
+                            - type
+                          type: object
+                          x-kubernetes-validations:
+                            - message: percent must be set when type is percent
+                              rule: "self.type == 'percent' ? has(self.percent) : true"
+                            - message: absolute must be set when type is absolute
+                              rule:
+                                "self.type == 'absolute' ? has(self.absolute) :
+                                true"
+                      type: object
+                  required:
+                    - mode
+                  type: object
+                  x-kubernetes-validations:
+                    - message: minReplicas must not be greater than maxReplicas
+                      rule:
+                        "!has(self.minReplicas) || !has(self.maxReplicas) || self.minReplicas
+                        <= self.maxReplicas"
+                model:
+                  description: |-
+                    Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                    how often forecasts are generated, how far ahead to predict, and how
+                    aggressively to scale.
+                  properties:
+                    forecast_blocks:
+                      default: 15m0s
+                      description:
+                        Time duration for how far into the future Thoras
+                        should forecast into.
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    forecast_buffer_percentage:
+                      default: 0%
+                      description:
+                        Percentage, represented as a int between 1 and 100,
+                        that Thoras will apply on top of predictions for safety.
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    forecast_cron:
+                      type: string
+                    forecast_interval:
+                      description: |-
+                        Time duration for the how frequently Thoras forecasts. This provides
+                        control for how often scaling decisions are made. Mutually exclusive with
+                        forecastCron.
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    metrics:
+                      additionalProperties:
+                        description: |-
+                          Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                          The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                          because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                          That check is handled by the admission webhook, which has full context.
+                        properties:
+                          forecast_buffer_percentage:
+                            description:
+                              Buffer percentage for this metric. Overrides
+                              global forecast_buffer_percentage.
+                            type: string
+                            x-kubernetes-int-or-string: true
+                          mode:
+                            description:
+                              Forecast mode for this metric. Overrides global
+                              model.mode.
+                            enum:
                               - balanced
                               - cost_optimized
                               - undershoot
                               - assurance_optimized
                               - overshoot
                               - percentile
-                              type: string
-                            percentile_value:
-                              description: |-
-                                Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                                Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                              type: string
-                              x-kubernetes-int-or-string: true
-                          type: object
-                          x-kubernetes-validations:
-                          - message: percentile_value can only be set when mode is
-                              percentile
-                            rule: '!has(self.mode) || self.mode == ''percentile''
-                              || !has(self.percentile_value)'
-                        description: Per-metric forecast configuration. Overrides
-                          global mode and forecast_buffer_percentage for specific
-                          metrics.
+                            type: string
+                          percentile_value:
+                            description: |-
+                              Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                              Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                            type: string
+                            x-kubernetes-int-or-string: true
                         type: object
-                      min_lookback_to_scale:
-                        description: Minimum lookback window before autonomous scaling
-                          is enabled. Autonomous scaling will only occur if historical
-                          data spans at least this duration.
-                        type: string
-                        x-kubernetes-int-or-string: true
-                      mode:
-                        description: While Thoras models always bias for reliability,
-                          you have the option to set a "mode" for the model to inform
-                          the level of aggression in scaling.
-                        enum:
+                        x-kubernetes-validations:
+                          - message: percentile_value can only be set when mode is percentile
+                            rule: "!has(self.mode) || self.mode == 'percentile' || !has(self.percentile_value)"
+                      description:
+                        Per-metric forecast configuration. Overrides global
+                        mode and forecast_buffer_percentage for specific metrics.
+                      type: object
+                    min_lookback_to_scale:
+                      description:
+                        Minimum lookback window before autonomous scaling
+                        is enabled. Autonomous scaling will only occur if historical
+                        data spans at least this duration.
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    mode:
+                      description:
+                        While Thoras models always bias for reliability,
+                        you have the option to set a "mode" for the model to inform
+                        the level of aggression in scaling.
+                      enum:
                         - balanced
                         - cost_optimized
                         - undershoot
                         - assurance_optimized
                         - overshoot
                         - percentile
-                        type: string
-                      percentile_value:
-                        description: |-
-                          Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
-                          Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
-                        type: string
-                        x-kubernetes-int-or-string: true
-                    type: object
-                    x-kubernetes-validations:
-                    - message: forecastCron and forecastInterval are mutually exclusive
-                      rule: '!has(self.forecast_cron) || self.forecast_cron == ''''
-                        || !has(self.forecast_interval) || self.forecast_interval
-                        == '''''
-                    - message: forecastInterval must be less than or equal to forecastBlocks
-                      rule: '!has(self.forecast_interval) || !has(self.forecast_blocks)
-                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)'
-                    - message: percentile_value is required when mode is percentile
-                      rule: '!has(self.mode) || self.mode != ''percentile'' || has(self.percentile_value)'
-                    - message: percentile_value can only be set when mode is percentile
-                      rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
-                        == ''percentile'')'
-                  oom_remediation:
-                    description: |-
-                      OOMRemediation configures operator-driven memory adjustment during active OOM episodes.
-                      When nil or Enabled is false, no automatic adjustment is applied.
-                    properties:
-                      enabled:
-                        description: Enabled activates automatic memory adjustment
-                          when OOM kills are detected.
-                        type: boolean
-                      stabilization_window:
-                        description: |-
-                          StabilizationWindow is the minimum time the workload must run without a new OOM before the
-                          operator allows a forecast to lower memory below the OOM-adjusted value. The floor
-                          resets on each new OOM. When nil, defaults to max(forecast_interval, 1h).
-                        type: string
-                    type: object
-                  scaling_behavior:
-                    description: Rules for how large a proposed scale event must be
-                      before triggering
-                    properties:
-                      scale_down:
-                        properties:
-                          absolute:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                              For vertical scaling: Use "memory" and "cpu" resource names.
-                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                these absolute values to trigger scaling, regardless of current usage percentage.
-                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
-                            type: object
-                          percent:
-                            description: |-
-                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                          type:
-                            enum:
-                            - percent
-                            - absolute
-                            type: string
-                        required:
-                        - type
-                        type: object
-                        x-kubernetes-validations:
-                        - message: percent must be set when type is percent
-                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
-                        - message: absolute must be set when type is absolute
-                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
-                            true'
-                      scale_up:
-                        properties:
-                          absolute:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
-                              For vertical scaling: Use "memory" and "cpu" resource names.
-                                Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
-                                these absolute values to trigger scaling, regardless of current usage percentage.
-                              For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
-                                Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
-                            type: object
-                          percent:
-                            description: |-
-                              Percent specifies a percentage threshold (0-100). Used when Type is "percent".
-                              For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                          type:
-                            enum:
-                            - percent
-                            - absolute
-                            type: string
-                        required:
-                        - type
-                        type: object
-                        x-kubernetes-validations:
-                        - message: percent must be set when type is percent
-                          rule: 'self.type == ''percent'' ? has(self.percent) : true'
-                        - message: absolute must be set when type is absolute
-                          rule: 'self.type == ''absolute'' ? has(self.absolute) :
-                            true'
-                    type: object
-                  update_policy:
-                    description: 'UpdatePolicy defines how pod updates are handled.
-                      If not specified, defaults to UpdatePolicy{UpdateMode: "recreate",
-                      RecreateResources: ["memory"]}.'
-                    properties:
-                      recreate_resources:
-                        default:
-                        - memory
-                        description: |-
-                          RecreateResources lists which resource types should trigger pod recreation when changed.
-                          Defaults to ["memory"] if not set.
-                        items:
-                          type: string
-                        type: array
-                      update_mode:
-                        default: recreate
-                        description: UpdateMode specifies the update strategy. Defaults
-                          to "recreate" if not set.
-                        enum:
-                        - initial
-                        - recreate
-                        - in_place_or_recreate
-                        - in_place
-                        type: string
-                    type: object
-                required:
-                - containers
-                - mode
-                type: object
-                x-kubernetes-validations:
-                - message: when in_place_resizing.enabled is true, update_policy.update_mode
-                    must be either 'in_place' or 'in_place_or_recreate'
-                  rule: '!has(self.in_place_resizing) || !has(self.in_place_resizing.enabled)
-                    || !self.in_place_resizing.enabled || !has(self.update_policy)
-                    || self.update_policy.update_mode == ''in_place'' || self.update_policy.update_mode
-                    == ''in_place_or_recreate'''
-                - message: when in_place_resizing.enabled is false, update_policy.update_mode
-                    cannot be 'in_place' or 'in_place_or_recreate'
-                  rule: '!has(self.in_place_resizing) || self.in_place_resizing.enabled
-                    || !has(self.update_policy) || (self.update_policy.update_mode
-                    != ''in_place'' && self.update_policy.update_mode != ''in_place_or_recreate'')'
-            required:
-            - model
-            type: object
-            x-kubernetes-validations:
-            - message: exactly one of scaleTargetRef or selector must be set
-              rule: (has(self.scaleTargetRef) && !has(self.selector)) || (!has(self.scaleTargetRef)
-                && has(self.selector))
-            - message: cannot have both horizontal and vertical scaling in autonomous
-                mode
-              rule: '!(has(self.horizontal) && has(self.vertical) && self.horizontal.mode.startsWith(''auto'')
-                && self.vertical.mode.startsWith(''auto''))'
-          status:
-            properties:
-              conditions:
-                description: Conditions represent the latest available observations
-                  of the AIScaleTarget's state
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
+                      type: string
+                    percentile_value:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                        Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                        Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
                       type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                      x-kubernetes-int-or-string: true
                   type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              horizontalSuggestion:
-                properties:
-                  currentReplicas:
-                    format: int32
-                    type: integer
-                  end:
-                    format: date-time
-                    type: string
-                  forecastError:
-                    description: |-
-                      ForecastError is set when a general forecasting error occurred that blocks all scaling.
-                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                    type: string
-                  hasEnoughDataToScale:
-                    description: |-
-                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
-                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
-                    type: boolean
-                  start:
-                    format: date-time
-                    type: string
-                  suggestedReplicas:
-                    format: int32
-                    type: integer
-                  suggestionUID:
-                    type: string
-                required:
-                - currentReplicas
-                - end
-                - hasEnoughDataToScale
-                - start
-                - suggestedReplicas
-                type: object
-              labelSelector:
-                type: string
-              lastCollectionTime:
-                description: LastCollectionTime is the last time metrics were successfully
-                  collected for this AIScaleTarget
-                format: date-time
-                type: string
-              lastOOMMemoryAdjusted:
-                description: |-
-                  LastOOMMemoryAdjusted is when the operator last applied an OOM memory adjustment.
-                  Used to enforce the cooldown between successive adjustments.
-                format: date-time
-                type: string
-              lastOOMTime:
-                description: |-
-                  LastOOMTime is the most recent collection time at which OOM kills were observed.
-                  Used to determine when the episode is over.
-                format: date-time
-                type: string
-              lastProcessedSuggestionUID:
-                description: |-
-                  LastProcessedSuggestionUID is the SuggestionUID of the last suggestion the operator
-                  fully processed (PrepareAction → execute → audit written). Used to prevent reprocessing
-                  the same suggestion on every reconcile.
-                type: string
-              latestSuggestion:
-                description: LatestSuggestion contains the most recent scaling recommendations
-                  from Thoras AI
-                properties:
-                  currentReplicas:
-                    description: |-
-                      CurrentReplicas is the number of replicas at the time this suggestion was generated.
-                      NB: This does not reflect the current replica count, just the count at suggestion time.
-
-                      replica count rather than a snapshot from when the forecaster created the suggestion.
-                    format: int32
-                    type: integer
-                  end:
-                    format: date-time
-                    type: string
-                  forecastErrorGeneral:
-                    description: |-
-                      ForecastErrorGeneral is set when a general forecasting error occurred that blocks all scaling.
-                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                    type: string
-                  forecastErrorHorizontal:
-                    description: |-
-                      ForecastErrorHorizontal is set when a horizontal-specific forecasting error occurred.
-                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                    type: string
-                  forecastErrorVertical:
-                    description: |-
-                      ForecastErrorVertical is set when a vertical-specific forecasting error occurred.
-                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                    type: string
-                  forecastedTotals:
-                    description: ForecastedTotals contains predicted resource usage
-                      metrics.
-                    items:
-                      description: ForecastMetric represents a predicted resource
-                        usage value for a specific metric.
-                      properties:
-                        metric:
-                          description: Metric name - can be "cpu", "memory", "heap",
-                            "non-heap", etc.
-                          type: string
-                        metricType:
-                          description: |-
-                            MetricType indicates the aggregation type of the metric
-                            Values: "average" (per-pod) or "total" (deployment-wide)
-                          type: string
-                        targetName:
-                          description: TargetName is the name of the deployment or
-                            container this metric applies to
-                          type: string
-                        targetType:
-                          description: |-
-                            TargetType indicates whether this is a deployment-level or container-level metric
-                            Values: "deployment" or "container"
-                          type: string
-                        value:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: Value is the forecasted value in Kubernetes
-                            resource format (e.g., "11m" for CPU, "24Mi" for memory)
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      required:
-                      - metric
-                      - targetName
-                      - targetType
-                      - value
+                  x-kubernetes-validations:
+                    - message: forecastCron and forecastInterval are mutually exclusive
+                      rule:
+                        "!has(self.forecast_cron) || self.forecast_cron == '' ||
+                        !has(self.forecast_interval) || self.forecast_interval == ''"
+                    - message: forecastInterval must be less than or equal to forecastBlocks
+                      rule:
+                        "!has(self.forecast_interval) || !has(self.forecast_blocks)
+                        || duration(self.forecast_interval) <= duration(self.forecast_blocks)"
+                    - message: percentile_value is required when mode is percentile
+                      rule: "!has(self.mode) || self.mode != 'percentile' || has(self.percentile_value)"
+                    - message: percentile_value can only be set when mode is percentile
+                      rule:
+                        "!has(self.percentile_value) || (has(self.mode) && self.mode
+                        == 'percentile')"
+                scaleTargetRef:
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                selector:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description:
+                        matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description:
+                              key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
-                    type: array
-                  hasEnoughDataToScale:
-                    description: |-
-                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
-                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
-                    type: boolean
-                  resourceRecommendations:
-                    description: ResourceRecommendations contains optimal resource
-                      requests for each container.
-                    items:
-                      description: ContainerRecommendation contains optimal resource
-                        allocation recommendations for a single container.
-                      properties:
-                        container:
-                          description: Container name
-                          type: string
-                        recommendations:
-                          description: Resource recommendations for this container
-                          items:
-                            description: ResourceRecommendation represents an optimal
-                              resource allocation for a specific resource type.
+                  type: object
+                  x-kubernetes-map-type: atomic
+                vertical:
+                  properties:
+                    containers:
+                      items:
+                        properties:
+                          cpu:
                             properties:
-                              resource:
-                                description: Resource type - "cpu" or "memory"
-                                type: string
-                              value:
+                              limit:
+                                properties:
+                                  ratio:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - ratio
+                                type: object
+                              lowerbound:
                                 anyOf:
-                                - type: integer
-                                - type: string
-                                description: Value in Kubernetes resource format (e.g.,
-                                  "12m" for CPU, "256Mi" for memory)
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              upperbound:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                             required:
-                            - resource
-                            - value
+                              - lowerbound
                             type: object
-                          type: array
-                      required:
-                      - container
-                      - recommendations
-                      type: object
-                    type: array
-                  start:
-                    description: Time window for this suggestion
-                    format: date-time
-                    type: string
-                  suggestedReplicas:
-                    description: SuggestedReplicas is the recommended number of pod
-                      replicas for horizontal scaling.
-                    format: int32
-                    type: integer
-                  suggestionUID:
-                    description: SuggestionUID is the stable UID assigned to this
-                      suggestion by proxySuggestionsRepository.
-                    type: string
-                required:
-                - currentReplicas
-                - end
-                - hasEnoughDataToScale
-                - start
-                - suggestedReplicas
-                type: object
-              oomAdjustedMemory:
-                description: |-
-                  OOMAdjustedMemory holds the per-container memory adjustments set by the operator
-                  during an active OOM episode. Keyed by container name. The admission webhook applies
-                  the adjusted request (floor on max(suggestion, floor)) and, when Limit is non-nil,
-                  applies the adjusted limit. Cleared when oomStabilizationWindowExpiry passes.
-
-                  The value type accepts both the legacy bare-Quantity form (request only, Limit nil)
-                  and the struct form {request, limit} via OOMContainerMemoryAdjustment.UnmarshalJSON.
-                x-kubernetes-preserve-unknown-fields: true
-              oomKilledContainers:
-                description: |-
-                  OOMKilledContainers is the set of container names that had OOM kills in the most recent
-                  collection cycle. Replaced on every cycle: set to containers with kills when OOMs are
-                  observed, cleared when no kills are observed. The operator uses this to scope memory
-                  adjustments to only containers that actually OOMed.
-                items:
-                  type: string
-                type: array
-              oomStabilizationWindowExpiry:
-                description: |-
-                  OOMStabilizationWindowExpiry is the time after which the OOM memory floor expires and forecasts are
-                  allowed to lower memory freely. Reset to now+StabilizationWindow on each new OOM adjustment.
-                format: date-time
-                type: string
-              previousVerticalMode:
-                type: string
-              replicas:
-                anyOf:
-                - type: integer
-                - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              thorasSuggestedReplicas:
-                anyOf:
-                - type: integer
-                - type: string
-                description: |-
-                  ThorasSuggestedReplicas is the latest recommended replica count.
-                  Deprecated: Use LatestSuggestion.SuggestedReplicas instead.
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              verticalSuggestion:
-                properties:
-                  containers:
-                    description: Containers contains optimal resource requirements
-                      for each container.
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        resources:
-                          description: ResourceRequirements describes the compute
-                            resource requirements.
-                          properties:
-                            claims:
-                              description: |-
-                                Claims lists the names of resources, defined in spec.resourceClaims,
-                                that are used by this container.
-
-                                This field depends on the
-                                DynamicResourceAllocation feature gate.
-
-                                This field is immutable. It can only be set for containers.
-                              items:
-                                description: ResourceClaim references one entry in
-                                  PodSpec.ResourceClaims.
+                          jvm_options:
+                            description: |-
+                              JVMOptions configures automatic JVM heap sizing.
+                              The calculation flow is:
+                               1. Xmx = max(heap_forecast, heap_current) * (1 + XmxBuffer)
+                               2. Apply XmxBounds clamping to Xmx
+                               3. Xms = Xmx * XmsRatio
+                               4. Container Memory = (Xmx + nonheap) * (1 + MemoryBuffer)
+                            properties:
+                              enable_auto_heap_size:
+                                description:
+                                  Enable automatic JVM heap size adjustment
+                                  based on memory requests.
+                                type: boolean
+                              memory_buffer:
+                                default: 10%
+                                description: |-
+                                  MemoryBuffer specifies the buffer percentage to add above total JVM memory (heap + non-heap) when setting container memory limits.
+                                  This accounts for non-heap memory regions such as metaspace, thread stacks, and native memory allocations.
+                                  Valid range: 0%-100%. Defaults to 10%.
+                                type: string
+                              xms_ratio:
+                                default: 80%
+                                description: |-
+                                  XmsRatio specifies the ratio of the initial heap size (Xms) relative to the maximum heap size (Xmx).
+                                  This determines how much memory is allocated to the JVM heap at startup.
+                                  Valid range: 0%-100%. Defaults to 80%.
+                                type: string
+                              xmx_bounds:
                                 properties:
-                                  name:
-                                    description: |-
-                                      Name must match the name of one entry in pod.spec.resourceClaims of
-                                      the Pod where this field is used. It makes that resource available
-                                      inside a container.
-                                    type: string
-                                  request:
-                                    description: |-
-                                      Request is the name chosen for a request in the referenced claim.
-                                      If empty, everything from the claim is made available, otherwise
-                                      only the result of this request.
-                                    type: string
+                                  limit:
+                                    properties:
+                                      ratio:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - ratio
+                                    type: object
+                                  lowerbound:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  upperbound:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                 required:
-                                - name
+                                  - lowerbound
                                 type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                              - name
-                              x-kubernetes-list-type: map
-                            limits:
-                              additionalProperties:
+                              xmx_buffer:
+                                default: 10%
+                                description: |-
+                                  XmxBuffer specifies the buffer percentage to add above observed heap memory usage when setting Xmx.
+                                  This provides headroom for heap allocation to prevent out-of-memory errors.
+                                  Valid range: 0%-100%. Defaults to 10%.
+                                type: string
+                            type: object
+                          memory:
+                            properties:
+                              limit:
+                                properties:
+                                  ratio:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - ratio
+                                type: object
+                              lowerbound:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: |-
-                                Limits describes the maximum amount of compute resources allowed.
-                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                              type: object
-                            requests:
-                              additionalProperties:
+                              upperbound:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: |-
-                                Requests describes the minimum amount of compute resources required.
-                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      - resources
+                            required:
+                              - lowerbound
+                            type: object
+                          name:
+                            description: name of container to scale
+                            type: string
+                            x-kubernetes-validations:
+                              - message: name must not be empty
+                                rule: size(self) > 0
+                        required:
+                          - name
+                        type: object
+                        x-kubernetes-validations:
+                          - message:
+                              EnableAutoHeapSize can only be true if memory.limit
+                              is set
+                            rule:
+                              "!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
+                              || (has(self.memory) && has(self.memory.limit))"
+                          - message: At least one of cpu or memory must be specified
+                            rule: has(self.cpu) || has(self.memory)
+                      type: array
+                      x-kubernetes-validations:
+                        - message: at least one container must be specified
+                          rule: self.size() > 0
+                    disruption:
+                      description: |-
+                        Disruption controls how aggressively Thoras applies pod changes (in-place
+                        resize or eviction) when applying vertical recommendations.
+                      properties:
+                        interval:
+                          default: 60s
+                          description: |-
+                            Interval is the minimum duration the operator waits after a batch of
+                            pod changes (resize or evict) before applying the next batch. Defaults to 60s.
+                          type: string
+                        max_disrupted:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          default: 20%
+                          description: |-
+                            MaxDisrupted is the maximum number of pods that may be
+                            disrupted at once across the workload. A pod is "disrupted" if it is
+                            terminating or its Ready condition is not True. The operator only
+                            applies pod changes (resize or evict) up to the remaining headroom in
+                            each batch, so prior batches that haven't finished rolling reduce the
+                            next batch's size. After issuing a batch, the operator waits Interval
+                            before issuing the next batch. Unlike PodDisruptionBudget.maxUnavailable,
+                            this cap is enforced by the operator itself: pods that are unavailable
+                            for reasons unrelated to Thoras (e.g. failing readiness probes) still
+                            consume the budget.
+
+                            Accepts an absolute integer (e.g. 2) or a percentage of the workload's
+                            desired replicas (e.g. "25%"). Defaults to 20%.
+                          x-kubernetes-int-or-string: true
                       type: object
-                    type: array
-                  end:
-                    format: date-time
+                      x-kubernetes-validations:
+                        - message:
+                            max_disrupted must be a positive integer or a percentage
+                            between 1% and 100%
+                          rule:
+                            "!has(self.max_disrupted) || (type(self.max_disrupted)
+                            == int ? self.max_disrupted >= 1 : self.max_disrupted.matches('^([1-9][0-9]?|100)%$'))"
+                        - message: interval must be a positive duration
+                          rule: "!has(self.interval) || duration(self.interval) > duration('0s')"
+                    in_place_resizing:
+                      description: |-
+                        Deprecated: Use UpdatePolicy instead.
+                        When InPlaceResizing is not specified and UpdatePolicy is not specified, the default behavior is UpdatePolicy{UpdateMode: "recreate", RecreateResources: ["memory"]}.
+                      properties:
+                        allow_restart_on_memory_limit_decrease:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    mode:
+                      enum:
+                        - autonomous
+                        - auto
+                        - recommendation
+                        - recommend
+                        - rec
+                        - observe
+                        - observation
+                      type: string
+                    model:
+                      description: |-
+                        Defines the forecasting and scaling behavior for an AIScaleTarget, including
+                        how often forecasts are generated, how far ahead to predict, and how
+                        aggressively to scale.
+                      properties:
+                        forecast_blocks:
+                          default: 15m0s
+                          description:
+                            Time duration for how far into the future Thoras
+                            should forecast into.
+                          type: string
+                          x-kubernetes-int-or-string: true
+                        forecast_buffer_percentage:
+                          default: 0%
+                          description:
+                            Percentage, represented as a int between 1 and
+                            100, that Thoras will apply on top of predictions for safety.
+                          type: string
+                          x-kubernetes-int-or-string: true
+                        forecast_cron:
+                          type: string
+                        forecast_interval:
+                          description: |-
+                            Time duration for the how frequently Thoras forecasts. This provides
+                            control for how often scaling decisions are made. Mutually exclusive with
+                            forecastCron.
+                          type: string
+                          x-kubernetes-int-or-string: true
+                        metrics:
+                          additionalProperties:
+                            description: |-
+                              Only the "forbidden" direction is enforced here — percentile_value set without mode: percentile.
+                              The "required" direction (mode: percentile without percentile_value) is intentionally omitted
+                              because CEL cannot see the parent spec; a metric may inherit percentile_value from spec.model.
+                              That check is handled by the admission webhook, which has full context.
+                            properties:
+                              forecast_buffer_percentage:
+                                description:
+                                  Buffer percentage for this metric. Overrides
+                                  global forecast_buffer_percentage.
+                                type: string
+                                x-kubernetes-int-or-string: true
+                              mode:
+                                description:
+                                  Forecast mode for this metric. Overrides
+                                  global model.mode.
+                                enum:
+                                  - balanced
+                                  - cost_optimized
+                                  - undershoot
+                                  - assurance_optimized
+                                  - overshoot
+                                  - percentile
+                                type: string
+                              percentile_value:
+                                description: |-
+                                  Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                                  Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                                type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                            x-kubernetes-validations:
+                              - message:
+                                  percentile_value can only be set when mode is
+                                  percentile
+                                rule:
+                                  "!has(self.mode) || self.mode == 'percentile'
+                                  || !has(self.percentile_value)"
+                          description:
+                            Per-metric forecast configuration. Overrides
+                            global mode and forecast_buffer_percentage for specific
+                            metrics.
+                          type: object
+                        min_lookback_to_scale:
+                          description:
+                            Minimum lookback window before autonomous scaling
+                            is enabled. Autonomous scaling will only occur if historical
+                            data spans at least this duration.
+                          type: string
+                          x-kubernetes-int-or-string: true
+                        mode:
+                          description:
+                            While Thoras models always bias for reliability,
+                            you have the option to set a "mode" for the model to inform
+                            the level of aggression in scaling.
+                          enum:
+                            - balanced
+                            - cost_optimized
+                            - undershoot
+                            - assurance_optimized
+                            - overshoot
+                            - percentile
+                          type: string
+                        percentile_value:
+                          description: |-
+                            Percentile value to use when mode is "percentile". Required when mode is "percentile", must not be set otherwise.
+                            Valid range: 0–100. Decimals supported via quoted string (e.g. "99.9"). Integer values do not need quotes (e.g. 75).
+                          type: string
+                          x-kubernetes-int-or-string: true
+                      type: object
+                      x-kubernetes-validations:
+                        - message: forecastCron and forecastInterval are mutually exclusive
+                          rule:
+                            "!has(self.forecast_cron) || self.forecast_cron == ''
+                            || !has(self.forecast_interval) || self.forecast_interval
+                            == ''"
+                        - message: forecastInterval must be less than or equal to forecastBlocks
+                          rule:
+                            "!has(self.forecast_interval) || !has(self.forecast_blocks)
+                            || duration(self.forecast_interval) <= duration(self.forecast_blocks)"
+                        - message: percentile_value is required when mode is percentile
+                          rule: "!has(self.mode) || self.mode != 'percentile' || has(self.percentile_value)"
+                        - message: percentile_value can only be set when mode is percentile
+                          rule:
+                            "!has(self.percentile_value) || (has(self.mode) && self.mode
+                            == 'percentile')"
+                    oom_remediation:
+                      description: |-
+                        OOMRemediation configures operator-driven memory adjustment during active OOM episodes.
+                        When nil or Enabled is false, no automatic adjustment is applied.
+                      properties:
+                        enabled:
+                          description:
+                            Enabled activates automatic memory adjustment
+                            when OOM kills are detected.
+                          type: boolean
+                        stabilization_window:
+                          description: |-
+                            StabilizationWindow is the minimum time the workload must run without a new OOM before the
+                            operator allows a forecast to lower memory below the OOM-adjusted value. The floor
+                            resets on each new OOM. When nil, defaults to max(forecast_interval, 1h).
+                          type: string
+                      type: object
+                    scaling_behavior:
+                      description:
+                        Rules for how large a proposed scale event must be
+                        before triggering
+                      properties:
+                        scale_down:
+                          properties:
+                            absolute:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                                For vertical scaling: Use "memory" and "cpu" resource names.
+                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                  these absolute values to trigger scaling, regardless of current usage percentage.
+                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
+                              type: object
+                            percent:
+                              description: |-
+                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type:
+                              enum:
+                                - percent
+                                - absolute
+                              type: string
+                          required:
+                            - type
+                          type: object
+                          x-kubernetes-validations:
+                            - message: percent must be set when type is percent
+                              rule: "self.type == 'percent' ? has(self.percent) : true"
+                            - message: absolute must be set when type is absolute
+                              rule:
+                                "self.type == 'absolute' ? has(self.absolute) :
+                                true"
+                        scale_up:
+                          properties:
+                            absolute:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Absolute specifies fixed resource amounts as thresholds. Used when Type is "absolute".
+                                For vertical scaling: Use "memory" and "cpu" resource names.
+                                  Example: {"memory": "50Mi", "cpu": "100m"} means the resource change must exceed
+                                  these absolute values to trigger scaling, regardless of current usage percentage.
+                                For horizontal scaling: Use "pods" resource name to specify replica count thresholds.
+                                  Example: {"pods": "5"} means the replica count change must be at least 5 to trigger scaling.
+                              type: object
+                            percent:
+                              description: |-
+                                Percent specifies a percentage threshold (0-100). Used when Type is "percent".
+                                For example, 20 means the resource change must exceed 20% of current usage to trigger scaling.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type:
+                              enum:
+                                - percent
+                                - absolute
+                              type: string
+                          required:
+                            - type
+                          type: object
+                          x-kubernetes-validations:
+                            - message: percent must be set when type is percent
+                              rule: "self.type == 'percent' ? has(self.percent) : true"
+                            - message: absolute must be set when type is absolute
+                              rule:
+                                "self.type == 'absolute' ? has(self.absolute) :
+                                true"
+                      type: object
+                    update_policy:
+                      description:
+                        'UpdatePolicy defines how pod updates are handled.
+                        If not specified, defaults to UpdatePolicy{UpdateMode: "recreate",
+                        RecreateResources: ["memory"]}.'
+                      properties:
+                        recreate_resources:
+                          default:
+                            - memory
+                          description: |-
+                            RecreateResources lists which resource types should trigger pod recreation when changed.
+                            Defaults to ["memory"] if not set.
+                          items:
+                            type: string
+                          type: array
+                        update_mode:
+                          default: recreate
+                          description:
+                            UpdateMode specifies the update strategy. Defaults
+                            to "recreate" if not set.
+                          enum:
+                            - initial
+                            - recreate
+                            - in_place_or_recreate
+                            - in_place
+                          type: string
+                      type: object
+                  required:
+                    - containers
+                    - mode
+                  type: object
+                  x-kubernetes-validations:
+                    - message:
+                        when in_place_resizing.enabled is true, update_policy.update_mode
+                        must be either 'in_place' or 'in_place_or_recreate'
+                      rule:
+                        "!has(self.in_place_resizing) || !has(self.in_place_resizing.enabled)
+                        || !self.in_place_resizing.enabled || !has(self.update_policy)
+                        || self.update_policy.update_mode == 'in_place' || self.update_policy.update_mode
+                        == 'in_place_or_recreate'"
+                    - message:
+                        when in_place_resizing.enabled is false, update_policy.update_mode
+                        cannot be 'in_place' or 'in_place_or_recreate'
+                      rule:
+                        "!has(self.in_place_resizing) || self.in_place_resizing.enabled
+                        || !has(self.update_policy) || (self.update_policy.update_mode
+                        != 'in_place' && self.update_policy.update_mode != 'in_place_or_recreate')"
+              required:
+                - model
+              type: object
+              x-kubernetes-validations:
+                - message: exactly one of scaleTargetRef or selector must be set
+                  rule:
+                    (has(self.scaleTargetRef) && !has(self.selector)) || (!has(self.scaleTargetRef)
+                    && has(self.selector))
+                - message:
+                    cannot have both horizontal and vertical scaling in autonomous
+                    mode
+                  rule:
+                    "!(has(self.horizontal) && has(self.vertical) && self.horizontal.mode.startsWith('auto')
+                    && self.vertical.mode.startsWith('auto'))"
+            status:
+              properties:
+                conditions:
+                  description:
+                    Conditions represent the latest available observations
+                    of the AIScaleTarget's state
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                horizontalSuggestion:
+                  properties:
+                    currentReplicas:
+                      format: int32
+                      type: integer
+                    end:
+                      format: date-time
+                      type: string
+                    forecastError:
+                      description: |-
+                        ForecastError is set when a general forecasting error occurred that blocks all scaling.
+                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                      type: string
+                    hasEnoughDataToScale:
+                      description: |-
+                        HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                        When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                      type: boolean
+                    start:
+                      format: date-time
+                      type: string
+                    suggestedReplicas:
+                      format: int32
+                      type: integer
+                    suggestionUID:
+                      type: string
+                  required:
+                    - currentReplicas
+                    - end
+                    - hasEnoughDataToScale
+                    - start
+                    - suggestedReplicas
+                  type: object
+                labelSelector:
+                  type: string
+                lastCollectionTime:
+                  description:
+                    LastCollectionTime is the last time metrics were successfully
+                    collected for this AIScaleTarget
+                  format: date-time
+                  type: string
+                lastOOMMemoryAdjusted:
+                  description: |-
+                    LastOOMMemoryAdjusted is when the operator last applied an OOM memory adjustment.
+                    Used to enforce the cooldown between successive adjustments.
+                  format: date-time
+                  type: string
+                lastOOMTime:
+                  description: |-
+                    LastOOMTime is the most recent collection time at which OOM kills were observed.
+                    Used to determine when the episode is over.
+                  format: date-time
+                  type: string
+                lastProcessedSuggestionUID:
+                  description: |-
+                    LastProcessedSuggestionUID is the SuggestionUID of the last suggestion the operator
+                    fully processed (PrepareAction → execute → audit written). Used to prevent reprocessing
+                    the same suggestion on every reconcile.
+                  type: string
+                latestSuggestion:
+                  description:
+                    LatestSuggestion contains the most recent scaling recommendations
+                    from Thoras AI
+                  properties:
+                    currentReplicas:
+                      description: |-
+                        CurrentReplicas is the number of replicas at the time this suggestion was generated.
+                        NB: This does not reflect the current replica count, just the count at suggestion time.
+
+                        replica count rather than a snapshot from when the forecaster created the suggestion.
+                      format: int32
+                      type: integer
+                    end:
+                      format: date-time
+                      type: string
+                    forecastErrorGeneral:
+                      description: |-
+                        ForecastErrorGeneral is set when a general forecasting error occurred that blocks all scaling.
+                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                      type: string
+                    forecastErrorHorizontal:
+                      description: |-
+                        ForecastErrorHorizontal is set when a horizontal-specific forecasting error occurred.
+                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                      type: string
+                    forecastErrorVertical:
+                      description: |-
+                        ForecastErrorVertical is set when a vertical-specific forecasting error occurred.
+                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                      type: string
+                    forecastedTotals:
+                      description:
+                        ForecastedTotals contains predicted resource usage
+                        metrics.
+                      items:
+                        description:
+                          ForecastMetric represents a predicted resource
+                          usage value for a specific metric.
+                        properties:
+                          metric:
+                            description:
+                              Metric name - can be "cpu", "memory", "heap",
+                              "non-heap", etc.
+                            type: string
+                          metricType:
+                            description: |-
+                              MetricType indicates the aggregation type of the metric
+                              Values: "average" (per-pod) or "total" (deployment-wide)
+                            type: string
+                          targetName:
+                            description:
+                              TargetName is the name of the deployment or
+                              container this metric applies to
+                            type: string
+                          targetType:
+                            description: |-
+                              TargetType indicates whether this is a deployment-level or container-level metric
+                              Values: "deployment" or "container"
+                            type: string
+                          value:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            description:
+                              Value is the forecasted value in Kubernetes
+                              resource format (e.g., "11m" for CPU, "24Mi" for memory)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - metric
+                          - targetName
+                          - targetType
+                          - value
+                        type: object
+                      type: array
+                    hasEnoughDataToScale:
+                      description: |-
+                        HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                        When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                      type: boolean
+                    resourceRecommendations:
+                      description:
+                        ResourceRecommendations contains optimal resource
+                        requests for each container.
+                      items:
+                        description:
+                          ContainerRecommendation contains optimal resource
+                          allocation recommendations for a single container.
+                        properties:
+                          container:
+                            description: Container name
+                            type: string
+                          recommendations:
+                            description: Resource recommendations for this container
+                            items:
+                              description:
+                                ResourceRecommendation represents an optimal
+                                resource allocation for a specific resource type.
+                              properties:
+                                resource:
+                                  description: Resource type - "cpu" or "memory"
+                                  type: string
+                                value:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description:
+                                    Value in Kubernetes resource format (e.g.,
+                                    "12m" for CPU, "256Mi" for memory)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - resource
+                                - value
+                              type: object
+                            type: array
+                        required:
+                          - container
+                          - recommendations
+                        type: object
+                      type: array
+                    start:
+                      description: Time window for this suggestion
+                      format: date-time
+                      type: string
+                    suggestedReplicas:
+                      description:
+                        SuggestedReplicas is the recommended number of pod
+                        replicas for horizontal scaling.
+                      format: int32
+                      type: integer
+                    suggestionUID:
+                      description:
+                        SuggestionUID is the stable UID assigned to this
+                        suggestion by proxySuggestionsRepository.
+                      type: string
+                  required:
+                    - currentReplicas
+                    - end
+                    - hasEnoughDataToScale
+                    - start
+                    - suggestedReplicas
+                  type: object
+                oomAdjustedMemory:
+                  description: |-
+                    OOMAdjustedMemory holds the per-container memory adjustments set by the operator
+                    during an active OOM episode. Keyed by container name. The admission webhook applies
+                    the adjusted request (floor on max(suggestion, floor)) and, when Limit is non-nil,
+                    applies the adjusted limit. Cleared when oomStabilizationWindowExpiry passes.
+
+                    The value type accepts both the legacy bare-Quantity form (request only, Limit nil)
+                    and the struct form {request, limit} via OOMContainerMemoryAdjustment.UnmarshalJSON.
+                  x-kubernetes-preserve-unknown-fields: true
+                oomKilledContainers:
+                  description: |-
+                    OOMKilledContainers is the set of container names that had OOM kills in the most recent
+                    collection cycle. Replaced on every cycle: set to containers with kills when OOMs are
+                    observed, cleared when no kills are observed. The operator uses this to scope memory
+                    adjustments to only containers that actually OOMed.
+                  items:
                     type: string
-                  forecastError:
-                    description: |-
-                      ForecastError is set when a general forecasting error occurred that blocks all scaling.
-                      Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
-                    type: string
-                  hasEnoughDataToScale:
-                    description: |-
-                      HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
-                      When false, scaling actions may be skipped to prevent decisions based on incomplete data.
-                    type: boolean
-                  start:
-                    format: date-time
-                    type: string
-                  suggestionUID:
-                    type: string
-                required:
-                - end
-                - hasEnoughDataToScale
-                - start
-                type: object
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                oomStabilizationWindowExpiry:
+                  description: |-
+                    OOMStabilizationWindowExpiry is the time after which the OOM memory floor expires and forecasts are
+                    allowed to lower memory freely. Reset to now+StabilizationWindow on each new OOM adjustment.
+                  format: date-time
+                  type: string
+                previousVerticalMode:
+                  type: string
+                replicas:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                thorasSuggestedReplicas:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    ThorasSuggestedReplicas is the latest recommended replica count.
+                    Deprecated: Use LatestSuggestion.SuggestedReplicas instead.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                verticalSuggestion:
+                  properties:
+                    containers:
+                      description:
+                        Containers contains optimal resource requirements
+                        for each container.
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          resources:
+                            description:
+                              ResourceRequirements describes the compute
+                              resource requirements.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description:
+                                    ResourceClaim references one entry in
+                                    PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        required:
+                          - name
+                          - resources
+                        type: object
+                      type: array
+                    end:
+                      format: date-time
+                      type: string
+                    forecastError:
+                      description: |-
+                        ForecastError is set when a general forecasting error occurred that blocks all scaling.
+                        Must not use omitempty: empty string must be explicitly patched to clear stale errors on the CRD.
+                      type: string
+                    hasEnoughDataToScale:
+                      description: |-
+                        HasEnoughDataToScale indicates whether sufficient data was available to generate reliable recommendations.
+                        When false, scaling actions may be skipped to prevent decisions based on incomplete data.
+                      type: boolean
+                    start:
+                      format: date-time
+                      type: string
+                    suggestionUID:
+                      type: string
+                  required:
+                    - end
+                    - hasEnoughDataToScale
+                    - start
+                  type: object
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -1366,6 +1366,10 @@ spec:
             - message: exactly one of scaleTargetRef or selector must be set
               rule: (has(self.scaleTargetRef) && !has(self.selector)) || (!has(self.scaleTargetRef)
                 && has(self.selector))
+            - message: cannot have both horizontal and vertical scaling in autonomous
+                mode
+              rule: '!(has(self.horizontal) && has(self.vertical) && self.horizontal.mode.startsWith(''auto'')
+                && self.vertical.mode.startsWith(''auto''))'
           status:
             properties:
               conditions:

--- a/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
+++ b/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
@@ -1068,6 +1068,9 @@ spec:
                             name:
                               description: name of container to scale
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must not be empty
+                                rule: size(self) > 0
                           required:
                           - name
                           type: object
@@ -1076,7 +1079,12 @@ spec:
                               is set
                             rule: '!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
                               || (has(self.memory) && has(self.memory.limit))'
+                          - message: At least one of cpu or memory must be specified
+                            rule: has(self.cpu) || has(self.memory)
                         type: array
+                        x-kubernetes-validations:
+                        - message: at least one container must be specified
+                          rule: self.size() > 0
                       disruption:
                         description: |-
                           Disruption controls how aggressively Thoras applies pod changes (in-place

--- a/charts/thoras/templates/crd/daemonsetautoscaler.yaml
+++ b/charts/thoras/templates/crd/daemonsetautoscaler.yaml
@@ -109,9 +109,15 @@ spec:
                     name:
                       description: name of container to scale
                       type: string
+                      x-kubernetes-validations:
+                      - message: name must not be empty
+                        rule: size(self) > 0
                   required:
                   - name
                   type: object
+                  x-kubernetes-validations:
+                  - message: At least one of cpu or memory must be specified
+                    rule: has(self.cpu) || has(self.memory)
                 type: array
               minObservationWindow:
                 description: |-


### PR DESCRIPTION
# What's changing and why?

Vertical container specs must specify either a `cpu` or `memory` block. Otherwise, right-sizing doesn't know which dimensions are acceptable for resizing.