### PR TITLE
chore: bump chart to 4.136.0, app to 4.112.0

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.135.3
+version: 4.136.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.135.3](https://img.shields.io/badge/Version-4.135.3-informational?style=flat-square) ![AppVersion: 4.111.3](https://img.shields.io/badge/AppVersion-4.111.3-informational?style=flat-square)
+![Version: 4.136.0](https://img.shields.io/badge/Version-4.136.0-informational?style=flat-square) ![AppVersion: 4.112.0](https://img.shields.io/badge/AppVersion-4.112.0-informational?style=flat-square)
 
 # Installs
 
@@ -52,7 +52,7 @@ helm install \
 
 | Key                                | Type    | Default                                          | Description                                                                                                          |
 | ---------------------------------- | ------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| thorasVersion                      | String  | 4.111.3                                          | Thoras app version                                                                                                   |
+| thorasVersion                      | String  | 4.112.0                                          | Thoras app version                                                                                                   |
 | imageCredentials.registry          | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                                                                              |
 | imageCredentials.username          | String  | \_json_key_base64                                | Container registry username                                                                                          |
 | imageCredentials.password          | String  | ""                                               | Container registry auth string                                                                                       |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "4.111.3"
+thorasVersion: "4.112.0"
 cluster:
   name: ""
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Ships the latest Thoras platform (app 4.112.0) to customers via a new chart release.

## What's changing?

- Bump chart version 4.135.3 → 4.136.0
- Bump `thorasVersion` 4.111.3 → 4.112.0
- Update README version badges/docs to match

## How Tested

Version-only bump; no template logic changed. CI unit tests and pre-commit hooks run on the PR.

Co-Authored-By: Claude <noreply@anthropic.com>