### PR TITLE
Disable forecast worker anti-affinities

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -83,7 +83,7 @@ The following flags are considered temporary and gate access to specific behavio
 | Key                                            | Type    | Default | Description                                               |
 | ---------------------------------------------- | ------- | ------- | --------------------------------------------------------- |
 | featureFlags.enableNodeDetailsCollector        | Boolean | true    | Collection of node detail snapshots                       |
-| featureFlags.enablePgLargeObjectStorage        | Boolean | false   | If true, enables storing blobs as postgres large objects  |
+| featureFlags.enablePgLargeObjectStorage        | Boolean | true    | If true, enables storing blobs as postgres large objects  |
 | featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
 | featureFlags.enableAstRecordMirroring          | Boolean | true    | If true, ASTs are mirrored to the database component      |

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -400,18 +400,6 @@ Default matches snapshot:
             app.kubernetes.io/name: thoras
             globalLabel: globalValue
         spec:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - podAffinityTerm:
-                    labelSelector:
-                      matchExpressions:
-                        - key: app
-                          operator: In
-                          values:
-                            - thoras-forecast-worker
-                    topologyKey: kubernetes.io/hostname
-                  weight: 100
           containers:
             - env:
                 - name: POSTGRES_PASSWORD
@@ -805,27 +793,6 @@ Default matches snapshot:
             app.kubernetes.io/name: thoras
             globalLabel: globalValue
         spec:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - podAffinityTerm:
-                    labelSelector:
-                      matchExpressions:
-                        - key: app
-                          operator: In
-                          values:
-                            - metrics-collector
-                    topologyKey: kubernetes.io/hostname
-                  weight: 100
-                - podAffinityTerm:
-                    labelSelector:
-                      matchExpressions:
-                        - key: app
-                          operator: In
-                          values:
-                            - thoras-forecast-worker
-                    topologyKey: kubernetes.io/hostname
-                  weight: 95
           containers:
             - command:
                 - worker

--- a/charts/thoras/tests/affinity_test.yaml
+++ b/charts/thoras/tests/affinity_test.yaml
@@ -14,10 +14,14 @@ set:
       config:
         enabled: false
 tests:
-  # Test 1a: Default - forecast-worker has only thoras-specific affinities
-  - it: forecast-worker has thoras-specific affinities by default
+  - it: forecast-worker has thoras-specific affinities when enabled
     templates:
       - forecast-worker/deployment.yaml
+    set:
+      thorasForecast:
+        enableSelfAntiAffinity: true
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       - isNotNull:
           path: spec.template.spec.affinity
@@ -34,13 +38,12 @@ tests:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
           value: thoras-forecast-worker
 
-  # Test 1a-ii: forecast-worker self anti-affinity absent when disabled
-  - it: forecast-worker self anti-affinity is absent when disabled
+  - it: forecast-worker self anti-affinity is absent by default
     templates:
       - forecast-worker/deployment.yaml
     set:
-      thorasForecast:
-        enableSelfAntiAffinity: false
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       - equal:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
@@ -55,13 +58,12 @@ tests:
                     - metrics-collector
                 topologyKey: kubernetes.io/hostname
 
-  # Test 1a-iii: forecast-collector anti-affinity absent on forecast-worker when disabled
-  - it: forecast-collector anti-affinity is absent on forecast-worker when disabled
+  - it: forecast-collector anti-affinity is absent on forecast-worker by default
     templates:
       - forecast-worker/deployment.yaml
     set:
-      featureFlags:
-        enableForecastCollectorAntiAffinity: false
+      thorasForecast:
+        enableSelfAntiAffinity: true
     asserts:
       - equal:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
@@ -76,21 +78,19 @@ tests:
                     - thoras-forecast-worker
                 topologyKey: kubernetes.io/hostname
 
-  # Test 1a-iv: forecast-collector anti-affinity absent on metrics-collector when disabled
-  - it: forecast-collector anti-affinity is absent on metrics-collector when disabled
+  - it: forecast-collector anti-affinity is absent on metrics-collector by default
     templates:
       - collector/deployment.yaml
-    set:
-      featureFlags:
-        enableForecastCollectorAntiAffinity: false
     asserts:
       - isNull:
           path: spec.template.spec.affinity
 
-  # Test 1b: Default - collector has only thoras-specific affinities
-  - it: metrics-collector has thoras-specific affinities by default
+  - it: metrics-collector has thoras-specific affinities when enabled
     templates:
       - collector/deployment.yaml
+    set:
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       - isNotNull:
           path: spec.template.spec.affinity
@@ -101,10 +101,12 @@ tests:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
           value: thoras-forecast-worker
 
-  # Test 1c: Default - operator has self anti-affinity; other components have NO affinity
-  - it: operator has self anti-affinity by default
+  - it: operator has self anti-affinity when enabled
     templates:
       - operator/deployment.yaml
+    set:
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       - isNotNull:
           path: spec.template.spec.affinity
@@ -141,6 +143,8 @@ tests:
                 operator: In
                 values:
                 - standard-pool
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       - isNotNull:
           path: spec.template.spec.affinity.podAntiAffinity
@@ -165,6 +169,8 @@ tests:
                 operator: In
                 values:
                 - standard-pool
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       - isNotNull:
           path: spec.template.spec.affinity.podAntiAffinity
@@ -426,6 +432,7 @@ tests:
                 values:
                 - compute
       thorasForecast:
+        enableSelfAntiAffinity: true
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -436,6 +443,8 @@ tests:
                   operator: In
                   values:
                   - "true"
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       # Thoras-specific podAntiAffinity
       - equal:
@@ -481,6 +490,8 @@ tests:
                   values:
                   - timescaledb
               topologyKey: kubernetes.io/hostname
+      featureFlags:
+        enableForecastCollectorAntiAffinity: true
     asserts:
       # Thoras-specific podAntiAffinity
       - equal:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -63,7 +63,7 @@ featureFlags:
   enableTypedInformers: true
   enableDisruptionSchedulerWorker: true
   enableAstRecordMirroring: true
-  enableForecastCollectorAntiAffinity: true
+  enableForecastCollectorAntiAffinity: false
   enableDaemonSetAutoscaler: false
   enableMultiDimensional: false
 
@@ -581,7 +581,7 @@ thorasForecast:
   # Component-specific priorityClassName (takes precedence over the global priorityClassName)
   priorityClassName: ""
   # Set to false to disable the default self anti-affinity between forecast-worker replicas
-  enableSelfAntiAffinity: true
+  enableSelfAntiAffinity: false
   extraEgressRules: []
 
 # K8s client max queries per second


### PR DESCRIPTION
# What's changing and why?

Forecast workers can play on the same pods next to metrics-collectors.