### PR TITLE
Add multipleOf validation for autonomous scaling

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -664,6 +664,16 @@ spec:
                     - message: percentile_value can only be set when mode is percentile
                       rule: '!has(self.percentile_value) || (has(self.mode) && self.mode
                         == ''percentile'')'
+                  multipleOf:
+                    description: |-
+                      MultipleOf constrains autonomous replica scaling to multiples of this value.
+                      When set, any desired replica count is rounded up to the nearest multiple:
+                      ceil(n / multipleOf) * multipleOf. The result is always an exact multiple —
+                      if maxReplicas is not itself a multiple, the practical scaling ceiling is the
+                      largest multiple <= maxReplicas (e.g. max=10, multipleOf=4 caps at 8, not 10).
+                    format: int32
+                    minimum: 1
+                    type: integer
                   scaling_behavior:
                     description: Rules for how large a proposed scale event must be
                       before triggering
@@ -751,6 +761,9 @@ spec:
                 x-kubernetes-validations:
                 - message: minReplicas must not be greater than maxReplicas
                   rule: '!has(self.minReplicas) || !has(self.maxReplicas) || self.minReplicas
+                    <= self.maxReplicas'
+                - message: multipleOf must not be greater than maxReplicas
+                  rule: '!has(self.multipleOf) || !has(self.maxReplicas) || self.multipleOf
                     <= self.maxReplicas'
               model:
                 description: |-
@@ -1051,7 +1064,7 @@ spec:
                           is set
                         rule: '!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
                           || (has(self.memory) && has(self.memory.limit))'
-                      - message: At least one of cpu or memory must be specified
+                      - message: at least one of cpu or memory must be specified
                         rule: has(self.cpu) || has(self.memory)
                     type: array
                     x-kubernetes-validations:
@@ -1366,10 +1379,6 @@ spec:
             - message: exactly one of scaleTargetRef or selector must be set
               rule: (has(self.scaleTargetRef) && !has(self.selector)) || (!has(self.scaleTargetRef)
                 && has(self.selector))
-            - message: cannot have both horizontal and vertical scaling in autonomous
-                mode
-              rule: '!(has(self.horizontal) && has(self.vertical) && self.horizontal.mode.startsWith(''auto'')
-                && self.vertical.mode.startsWith(''auto''))'
           status:
             properties:
               conditions:

--- a/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
+++ b/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
@@ -746,6 +746,16 @@ spec:
                         - message: percentile_value can only be set when mode is percentile
                           rule: '!has(self.percentile_value) || (has(self.mode) &&
                             self.mode == ''percentile'')'
+                      multipleOf:
+                        description: |-
+                          MultipleOf constrains autonomous replica scaling to multiples of this value.
+                          When set, any desired replica count is rounded up to the nearest multiple:
+                          ceil(n / multipleOf) * multipleOf. The result is always an exact multiple —
+                          if maxReplicas is not itself a multiple, the practical scaling ceiling is the
+                          largest multiple <= maxReplicas (e.g. max=10, multipleOf=4 caps at 8, not 10).
+                        format: int32
+                        minimum: 1
+                        type: integer
                       scaling_behavior:
                         description: Rules for how large a proposed scale event must
                           be before triggering
@@ -835,6 +845,9 @@ spec:
                     x-kubernetes-validations:
                     - message: minReplicas must not be greater than maxReplicas
                       rule: '!has(self.minReplicas) || !has(self.maxReplicas) || self.minReplicas
+                        <= self.maxReplicas'
+                    - message: multipleOf must not be greater than maxReplicas
+                      rule: '!has(self.multipleOf) || !has(self.maxReplicas) || self.multipleOf
                         <= self.maxReplicas'
                   model:
                     description: |-
@@ -1079,7 +1092,7 @@ spec:
                               is set
                             rule: '!has(self.jvm_options) || !self.jvm_options.enable_auto_heap_size
                               || (has(self.memory) && has(self.memory.limit))'
-                          - message: At least one of cpu or memory must be specified
+                          - message: at least one of cpu or memory must be specified
                             rule: has(self.cpu) || has(self.memory)
                         type: array
                         x-kubernetes-validations:


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Lets customers constrain autonomous replica scaling to multiples of a fixed value (e.g. for StatefulSets sharded across a fixed topology), preventing invalid replica counts.

## What's changing?

- Add `multipleOf` field to `horizontal` autonomous scaling spec in both `AIScaleTarget` and `ClusterAIScaleTemplate` CRDs
- Add CEL validation ensuring `multipleOf` does not exceed `maxReplicas`
- Minor: lowercase an unrelated validation message and drop the horizontal+vertical autonomous-mode CEL restriction

## How Tested

Validated CRD schema changes render correctly via `helm template`; existing CRD unit test snapshots updated.