### PR TITLE
Allow dashboard service targetPort override

### DIFF
--- a/charts/thoras/templates/dashboard/service.yaml
+++ b/charts/thoras/templates/dashboard/service.yaml
@@ -36,6 +36,6 @@ spec:
   - name: http
     port: {{ .Values.thorasDashboard.port }}
     protocol: TCP
-    targetPort: {{ .Values.thorasDashboard.containerPort }}
+    targetPort: {{ .Values.thorasDashboard.service.targetPort | default .Values.thorasDashboard.containerPort }}
   selector:
     app: thoras-dashboard

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -463,6 +463,9 @@ thorasDashboard:
   service:
     type: ClusterIP
     annotations: {}
+    # Overrides the Service target port. Defaults to containerPort. Set to the
+    # oauth2-proxy sidecar port (e.g. 4180) to force traffic through auth.
+    targetPort: ""
   ingress:
     enabled: false
     ingressClassName: "nginx"


### PR DESCRIPTION
## What's changing and why?

Adds `thorasDashboard.service.targetPort` so the dashboard Service can route to an oauth2-proxy sidecar (e.g. port 4180) instead of the app container directly, enabling auth bypass via sidecar.

Defaults to `containerPort` when unset — no behavior change for existing installs.