### PR TITLE
Enable persistence if not explicit turned off

### DIFF
--- a/charts/thoras/templates/NOTES.txt
+++ b/charts/thoras/templates/NOTES.txt
@@ -1,0 +1,11 @@
+Thoras platform installed in namespace {{ .Release.Namespace }}.
+
+{{ if (include "thoras.persistenceEnabled" .) -}}
+Metrics collector persistence: ENABLED
+  StorageClass: {{ .Values.metricsCollector.persistence.storageClassName | default "(cluster default)" }}
+  Size:         {{ .Values.metricsCollector.persistence.pvcStorageRequestSize | default "3Gi" }}
+{{- else -}}
+Metrics collector persistence: DISABLED (ephemeral emptyDir — data is lost on pod restart).
+  To enable, set metricsCollector.persistence.enabled=true, or configure a
+  storageClassName / pvcStorageRequestSize and it will be enabled automatically.
+{{- end }}

--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -126,6 +126,22 @@ true
 {{- end -}}
 {{- end -}}
 
+{{/*
+True when the metrics collector should use a persistent volume.
+Tri-state: an explicit metricsCollector.persistence.enabled (true/false) is
+always honored. When it is unset, infer "on" if the customer configured any
+persistence knob (storageClassName, pvcStorageRequestSize, or a fileSystemId).
+This avoids the silent footgun where knobs are set but enabled is forgotten.
+*/}}
+{{- define "thoras.persistenceEnabled" -}}
+{{- $p := .Values.metricsCollector.persistence -}}
+{{- if not (kindIs "invalid" $p.enabled) -}}
+{{- if $p.enabled -}}true{{- end -}}
+{{- else if or $p.storageClassName $p.pvcStorageRequestSize $p.createEFSStorageClass.fileSystemId -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "thoras.globalEnv" -}}
 {{- $out := list -}}
 {{- with .Values.proxy.httpProxy -}}

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           configMap:
             name: thoras-timescale-config
       {{- end }}
-      {{- if and .Values.metricsCollector.persistence.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
+      {{- if and (include "thoras.persistenceEnabled" .) (not (include "thoras.externalTimescaleEnabled" .)) }}
         - name: elastic-search-data
           persistentVolumeClaim:
             claimName:  elastic-search-data
@@ -88,7 +88,7 @@ spec:
         {{- end }}
         volumeMounts:
           - mountPath: /var/lib/share
-      {{- if and .Values.metricsCollector.persistence.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
+      {{- if and (include "thoras.persistenceEnabled" .) (not (include "thoras.externalTimescaleEnabled" .)) }}
             name: elastic-search-data
       {{- else }}
             name: timescale-data
@@ -124,7 +124,7 @@ spec:
         {{- end }}
         volumeMounts:
           - mountPath: /var/lib/share
-      {{- if .Values.metricsCollector.persistence.enabled }}
+      {{- if (include "thoras.persistenceEnabled" .) }}
             name: elastic-search-data
       {{- else }}
             name: timescale-data
@@ -190,7 +190,7 @@ spec:
             subPath: custom.conf
         {{- end }}
           - mountPath: /var/lib/share
-      {{- if .Values.metricsCollector.persistence.enabled }}
+      {{- if (include "thoras.persistenceEnabled" .) }}
             name: elastic-search-data
       {{- else }}
             name: timescale-data
@@ -318,7 +318,7 @@ spec:
           name: http
         volumeMounts:
           - mountPath: /var/lib/share
-      {{- if and .Values.metricsCollector.persistence.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
+      {{- if and (include "thoras.persistenceEnabled" .) (not (include "thoras.externalTimescaleEnabled" .)) }}
             name: elastic-search-data
       {{- else }}
             name: timescale-data

--- a/charts/thoras/templates/collector/pvc.yaml
+++ b/charts/thoras/templates/collector/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metricsCollector.persistence.enabled (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .)))}}
+{{- if and (include "thoras.persistenceEnabled" .) (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .)))}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -11,10 +11,12 @@ spec:
   {{- if .Values.metricsCollector.persistence.volumeName }}
   volumeName: {{ .Values.metricsCollector.persistence.volumeName }}
   {{- end }}
-  storageClassName: {{ .Values.metricsCollector.persistence.storageClassName }}
+  {{- with .Values.metricsCollector.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - {{ .Values.metricsCollector.persistence.accessMode | default "ReadWriteOnce" }}
   resources:
     requests:
-      storage: {{ .Values.metricsCollector.persistence.pvcStorageRequestSize }}
+      storage: {{ .Values.metricsCollector.persistence.pvcStorageRequestSize | default "3Gi" }}
 {{- end }}

--- a/charts/thoras/templates/collector/storageclass.yaml
+++ b/charts/thoras/templates/collector/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metricsCollector.persistence.enabled .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .))) }}
+{{- if and (include "thoras.persistenceEnabled" .) .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .))) }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:

