### PR TITLE
feat: allow node summary endpoint in dashboard nginx config

### DIFF
--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -56,6 +56,7 @@ data:
         ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
         ~*^GET/v1/views/node-pools(\?|$)                                          1;
         ~*^GET/v1/views/nodes(\?|$)                                               1;
+        ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
         ~*^GET/v1/persistent-volumes(\?|$)                                        1;
 
 

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -52,6 +52,7 @@ Should default to v2 port:
             ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
             ~*^GET/v1/views/node-pools(\?|$)                                          1;
             ~*^GET/v1/views/nodes(\?|$)                                               1;
+            ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
             ~*^GET/v1/persistent-volumes(\?|$)                                        1;
 
 
@@ -173,6 +174,7 @@ should set extras in config.json:
             ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
             ~*^GET/v1/views/node-pools(\?|$)                                          1;
             ~*^GET/v1/views/nodes(\?|$)                                               1;
+            ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
             ~*^GET/v1/persistent-volumes(\?|$)                                        1;
 
 


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

Unblocks the node summary view in the dashboard. Without this allowlist entry, nginx rejects `GET /v1/views/nodes/summary`, so the UI can't load node summary data.

## What's changing?

- Add `~*^GET/v1/views/nodes/summary(\?|$)` to the dashboard nginx allowlist
- Refresh the `dashboard_configmap` snapshot to match

## How Tested

`helm unittest ./charts/thoras` — 265 tests / 68 snapshots pass. The snapshot diff is limited to the single added allowlist line.