### PR TITLE
Support ipv6 on forecast worker metrics

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -155,6 +155,7 @@ All components support `<component>.useGlobalAffinity` (default: `true`) and `<c
 | thorasForecast.worker.forecastTimeout        | Number   | 600                    | Maximum time (in seconds) spent on a single forecast by the `thoras-forecast-worker`           |
 | thorasForecast.trainingJitterMinutes         | Number   | 0                      | Random jitter (in minutes, 0-120) added to training threshold to desynchronize training jobs   |
 | thorasForecast.minLookbackToScale            | Duration | 3h                     | Minimum lookback window before autonomous scaling (minimum: 3h). Supports 3h, 180m, 1h30m      |
+| thorasForecast.prometheus.host               | String   | ::                     | Address the metrics server binds to (dual-stack by default)                                    |
 | thorasWorker.prometheus.enabled              | Boolean  | true                   | Enables a prometheus metric exporter                                                           |
 | thorasWorker.prometheus.port                 | Number   | 9101                   | Port for the prometheus metric exporter                                                        |
 

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -95,6 +95,8 @@ spec:
           {{- if .Values.thorasForecast.prometheus.enabled }}
           - name: METRICS_PORT
             value: {{ .Values.thorasForecast.prometheus.port | quote }}
+          - name: METRICS_HOST
+            value: {{ .Values.thorasForecast.prometheus.host | quote }}
           {{- end }}
           - name: WORKER_HEARTBEAT_FILE
             value: /var/run/thoras/worker-heartbeat

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -889,6 +889,8 @@ Default matches snapshot:
                       fieldPath: metadata.uid
                 - name: METRICS_PORT
                   value: "9101"
+                - name: METRICS_HOST
+                  value: '::'
                 - name: WORKER_HEARTBEAT_FILE
                   value: /var/run/thoras/worker-heartbeat
               image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-forecast:TEST

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -93,6 +93,11 @@ tests:
           content:
             name: METRICS_PORT
             value: "9101"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_HOST
+            value: "::"
 
   - it: omits spec.replicas when worker.replicas is unset
     asserts:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -587,6 +587,9 @@ thorasForecast:
   prometheus:
     enabled: true
     port: 9101
+    # Address the metrics server binds to. Defaults to the dual-stack
+    # wildcard so it's reachable on both IPv4-only and IPv6-only clusters.
+    host: "::"
   service:
     annotations: {}
   # Set to true to apply global affinity rules to this component


### PR DESCRIPTION
# What's changing and why?

To avoid errors like the following, we need to support both mixed and ipv6-only clusters.

```
/proc/net/tcp: 0.0.0.0:9101 LISTEN
There was no :9101 entry in /proc/net/tcp6
```