### PR TITLE
Release 4.135.2

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.135.1
+version: 4.135.2

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.135.1](https://img.shields.io/badge/Version-4.135.1-informational?style=flat-square) ![AppVersion: 4.111.1](https://img.shields.io/badge/AppVersion-4.111.1-informational?style=flat-square)
+![Version: 4.135.2](https://img.shields.io/badge/Version-4.135.2-informational?style=flat-square) ![AppVersion: 4.111.2](https://img.shields.io/badge/AppVersion-4.111.2-informational?style=flat-square)
 
 # Installs
 
@@ -52,7 +52,7 @@ helm install \
 
 | Key                                | Type    | Default                                          | Description                                                                                                          |
 | ---------------------------------- | ------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| thorasVersion                      | String  | 4.111.1                                          | Thoras app version                                                                                                   |
+| thorasVersion                      | String  | 4.111.2                                          | Thoras app version                                                                                                   |
 | imageCredentials.registry          | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                                                                              |
 | imageCredentials.username          | String  | \_json_key_base64                                | Container registry username                                                                                          |
 | imageCredentials.password          | String  | ""                                               | Container registry auth string                                                                                       |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "4.111.1"
+thorasVersion: "4.111.2"
 cluster:
   name: ""
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Publishes chart version 4.135.2, making the latest Thoras platform release installable via the Helm chart.

## What's changing?

- Bump chart version to 4.135.2 in Chart.yaml
- Bump thorasVersion (app version) to 4.111.2 in values.yaml
- Update README.md version badges and defaults table

## How Tested

Version-only bump matching the existing release pattern; no functional changes to templates.