--- a/charts/thoras/templates/collector/storageclass.yaml
+++ b/charts/thoras/templates/collector/storageclass.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId (not .Values.metricsCollector.persistence.storageClassName) }}
+{{- fail "Error: 'metricsCollector.persistence.createEFSStorageClass.fileSystemId' is set but 'metricsCollector.persistence.storageClassName' is empty. Set storageClassName to name the StorageClass to create." }}
+{{- end }}
 {{- if and (include "thoras.persistenceEnabled" .) .Values.metricsCollector.persistence.createEFSStorageClass.fileSystemId (or (not .Values.featureFlags.enableNoBlobApiServer) (not (include "thoras.externalTimescaleEnabled" .))) }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/charts/thoras/tests/collector_deployment_test.yaml
+++ b/charts/thoras/tests/collector_deployment_test.yaml
@@ -45,6 +45,19 @@ tests:
           value:
             - mountPath: /var/lib/share
               name: elastic-search-data
+  - it: Should mount pvc when persistence is inferred from a knob
+    set:
+      metricsCollector:
+        persistence:
+          storageClassName: "gp3"
+    template: collector/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: elastic-search-data
+              persistentVolumeClaim:
+                claimName: elastic-search-data
   - it: Should not mount timescale config when config is disabled
     set:
       metricsCollector:

--- a/charts/thoras/tests/external_timescale_test.yaml
+++ b/charts/thoras/tests/external_timescale_test.yaml
@@ -223,6 +223,7 @@ tests:
       metricsCollector:
         persistence:
           enabled: true
+          storageClassName: "efs-sc"
           createEFSStorageClass:
             fileSystemId: "fs-12345"
     asserts:

--- a/charts/thoras/tests/pvc_test.yaml
+++ b/charts/thoras/tests/pvc_test.yaml
@@ -32,3 +32,55 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Infers persistence when only storageClassName is set
+    templates:
+      - collector/pvc.yaml
+    set:
+      metricsCollector:
+        persistence:
+          storageClassName: "gp3"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.storageClassName
+          value: "gp3"
+
+  - it: Infers persistence when only pvcStorageRequestSize is set
+    templates:
+      - collector/pvc.yaml
+    set:
+      metricsCollector:
+        persistence:
+          pvcStorageRequestSize: "5Gi"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.resources.requests.storage
+          value: "5Gi"
+
+  - it: Explicit enabled false suppresses inference
+    templates:
+      - collector/pvc.yaml
+    set:
+      metricsCollector:
+        persistence:
+          enabled: false
+          storageClassName: "gp3"
+          pvcStorageRequestSize: "5Gi"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Omits storageClassName field when empty (uses cluster default)
+    templates:
+      - collector/pvc.yaml
+    set:
+      metricsCollector:
+        persistence:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.storageClassName

--- a/charts/thoras/tests/storageclass_test.yaml
+++ b/charts/thoras/tests/storageclass_test.yaml
@@ -1,0 +1,39 @@
+suite: StorageClass
+templates:
+  - collector/storageclass.yaml
+tests:
+  - it: Fails when fileSystemId is set without storageClassName
+    set:
+      metricsCollector:
+        persistence:
+          createEFSStorageClass:
+            fileSystemId: "fs-12345"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: 'metricsCollector.persistence.createEFSStorageClass.fileSystemId' is set but 'metricsCollector.persistence.storageClassName' is empty. Set storageClassName to name the StorageClass to create."
+
+  - it: Creates StorageClass when both fileSystemId and storageClassName are set
+    set:
+      metricsCollector:
+        persistence:
+          storageClassName: "efs-sc"
+          createEFSStorageClass:
+            fileSystemId: "fs-12345"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: "efs-sc"
+      - equal:
+          path: parameters.fileSystemId
+          value: "fs-12345"
+
+  - it: Doesn't create StorageClass when fileSystemId is not set
+    set:
+      metricsCollector:
+        persistence:
+          storageClassName: "gp3"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -222,13 +222,18 @@ metricsCollector:
     enabled: true
     stabilization_window: ""
   persistence:
-    enabled: false
+    # Leave unset (null) to auto-detect: persistence turns on if you set any of
+    # storageClassName / pvcStorageRequestSize / createEFSStorageClass.fileSystemId.
+    # Set explicitly to true/false to override auto-detection (false always wins).
+    enabled: null
     volumeName: ""
-    storageClassName: "efs-sc-thoras"
+    # Empty uses the cluster's default StorageClass. Set to bind a specific class.
+    storageClassName: ""
     accessMode: "ReadWriteOnce"
     createEFSStorageClass:
       fileSystemId: ""
-    pvcStorageRequestSize: "3Gi"
+    # Empty defaults to 3Gi (applied in the PVC template).
+    pvcStorageRequestSize: ""
   podAnnotations: {}
   labels: {}
   # PodDisruptionBudget. Defaults to maxUnavailable: 1 when neither field is set


### PR DESCRIPTION
# What's changing and why?

`metricsCollector.persistence.enabled=true` was easy to forget alongside PV settings, causing silent installs without persistence. `enabled` is now tri-state: explicit `true/false` is always honored; left unset, it's inferred `true` if any PV setting is configured.

On Minkube:

```sh
❯ helm install thoras thoras/thoras -n thoras --set imageCredentials.password=<<CREDS>> --set metricsCollector.persistence.storageClassName=standard --create-namespace
NAME: thoras
LAST DEPLOYED: Thu Jul 23 16:20:43 2026
NAMESPACE: thoras
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
NOTES:
Thoras platform installed in namespace thoras.

Metrics collector persistence: ENABLED
  StorageClass: standard
  Size:         3Gi
```