### PR TITLE
Enable disruption worker by default

### DIFF
--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1060,7 +1060,7 @@ Default matches snapshot:
                 - name: SERVICE_UNDERPROVISIONED_THRESHOLD
                   value: "92"
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
                   value: "false"
                 - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
@@ -1503,7 +1503,7 @@ Default matches snapshot:
                 - name: SERVICE_FORECAST_WORKER_ASTS_PER_REPLICA
                   value: "67"
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_ENABLE_DAEMON_SET_AUTOSCALER
                   value: "false"
                 - name: SERVICE_MULTI_DIMENSIONAL_ENABLED

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -61,7 +61,7 @@ featureFlags:
   enableForecastQueueStats: false
   enableInformersStripManagedFields: true
   enableTypedInformers: true
-  enableDisruptionSchedulerWorker: false
+  enableDisruptionSchedulerWorker: true
   enableAstRecordMirroring: false
   enableForecastCollectorAntiAffinity: true
   enableDaemonSetAutoscaler: false


### PR DESCRIPTION
# What's changing and why?

Turning on by default for all customers
