### PR TITLE
chore: increase default min lookback to scale and wire worker templat

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -133,7 +133,7 @@ spec:
           - name: SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME
             value: "{{ .Values.thorasForecast.podEligibilityMinRunningTime }}"
           - name: SERVICE_MIN_LOOKBACK_TO_SCALE
-            value: "{{ .Values.thorasForecast.minLookbackToScale | default "3h" }}"
+            value: "{{ .Values.thorasForecast.minLookbackToScale | default "24h" }}"
           - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
             value: {{ .Values.featureFlags.enablePrometheusMetricScraping | quote }}
           - name: SERVICE_ENABLE_CLOUD_SYNC

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -161,6 +161,8 @@ spec:
                 name: thoras-cloud-sync
                 key: clusterKey
             {{- end }}
+          - name: SERVICE_MIN_LOOKBACK_TO_SCALE
+            value: {{ .Values.thorasForecast.minLookbackToScale | quote }}
           - name: SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME
             value: "{{ .Values.thorasForecast.podEligibilityMinRunningTime }}"
           - name: SERVICE_ENABLE_NODE_DETAILS_COLLECTOR

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -84,7 +84,7 @@ Default matches snapshot:
                 - name: SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME
                   value: 2m
                 - name: SERVICE_MIN_LOOKBACK_TO_SCALE
-                  value: 3h
+                  value: 24h
                 - name: SERVICE_ENABLE_PROMETHEUS_METRIC_SCRAPING
                   value: "false"
                 - name: SERVICE_ENABLE_CLOUD_SYNC
@@ -1105,7 +1105,7 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_FORECAST_QUEUE_STATS
                   value: "false"
                 - name: SERVICE_MIN_LOOKBACK_TO_SCALE
-                  value: 3h
+                  value: 24h
                 - name: DATABASE_HOST
                   valueFrom:
                     secretKeyRef:
@@ -1561,6 +1561,8 @@ Default matches snapshot:
                     secretKeyRef:
                       key: clusterKey
                       name: thoras-cloud-sync
+                - name: SERVICE_MIN_LOOKBACK_TO_SCALE
+                  value: 24h
                 - name: SERVICE_POD_ELIGIBILITY_MIN_RUNNING_TIME
                   value: 2m
                 - name: SERVICE_ENABLE_NODE_DETAILS_COLLECTOR

--- a/charts/thoras/tests/api_service_deployment_test.yaml
+++ b/charts/thoras/tests/api_service_deployment_test.yaml
@@ -170,7 +170,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_MIN_LOOKBACK_TO_SCALE')].value
-          value: "3h"
+          value: "24h"
   - it: Should override SERVICE_MIN_LOOKBACK_TO_SCALE
     set:
       thorasForecast:
@@ -186,7 +186,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == 'SERVICE_MIN_LOOKBACK_TO_SCALE')].value
-          value: "3h"
+          value: "24h"
   - it: Should set SERVICE_BLOB_SERVICE_API_URL by default
     asserts:
       - equal:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -536,8 +536,8 @@ thorasForecast:
   useAstMetricsSeries: true
   useForecasterComputedMetricId: true
   useForecastEnrichment: false
-  # Minimum lookback window required before autonomous scaling is enabled (minimum 3h).
-  minLookbackToScale: "3h"
+  # Minimum lookback window required before autonomous scaling is enabled.
+  minLookbackToScale: "24h"
   worker:
     # Number of forecast-worker replicas. Leave unset to let the scaler manage
     # the replica count. Set to a fixed number to pin a static count and disable


### PR DESCRIPTION
# What's changing and why?

- Bumps `thorasForecast.minLookbackToScale` default from 3h to 24h — gives workloads a full day of history before autonomous scaling kicks in, reducing churn on fresh installs
- Wires `SERVICE_MIN_LOOKBACK_TO_SCALE` into the worker deployment template — was previously missing, so the helm value was silently ignored by the worker; per-workload overrides via AST or CASTT were unaffected