### PR TITLE
Wire up metrics-collector follows-mode flag

### DIFF
--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -195,6 +195,8 @@ spec:
             value: {{ .Values.featureFlags.thorasManageThoras.enabled | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_MODE
             value: {{ .Values.featureFlags.thorasManageThoras.mode | quote }}
+          - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_FOLLOWS_MODE
+            value: {{ .Values.featureFlags.thorasManageThoras.metricsCollectorFollowsMode | ternary "true" "false" | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_UPDATE_MODE
             value: {{ .Values.featureFlags.thorasManageThoras.updateMode | quote }}
           - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_UPDATE_MODE

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1596,7 +1596,7 @@ Default matches snapshot:
                 - name: SERVICE_THORAS_SCALING_THORAS_MODE
                   value: recommendation
                 - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_FOLLOWS_MODE
-                  value: "false"
+                  value: "true"
                 - name: SERVICE_THORAS_SCALING_THORAS_UPDATE_MODE
                   value: in_place_or_recreate
                 - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_UPDATE_MODE

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1595,6 +1595,8 @@ Default matches snapshot:
                   value: "true"
                 - name: SERVICE_THORAS_SCALING_THORAS_MODE
                   value: recommendation
+                - name: SERVICE_THORAS_SCALING_THORAS_METRICS_COLLECTOR_FOLLOWS_MODE
+                  value: "false"
                 - name: SERVICE_THORAS_SCALING_THORAS_UPDATE_MODE
                   value: in_place_or_recreate
                 - name: SERVICE_THORAS_SCALING_THORAS_DATABASE_UPDATE_MODE

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -48,6 +48,10 @@ featureFlags:
     enabled: true
     # Recommendation Mode by default
     mode: "recommendation"
+    # When true, the metrics-collector AST follows `mode` above instead of
+    # being pinned to observation mode. Defaults to false since WAL issues
+    # with metrics-collector autonomous mode are still being resolved.
+    metricsCollectorFollowsMode: false
     updateMode: "in_place_or_recreate"
     db:
       updateMode: "in_place_or_recreate"

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -51,7 +51,7 @@ featureFlags:
     # When true, the metrics-collector AST follows `mode` above instead of
     # being pinned to observation mode. Defaults to false since WAL issues
     # with metrics-collector autonomous mode are still being resolved.
-    metricsCollectorFollowsMode: false
+    metricsCollectorFollowsMode: true
     updateMode: "in_place_or_recreate"
     db:
       updateMode: "in_place_or_recreate"


### PR DESCRIPTION
# What's changing and why?

Wiring up a feature flag for enabling the `metrics-collector` following the Thoras-scaling-Thoras mode.