### PR TITLE
Add priorityClassName support across components

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -239,3 +239,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.thorasApiServerV2.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -349,4 +349,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.metricsCollector.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
 {{- end }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -109,3 +109,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.thorasDashboard.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -155,3 +155,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.thorasForecast.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -270,3 +270,6 @@ spec:
       affinity:
         {{- toYaml $mergedAffinity | nindent 8 }}
       {{- end }}
+      {{- with .Values.thorasOperator.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/thoras/templates/operator/pre-delete-hook.yaml
+++ b/charts/thoras/templates/operator/pre-delete-hook.yaml
@@ -22,6 +22,9 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: {{ .Values.thorasOperator.serviceAccount.name }}
+      {{- with .Values.thorasOperator.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
       - name: thoras-delete-asts

--- a/charts/thoras/templates/operator/webhooks-certgen-create.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-create.yaml
@@ -23,6 +23,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: thoras-tls-certsgen
+      {{- with .Values.thorasOperator.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.imageCredentials.secretRef }}
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.secretRef }}

--- a/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-patch.yaml
@@ -22,6 +22,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: thoras-tls-certsgen
+      {{- with .Values.thorasOperator.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.imageCredentials.secretRef }}
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.secretRef }}
@@ -72,6 +75,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: thoras-tls-certsgen
+      {{- with .Values.thorasOperator.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.imageCredentials.secretRef }}
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.secretRef }}

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -336,3 +336,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.thorasWorker.priorityClassName | default .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/thoras/tests/priorityclassname_test.yaml
+++ b/charts/thoras/tests/priorityclassname_test.yaml
@@ -1,0 +1,116 @@
+suite: PriorityClassName Configuration
+set:
+  thorasMonitor:
+    unittesting: true
+  thorasDashboard:
+    unittesting: true
+  thorasForecast:
+    worker:
+      enabled: true
+tests:
+  - it: no priorityClassName set by default
+    templates:
+      - operator/deployment.yaml
+      - api-server-v2/deployment.yaml
+      - worker/deployment.yaml
+      - dashboard/deployment.yaml
+      - collector/deployment.yaml
+      - forecast-worker/deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.priorityClassName
+
+  - it: global priorityClassName applies to all components
+    templates:
+      - operator/deployment.yaml
+      - api-server-v2/deployment.yaml
+      - worker/deployment.yaml
+      - dashboard/deployment.yaml
+      - collector/deployment.yaml
+      - forecast-worker/deployment.yaml
+    set:
+      priorityClassName: global-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: global-priority
+
+  - it: component-specific priorityClassName takes precedence over global
+    templates:
+      - operator/deployment.yaml
+    set:
+      priorityClassName: global-priority
+      thorasOperator:
+        priorityClassName: operator-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: operator-priority
+
+  - it: component-specific priorityClassName works for api-server-v2
+    templates:
+      - api-server-v2/deployment.yaml
+    set:
+      thorasApiServerV2:
+        priorityClassName: api-server-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: api-server-priority
+
+  - it: component-specific priorityClassName works for worker
+    templates:
+      - worker/deployment.yaml
+    set:
+      thorasWorker:
+        priorityClassName: worker-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: worker-priority
+
+  - it: component-specific priorityClassName works for dashboard
+    templates:
+      - dashboard/deployment.yaml
+    set:
+      thorasDashboard:
+        priorityClassName: dashboard-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: dashboard-priority
+
+  - it: component-specific priorityClassName works for collector
+    templates:
+      - collector/deployment.yaml
+    set:
+      metricsCollector:
+        priorityClassName: collector-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: collector-priority
+
+  - it: component-specific priorityClassName works for forecast-worker
+    templates:
+      - forecast-worker/deployment.yaml
+    set:
+      thorasForecast:
+        priorityClassName: forecast-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: forecast-priority
+
+  - it: operator-owned jobs inherit operator priorityClassName
+    templates:
+      - operator/pre-delete-hook.yaml
+      - operator/webhooks-certgen-create.yaml
+      - operator/webhooks-certgen-patch.yaml
+    set:
+      thorasOperator:
+        priorityClassName: operator-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: operator-priority

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -179,6 +179,8 @@ thorasOperator:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  # Component-specific priorityClassName (takes precedence over the global priorityClassName)
+  priorityClassName: ""
   # Webhook certificate generation configuration
   webhookCertGen:
     imageTag: v1.4.4
@@ -289,6 +291,8 @@ metricsCollector:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  # Component-specific priorityClassName (takes precedence over the global priorityClassName)
+  priorityClassName: ""
   extraEgressRules: []
 
 thorasApiServerV2:
@@ -347,6 +351,8 @@ thorasApiServerV2:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  # Component-specific priorityClassName (takes precedence over the global priorityClassName)
+  priorityClassName: ""
   extraEgressRules: []
 
 thorasWorker:
@@ -410,6 +416,8 @@ thorasWorker:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  # Component-specific priorityClassName (takes precedence over the global priorityClassName)
+  priorityClassName: ""
   extraEgressRules: []
 
 thorasDashboard:
@@ -489,6 +497,8 @@ thorasDashboard:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  # Component-specific priorityClassName (takes precedence over the global priorityClassName)
+  priorityClassName: ""
   extraEgressRules: []
   extraContainers: []
 
@@ -565,6 +575,8 @@ thorasForecast:
   useGlobalAffinity: true
   # Component-specific affinity (merged with global if useGlobalAffinity is true)
   affinity: {}
+  # Component-specific priorityClassName (takes precedence over the global priorityClassName)
+  priorityClassName: ""
   # Set to false to disable the default self anti-affinity between forecast-worker replicas
   enableSelfAntiAffinity: true
   extraEgressRules: []
@@ -579,6 +591,10 @@ tolerations: []
 
 # Global affinity rules that components can opt into
 affinity: {}
+
+# priorityClassName is used to assign a PriorityClass to all components.
+# Component-specific priorityClassName takes precedence when set.
+priorityClassName: ""
 
 # Create Prometheus ServiceMonitors for all Prometheus-enabled components
 serviceMonitor:


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Lets customers assign Kubernetes `PriorityClass` to Thoras components, so critical workloads (operator, API server, etc.) can be protected from preemption/eviction under node pressure, per-component or cluster-wide.

## What's changing?

- Add `priorityClassName` field to each component's values block (operator, api-server-v2, worker, dashboard, collector, forecast-worker) plus a global `priorityClassName`
- Component-specific value takes precedence over the global default
- Applied to deployments and operator-owned jobs (pre-delete hook, webhook certgen create/patch)

## How Tested

Added `priorityclassname_test.yaml` covering default (unset), global-only, and component-override precedence across all components and operator jobs. Full `helm unittest` suite passes (258 tests).