### PR TITLE
feat: add configurable idle utilization threshold

### DIFF
--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -176,6 +176,8 @@ spec:
             value: {{ .Values.utilizationThresholds.overprovisioned | quote }}
           - name: SERVICE_UNDERPROVISIONED_THRESHOLD
             value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
+          - name: SERVICE_IDLE_THRESHOLD
+            value: {{ .Values.utilizationThresholds.idle | quote }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         volumeMounts:
           - name: monitor-config

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -114,6 +114,8 @@ Default matches snapshot:
                   value: "60"
                 - name: SERVICE_UNDERPROVISIONED_THRESHOLD
                   value: "92"
+                - name: SERVICE_IDLE_THRESHOLD
+                  value: "5"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -644,3 +644,4 @@ flux:
 utilizationThresholds:
   overprovisioned: 60
   underprovisioned: 92
+  idle: 5


### PR DESCRIPTION
# What's changing and why?

## How does this change deliver value (especially for customers)

Lets customers tune the utilization level at which a workload is classified as idle, rather than relying on a hardcoded server-side value.

## What's changing?

- Add `utilizationThresholds.idle` (default `5`) to `values.yaml`
- Pass it as `SERVICE_IDLE_THRESHOLD` to the API server v2 deployment
- Update global label snapshot

## How Tested

`helm unittest ./charts/thoras` — 265 tests / 68 snapshots pass, including the updated snapshot asserting the new env var.

## Note

Chart version in `Chart.yaml` is not bumped, so merging this won't trigger a release.