### PR TITLE
Run WAL recovery always on collector startup

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.134.0
+version: 4.135.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.134.0](https://img.shields.io/badge/Version-4.134.0-informational?style=flat-square) ![AppVersion: 4.110.0](https://img.shields.io/badge/AppVersion-4.110.0-informational?style=flat-square)
+![Version: 4.135.0](https://img.shields.io/badge/Version-4.135.0-informational?style=flat-square) ![AppVersion: 4.111.0](https://img.shields.io/badge/AppVersion-4.111.0-informational?style=flat-square)
 
 # Installs
 
@@ -52,7 +52,7 @@ helm install \
 
 | Key                                | Type    | Default                                          | Description                                                                                                          |
 | ---------------------------------- | ------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| thorasVersion                      | String  | 4.110.0                                          | Thoras app version                                                                                                   |
+| thorasVersion                      | String  | 4.111.0                                          | Thoras app version                                                                                                   |
 | imageCredentials.registry          | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                                                                              |
 | imageCredentials.username          | String  | \_json_key_base64                                | Container registry username                                                                                          |
 | imageCredentials.password          | String  | ""                                               | Container registry auth string                                                                                       |

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -93,7 +93,7 @@ spec:
       {{- else }}
             name: timescale-data
       {{- end }}
-      {{- if and .Values.metricsCollector.timescale.walRecovery.enabled (not (include "thoras.externalTimescaleEnabled" .)) }}
+      {{- if not (include "thoras.externalTimescaleEnabled" .) }}
       - name: reset-wal-on-startup
         image: {{ .Values.imageCredentials.registry }}/{{ .Values.metricsCollector.timescale.image }}:{{ .Values.metricsCollector.timescale.imageTag }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
@@ -105,15 +105,28 @@ spec:
         args:
           - |
             echo "Checking WAL integrity..."
-            if ! pg_resetwal --check "$PGDATA" 2>/dev/null; then
-              echo "WAL check failed, running pg_resetwal -f"
+            if [ ! -f "$PGDATA/PG_VERSION" ]; then
+              echo "No existing database found; nothing to recover."
+            elif pg_ctl start -D "$PGDATA" -w -t "$WAL_RECOVERY_TIMEOUT_SECONDS" -l /tmp/wal-check.log{{ if .Values.metricsCollector.timescale.config.enabled }} -o "-c config_file=/etc/postgresql.conf"{{ end }}; then
+              echo "Postgres started cleanly; WAL is healthy."
+              pg_ctl stop -D "$PGDATA" -m fast -w
+            elif [ "$WAL_RECOVERY_FORCE" = "true" ]; then
+              echo "Postgres failed to start within ${WAL_RECOVERY_TIMEOUT_SECONDS}s (see log below) -- forcing pg_resetwal -f. This discards WAL after the last valid checkpoint and WILL lose recent data."
+              cat /tmp/wal-check.log || true
+              pg_ctl stop -D "$PGDATA" -m immediate -w -t 30 2>/dev/null || true
               pg_resetwal -f "$PGDATA"
             else
-              echo "WAL OK"
+              echo "Postgres failed to start within ${WAL_RECOVERY_TIMEOUT_SECONDS}s (see log below). Automatic recovery is disabled (metricsCollector.timescale.walRecovery.enabled=false); leaving the database as-is."
+              cat /tmp/wal-check.log || true
+              pg_ctl stop -D "$PGDATA" -m immediate -w -t 30 2>/dev/null || true
             fi
         env:
           - name: PGDATA
             value: /var/lib/share/postgresql
+          - name: WAL_RECOVERY_FORCE
+            value: {{ .Values.metricsCollector.timescale.walRecovery.enabled | quote }}
+          - name: WAL_RECOVERY_TIMEOUT_SECONDS
+            value: {{ .Values.metricsCollector.timescale.walRecovery.timeoutSeconds | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         {{- if .Values.metricsCollector.timescale.resources }}
         resources: {{ .Values.metricsCollector.timescale.resources | toYaml | nindent 10 }}
@@ -123,6 +136,11 @@ spec:
           requests: {{ .Values.metricsCollector.timescale.requests | toYaml | nindent 12 }}
         {{- end }}
         volumeMounts:
+        {{- if .Values.metricsCollector.timescale.config.enabled }}
+          - name: timescale-config
+            mountPath: /etc/postgresql.conf
+            subPath: custom.conf
+        {{- end }}
           - mountPath: /var/lib/share
       {{- if (include "thoras.persistenceEnabled" .) }}
             name: elastic-search-data

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -587,6 +587,51 @@ Default matches snapshot:
               volumeMounts:
                 - mountPath: /var/lib/share
                   name: timescale-data
+            - args:
+                - |
+                  echo "Checking WAL integrity..."
+                  if [ ! -f "$PGDATA/PG_VERSION" ]; then
+                    echo "No existing database found; nothing to recover."
+                  elif pg_ctl start -D "$PGDATA" -w -t "$WAL_RECOVERY_TIMEOUT_SECONDS" -l /tmp/wal-check.log; then
+                    echo "Postgres started cleanly; WAL is healthy."
+                    pg_ctl stop -D "$PGDATA" -m fast -w
+                  elif [ "$WAL_RECOVERY_FORCE" = "true" ]; then
+                    echo "Postgres failed to start within ${WAL_RECOVERY_TIMEOUT_SECONDS}s (see log below) -- forcing pg_resetwal -f. This discards WAL after the last valid checkpoint and WILL lose recent data."
+                    cat /tmp/wal-check.log || true
+                    pg_ctl stop -D "$PGDATA" -m immediate -w -t 30 2>/dev/null || true
+                    pg_resetwal -f "$PGDATA"
+                  else
+                    echo "Postgres failed to start within ${WAL_RECOVERY_TIMEOUT_SECONDS}s (see log below). Automatic recovery is disabled (metricsCollector.timescale.walRecovery.enabled=false); leaving the database as-is."
+                    cat /tmp/wal-check.log || true
+                    pg_ctl stop -D "$PGDATA" -m immediate -w -t 30 2>/dev/null || true
+                  fi
+              command:
+                - /bin/sh
+                - -c
+              env:
+                - name: PGDATA
+                  value: /var/lib/share/postgresql
+                - name: WAL_RECOVERY_FORCE
+                  value: "true"
+                - name: WAL_RECOVERY_TIMEOUT_SECONDS
+                  value: "30"
+              image: us-east4-docker.pkg.dev/thoras-registry/platform/timescaledb:2.28.2-pg16
+              imagePullPolicy: IfNotPresent
+              name: reset-wal-on-startup
+              resources:
+                limits:
+                  memory: 16384Mi
+                requests:
+                  cpu: 1024m
+                  memory: 3072Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - mountPath: /var/lib/share
+                  name: timescale-data
           securityContext:
             fsGroup: 1000
             runAsGroup: 1000

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "4.110.0"
+thorasVersion: "4.111.0"
 cluster:
   name: ""
 
@@ -275,7 +275,12 @@ metricsCollector:
       enabled: false
       content: ""
     walRecovery:
-      enabled: false
+      # If the database fails to start, Thoras assume WAL corruption and reset
+      # the WAL: when enabled, pg_resetwal -f is run to force recovery,
+      # discarding WAL after the last valid checkpoint (lossy, but unblocks
+      # startup). When disabled, the corrupt state is left as-is.
+      enabled: true
+      timeoutSeconds: 30
   blobService:
     logLevel: "info"
     pprof:


### PR DESCRIPTION
# What's changing and why?

The startup WAL integrity check now always runs; `walRecovery.enabled` only
gates whether a failed check triggers a forced `pg_resetwal -f` or leaves the
database untouched. Previously the whole check was skipped when the flag was
off, so corrupted WAL could go unnoticed.

**Testing:** helm unit tests updated/passing.

Logs from trying this out on Minikube after damaging the `pg_wal` directory:

```
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup Checking WAL integrity...
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup waiting for server to start............ stopped waiting
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup Postgres failed to start within 30s (see log below) -- forcing pg_resetwal -f. This discards WAL after the last valid checkpoint and WILL lose recent data.
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup pg_ctl: could not start server
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup Examine the log output.
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.472 UTC [9] LOG:  starting PostgreSQL 16.14 on aarch64-unknown-linux-musl, compiled by gcc (Alpine 15.2.0) 15.2.0, 64-bit
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.472 UTC [9] LOG:  listening on IPv4 address "0.0.0.0", port 5432
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.472 UTC [9] LOG:  listening on IPv6 address "::", port 5432
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.475 UTC [9] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.478 UTC [12] LOG:  database system was shut down at 2026-07-28 22:27:04 UTC
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.478 UTC [12] LOG:  creating missing WAL directory "pg_wal/archive_status"
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.478 UTC [12] LOG:  invalid checkpoint record
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:12.478 UTC [12] PANIC:  could not locate a valid checkpoint record
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:20.805 UTC [9] LOG:  startup process (PID 12) was terminated by signal 6: Aborted
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:20.840 UTC [9] LOG:  terminating any other active server processes
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:20.841 UTC [9] LOG:  shutting down due to startup process failure
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup 2026-07-28 22:27:21.050 UTC [9] LOG:  database system is shut down
metrics-collector-7b599897dd-zp2d5 reset-wal-on-startup Write-ahead log reset
- metrics-collector-7b599897dd-zp2d5 › reset-wal-on-startup
+ metrics-collector-7b599897dd-zp2d5 › timescaledb
+ metrics-collector-7b599897dd-zp2d5 › thoras-blob-api
metrics-collector-7b599897dd-zp2d5 thoras-blob-api localhost:5432 - no response
metrics-collector-7b599897dd-zp2d5 thoras-blob-api postgres not ready
metrics-collector-7b599897dd-zp2d5 timescaledb chmod: /var/run/postgresql: Operation not permitted
metrics-collector-7b599897dd-zp2d5 timescaledb
metrics-collector-7b599897dd-zp2d5 timescaledb PostgreSQL Database directory appears to contain a database; Skipping initialization
metrics-collector-7b599897dd-zp2d5 timescaledb
metrics-collector-7b599897dd-zp2d5 timescaledb 2026-07-28 22:27:21.931 UTC [1] LOG:  starting PostgreSQL 16.14 on aarch64-unknown-linux-musl, compiled by gcc (Alpine 15.2.0) 15.2.0, 64-bit
```