### PR TITLE
feat: add extraIngressRules to all component network policies

### DIFF
--- a/charts/thoras/templates/api-server-v2/network-policy.yaml
+++ b/charts/thoras/templates/api-server-v2/network-policy.yaml
@@ -18,6 +18,9 @@ spec:
   # Allow all ingress from pods within the same namespace
   - from:
     - podSelector: {}
+  {{- with .Values.thorasApiServerV2.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to pods within the same namespace
   - to:
@@ -62,6 +65,9 @@ spec:
   # Allow all ingress from endpoints within the same namespace
   - fromEndpoints:
     - {}
+  {{- with .Values.thorasApiServerV2.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to endpoints within the same namespace
   - toEndpoints:

--- a/charts/thoras/templates/collector/network-policy.yaml
+++ b/charts/thoras/templates/collector/network-policy.yaml
@@ -18,6 +18,9 @@ spec:
   # Allow all ingress from pods within the same namespace
   - from:
     - podSelector: {}
+  {{- with .Values.metricsCollector.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to pods within the same namespace
   - to:
@@ -54,6 +57,9 @@ spec:
   # Allow all ingress from endpoints within the same namespace
   - fromEndpoints:
     - {}
+  {{- with .Values.metricsCollector.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to endpoints within the same namespace
   - toEndpoints:

--- a/charts/thoras/templates/dashboard/network-policy.yaml
+++ b/charts/thoras/templates/dashboard/network-policy.yaml
@@ -22,6 +22,9 @@ spec:
   - ports:
     - port: 8080
       protocol: TCP
+  {{- with .Values.thorasDashboard.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to pods within the same namespace
   - to:
@@ -65,6 +68,9 @@ spec:
     - ports:
       - port: "8080"
         protocol: TCP
+  {{- with .Values.thorasDashboard.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to endpoints within the same namespace
   - toEndpoints:

--- a/charts/thoras/templates/forecast-worker/network-policy.yaml
+++ b/charts/thoras/templates/forecast-worker/network-policy.yaml
@@ -18,6 +18,9 @@ spec:
   # Allow all ingress from pods within the same namespace
   - from:
     - podSelector: {}
+  {{- with .Values.thorasForecast.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to pods within the same namespace
   - to:
@@ -54,6 +57,9 @@ spec:
   # Allow all ingress from endpoints within the same namespace
   - fromEndpoints:
     - {}
+  {{- with .Values.thorasForecast.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to endpoints within the same namespace
   - toEndpoints:

--- a/charts/thoras/templates/operator/network-policy.yaml
+++ b/charts/thoras/templates/operator/network-policy.yaml
@@ -24,6 +24,9 @@ spec:
   - ports:
     - port: 9443
       protocol: TCP
+  {{- with .Values.thorasOperator.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to pods within the same namespace
   - to:
@@ -71,6 +74,9 @@ spec:
   # Allow webhook callbacks from the Kubernetes API server
   - fromEntities:
     - kube-apiserver
+  {{- with .Values.thorasOperator.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to endpoints within the same namespace
   - toEndpoints:

--- a/charts/thoras/templates/worker/network-policy.yaml
+++ b/charts/thoras/templates/worker/network-policy.yaml
@@ -18,6 +18,9 @@ spec:
   # Allow all ingress from pods within the same namespace
   - from:
     - podSelector: {}
+  {{- with .Values.thorasWorker.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to pods within the same namespace
   - to:
@@ -62,6 +65,9 @@ spec:
   # Allow all ingress from endpoints within the same namespace
   - fromEndpoints:
     - {}
+  {{- with .Values.thorasWorker.extraIngressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   egress:
   # Allow all egress to endpoints within the same namespace
   - toEndpoints:

--- a/charts/thoras/tests/network_policy_test.yaml
+++ b/charts/thoras/tests/network_policy_test.yaml
@@ -216,6 +216,42 @@ tests:
             toFQDNs:
             - matchName: "my-database.example.com"
 
+  # --- extraIngressRules ---
+
+  - it: Injects extraIngressRules into the kubernetes ingress list
+    template: api-server-v2/network-policy.yaml
+    set:
+      thorasApiServerV2:
+        extraIngressRules:
+          - ports:
+            - port: 8443
+              protocol: TCP
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            ports:
+            - port: 8443
+              protocol: TCP
+
+  - it: Injects extraIngressRules into the cilium ingress list
+    template: collector/network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+      metricsCollector:
+        extraIngressRules:
+          - fromEndpoints:
+            - matchLabels:
+                k8s:io.kubernetes.pod.namespace: monitoring
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            fromEndpoints:
+            - matchLabels:
+                k8s:io.kubernetes.pod.namespace: monitoring
+
   # --- Certgen network policy ---
 
   - it: Certgen kubernetes policy targets the webhook-certgen component selector

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -209,6 +209,7 @@ thorasOperator:
       pods: IfNeeded
       scale: Never
   extraEgressRules: []
+  extraIngressRules: []
 
 metricsCollector:
   # Resource upperbound used when thorasManageThoras is enabled. Empty means
@@ -307,6 +308,7 @@ metricsCollector:
   # Component-specific priorityClassName (takes precedence over the global priorityClassName)
   priorityClassName: ""
   extraEgressRules: []
+  extraIngressRules: []
 
 thorasApiServerV2:
   # Overrides for the global `postgresql` connection-pool settings. Any field
@@ -367,6 +369,7 @@ thorasApiServerV2:
   # Component-specific priorityClassName (takes precedence over the global priorityClassName)
   priorityClassName: ""
   extraEgressRules: []
+  extraIngressRules: []
 
 thorasWorker:
   enabled: true
@@ -432,6 +435,7 @@ thorasWorker:
   # Component-specific priorityClassName (takes precedence over the global priorityClassName)
   priorityClassName: ""
   extraEgressRules: []
+  extraIngressRules: []
 
 thorasDashboard:
   enabled: true
@@ -522,6 +526,7 @@ thorasDashboard:
   # Component-specific priorityClassName (takes precedence over the global priorityClassName)
   priorityClassName: ""
   extraEgressRules: []
+  extraIngressRules: []
   extraContainers: []
 
 thorasMonitor:
@@ -605,6 +610,7 @@ thorasForecast:
   # Set to false to disable the default self anti-affinity between forecast-worker replicas
   enableSelfAntiAffinity: false
   extraEgressRules: []
+  extraIngressRules: []
 
 # K8s client max queries per second
 queriesPerSecond: "50"


### PR DESCRIPTION
## How does this change deliver value (especially for customers)

With `networkPolicy.enabled`, the default ingress rule only admits pods in the Thoras namespace, so cross-namespace Prometheus scrapes are dropped — the chart advertises `prometheus.io/scrape` annotations and `http-metrics` ports that nothing outside the namespace can reach. Customers can now allow their monitoring stack in without disabling network policies wholesale.

## What's changing?

- `extraIngressRules` on all six components (operator, collector, api-server-v2, worker, dashboard, forecast-worker), for both `kubernetes` and `cilium` flavors
- Mirrors the existing `extraEgressRules` pattern; defaults to `[]`
- Rules append after built-in ingress, so dashboard 8080 and operator webhook 9443 are unaffected

Example — letting Prometheus scrape the operator on 9101:

```yaml
thorasOperator:
  extraIngressRules:
    - from:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: monitoring
      ports:
        - port: 9101
          protocol: TCP
```

Note metrics ports differ per component (operator/forecast-worker 9101, worker 9102). Prometheus also needs matching egress if it has its own policy.

## How Tested

Added 2 unit tests (kubernetes + cilium injection); full suite passes at 267 tests / 68 snapshots. Rendered all 6 components x 2 flavors with a probe rule and asserted via YAML parsing that it lands in `spec.ingress`, not `spec.egress`. Diffed rendered output against main with empty defaults — network policies byte-identical, so no-op for existing installs.