### PR TITLE
Pass namespace to operator and worker

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -175,6 +175,10 @@ spec:
           - name: SERVICE_FIELD_MANAGER
             value: {{ .Values.flux.fieldManager | quote }}
           {{- end }}
+          - name: SERVICE_THORAS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.thorasOperator.pprof.enabled | quote }}
           - name: SERVICE_SHOULD_MIGRATE_ON_START

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -101,6 +101,10 @@ spec:
             value: "{{ .Values.cluster.name }}"
           - name: SERVICE_QUERIES_PER_SECOND
             value: {{ .Values.thorasWorker.queriesPerSecond | default .Values.queriesPerSecond | quote }}
+          - name: SERVICE_THORAS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.thorasWorker.pprof.enabled | quote }}
           - name: SERVICE_CHART_VERSION

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1072,6 +1072,10 @@ Default matches snapshot:
                     secretKeyRef:
                       key: clusterKey
                       name: thoras-cloud-sync
+                - name: SERVICE_THORAS_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: SERVICE_ENABLE_PPROF
                   value: "false"
                 - name: SERVICE_SHOULD_MIGRATE_ON_START
@@ -1400,6 +1404,10 @@ Default matches snapshot:
                   value: ""
                 - name: SERVICE_QUERIES_PER_SECOND
                   value: "50"
+                - name: SERVICE_THORAS_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: SERVICE_ENABLE_PPROF
                   value: "false"
                 - name: SERVICE_CHART_VERSION


### PR DESCRIPTION
# What's changing and why?

The worker and operator both need the thoras namespace in order to read Thoras service config maps