### PR TITLE
Allow persistent volumes API in dashboard NGINX

### DIFF
--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -56,6 +56,8 @@ data:
         ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
         ~*^GET/v1/views/node-pools(\?|$)                                          1;
         ~*^GET/v1/views/nodes(\?|$)                                               1;
+        ~*^GET/v1/persistent-volumes(\?|$)                                        1;
+
 
         # POST — dashboard-initiated mutations
         ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -52,6 +52,8 @@ Should default to v2 port:
             ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
             ~*^GET/v1/views/node-pools(\?|$)                                          1;
             ~*^GET/v1/views/nodes(\?|$)                                               1;
+            ~*^GET/v1/persistent-volumes(\?|$)                                        1;
+
 
             # POST — dashboard-initiated mutations
             ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
@@ -171,6 +173,8 @@ should set extras in config.json:
             ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
             ~*^GET/v1/views/node-pools(\?|$)                                          1;
             ~*^GET/v1/views/nodes(\?|$)                                               1;
+            ~*^GET/v1/persistent-volumes(\?|$)                                        1;
+
 
             # POST — dashboard-initiated mutations
             ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;


### PR DESCRIPTION
# What's changing and why?

Adds an NGINX allow-list rule for `GET /v1/persistent-volumes` so the dashboard can reach this endpoint. Without it, requests to the persistent volumes API are blocked by the reverse proxy, preventing related dashboard views from loading data.