### PR TITLE
fix: hot-reload webhook TLS cert via directory mount

### DIFF
--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -209,12 +209,7 @@ spec:
             subPath: system-config.yaml
             readOnly: true
           - name: tls
-            mountPath: /tmp/k8s-webhook-server/serving-certs/tls.crt
-            subPath: tls.crt
-            readOnly: true
-          - name: tls
-            mountPath: /tmp/k8s-webhook-server/serving-certs/tls.key
-            subPath: tls.key
+            mountPath: /tmp/k8s-webhook-server/serving-certs
             readOnly: true
         ports:
           - name: https-web-hooks

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -1201,14 +1201,9 @@ Default matches snapshot:
                   name: system-config
                   readOnly: true
                   subPath: system-config.yaml
-                - mountPath: /tmp/k8s-webhook-server/serving-certs/tls.crt
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: tls
                   readOnly: true
-                  subPath: tls.crt
-                - mountPath: /tmp/k8s-webhook-server/serving-certs/tls.key
-                  name: tls
-                  readOnly: true
-                  subPath: tls.key
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534


### PR DESCRIPTION
## What's changing and why?

The operator's webhook server already supports hot-reloading its TLS cert (controller-runtime's built-in `certwatcher` fsnotify-watches the cert files — no operator code change needed). But the chart mounted `tls.crt`/`tls.key` individually via `subPath`, and `subPath` mounts are never live-updated by kubelet when the backing Secret rotates, so the watcher never saw a change.

Switches to a single whole-directory mount at `/tmp/k8s-webhook-server/serving-certs`, keeping the existing `secret.items` key remap (cert-manager's `tls.crt`/`tls.key` vs. the self-signed job's `cert`/`key`). Now cert rotation is picked up without a pod restart.

Verified with `helm unittest ./charts/thoras --chart-tests-path ./charts/thoras/tests -u` — 265/265 tests, 68/68 snapshots pass.