### PR TITLE
Feature flag for creating secret-based authn

### DIFF
--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -87,6 +87,7 @@ The following flags are considered temporary and gate access to specific behavio
 | featureFlags.enableInformersStripManagedFields | Boolean | true    | If true, enables informer memory optimizations            |
 | featureFlags.enableTypedInformers              | Boolean | true    | If true, enables additional informer memory optimizations |
 | featureFlags.enableAstRecordMirroring          | Boolean | true    | If true, ASTs are mirrored to the database component      |
+| featureFlags.enableSimpleAuthSecret            | Boolean | false   | If true, generates the `api-client-secret` Secret and wires it into all components |
 
 ## Affinity Configuration
 

--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -222,6 +222,27 @@ true
 {{- end }}
 
 {{/*
+Simple auth env vars injected into every Thoras component. The enable flag is
+always emitted so the components have an explicit "false"; the secret itself is
+only bound when the flag is on. "prefix" is required and must be passed
+explicitly (an empty string is falsey, so it cannot be defaulted): the Go
+services read SERVICE_-prefixed vars, the forecaster reads them unprefixed.
+Usage: {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
+*/}}
+{{- define "thoras.simpleAuthEnv" -}}
+{{- $enabled := .root.Values.featureFlags.enableSimpleAuthSecret -}}
+- name: {{ .prefix }}ENABLE_SIMPLE_AUTH_SECRET
+  value: {{ $enabled | ternary "true" "false" | quote }}
+{{- if $enabled }}
+- name: {{ .prefix }}SIMPLE_AUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: api-client-secret
+      key: secret
+{{- end }}
+{{- end -}}
+
+{{/*
 PodDisruptionBudget for a component. Renders nothing when pdb.enabled is falsey.
 Spec precedence: minAvailable wins if set, else maxUnavailable, else defaults to
 maxUnavailable: 1. Uses kindIs "invalid" so an explicit 0 is honored.

--- a/charts/thoras/templates/api-client-secret.yaml
+++ b/charts/thoras/templates/api-client-secret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.featureFlags.enableSimpleAuthSecret }}
+---
+{{- $newAuthSecret := randAlphaNum 32 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-client-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thoras.resourceLabels" (dict "root" . "component" dict) | nindent 4 }}
+data:
+  {{- /* Reuse the value already in the cluster so upgrades don't rotate the
+         secret out from under running components; only generate on first
+         install (or when the secret has been deleted). */}}
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "api-client-secret") }}
+  {{- $secretData := (get $secretObj "data") | default dict }}
+  {{- $authSecret := (get $secretData "secret") | default ($newAuthSecret | b64enc) }}
+  secret: {{ $authSecret | quote }}
+{{- end }}

--- a/charts/thoras/templates/api-server-v2/deployment.yaml
+++ b/charts/thoras/templates/api-server-v2/deployment.yaml
@@ -178,6 +178,7 @@ spec:
             value: {{ .Values.utilizationThresholds.underprovisioned | quote }}
           - name: SERVICE_IDLE_THRESHOLD
             value: {{ .Values.utilizationThresholds.idle | quote }}
+          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         volumeMounts:
           - name: monitor-config

--- a/charts/thoras/templates/collector/deployment.yaml
+++ b/charts/thoras/templates/collector/deployment.yaml
@@ -317,6 +317,7 @@ spec:
             value: "/var/lib/share"
           - name: SERVICE_ENABLE_PPROF
             value: {{ .Values.metricsCollector.blobService.pprof.enabled | quote }}
+          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         {{- if .Values.metricsCollector.blobService.resources }}
         resources: {{ .Values.metricsCollector.blobService.resources | toYaml | nindent 10 }}

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -48,10 +48,9 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: [ALL]
-        {{- with include "thoras.globalEnv" . }}
         env:
-          {{- . | nindent 10 }}
-        {{- end }}
+          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
+          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
         - containerPort: {{ .Values.thorasDashboard.containerPort }}
           name: http

--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -100,6 +100,7 @@ spec:
           {{- end }}
           - name: WORKER_HEARTBEAT_FILE
             value: /var/run/thoras/worker-heartbeat
+          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "") | nindent 10 }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         {{- if .Values.thorasForecast.worker.resources }}
         resources: {{ .Values.thorasForecast.worker.resources | toYaml | nindent 10 }}

--- a/charts/thoras/templates/operator/deployment.yaml
+++ b/charts/thoras/templates/operator/deployment.yaml
@@ -199,6 +199,7 @@ spec:
             value: {{ .Values.featureFlags.enableAstRecordMirroring | ternary "true" "false" | quote }}
           - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
             value: {{ .Values.featureFlags.enableMultiDimensional | ternary "true" "false" | quote }}
+          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         command: [
           "/app/operator"

--- a/charts/thoras/templates/operator/pre-delete-hook.yaml
+++ b/charts/thoras/templates/operator/pre-delete-hook.yaml
@@ -35,4 +35,7 @@ spec:
           capabilities:
             drop: [ALL]
         command: ["/app/operator", "uninstall"]
+        env:
+          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
+          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         resources: {}

--- a/charts/thoras/templates/worker/deployment.yaml
+++ b/charts/thoras/templates/worker/deployment.yaml
@@ -283,6 +283,7 @@ spec:
             value: {{ .Values.featureFlags.enableDisruptionSchedulerWorker | ternary "true" "false" | quote }}
           - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
             value: {{ .Values.featureFlags.enableMultiDimensional | ternary "true" "false" | quote }}
+          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
           {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
         ports:
           - name: http-metrics

--- a/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/collector_deployment_test.yaml.snap
@@ -123,6 +123,8 @@ Default containers should match snapshots:
         value: /var/lib/share
       - name: SERVICE_ENABLE_PPROF
         value: "false"
+      - name: SERVICE_ENABLE_SIMPLE_AUTH_SECRET
+        value: "false"
     image: us-east4-docker.pkg.dev/thoras-registry/platform/services:dev
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -116,6 +116,8 @@ Default matches snapshot:
                   value: "92"
                 - name: SERVICE_IDLE_THRESHOLD
                   value: "5"
+                - name: SERVICE_ENABLE_SIMPLE_AUTH_SECRET
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -581,6 +583,8 @@ Default matches snapshot:
                   value: /var/lib/share
                 - name: SERVICE_ENABLE_PPROF
                   value: "false"
+                - name: SERVICE_ENABLE_SIMPLE_AUTH_SECRET
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -797,7 +801,10 @@ Default matches snapshot:
             globalLabel: globalValue
         spec:
           containers:
-            - image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard-v2:TEST
+            - env:
+                - name: SERVICE_ENABLE_SIMPLE_AUTH_SECRET
+                  value: "false"
+              image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard-v2:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 48
@@ -951,6 +958,8 @@ Default matches snapshot:
                   value: '::'
                 - name: WORKER_HEARTBEAT_FILE
                   value: /var/run/thoras/worker-heartbeat
+                - name: ENABLE_SIMPLE_AUTH_SECRET
+                  value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-forecast:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -1155,6 +1164,8 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_AST_RECORD_MIRRORING
                   value: "true"
                 - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
+                  value: "false"
+                - name: SERVICE_ENABLE_SIMPLE_AUTH_SECRET
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent
@@ -1655,6 +1666,8 @@ Default matches snapshot:
                 - name: SERVICE_ENABLE_DISRUPTION_SCHEDULER_WORKER
                   value: "true"
                 - name: SERVICE_MULTI_DIMENSIONAL_ENABLED
+                  value: "false"
+                - name: SERVICE_ENABLE_SIMPLE_AUTH_SECRET
                   value: "false"
               image: us-east4-docker.pkg.dev/thoras-registry/platform/services:TEST
               imagePullPolicy: IfNotPresent

--- a/charts/thoras/tests/simple_auth_secret_test.yaml
+++ b/charts/thoras/tests/simple_auth_secret_test.yaml
@@ -1,0 +1,113 @@
+suite: SimpleAuthSecret
+tests:
+  - it: Does not render the api-client-secret by default
+    templates:
+      - api-client-secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Renders the api-client-secret with a generated value when enabled
+    templates:
+      - api-client-secret.yaml
+    set:
+      featureFlags:
+        enableSimpleAuthSecret: true
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: api-client-secret
+      - exists:
+          path: data.secret
+      - matchRegex:
+          # base64 of a 32-character randAlphaNum
+          path: data.secret
+          pattern: "^[A-Za-z0-9+/]{43}=$"
+
+  - it: Defaults SERVICE_ENABLE_SIMPLE_AUTH_SECRET to false on the Go services
+    templates:
+      - operator/deployment.yaml
+      - operator/pre-delete-hook.yaml
+      - api-server-v2/deployment.yaml
+      - worker/deployment.yaml
+      - collector/deployment.yaml
+      - dashboard/deployment.yaml
+    set:
+      thorasMonitor:
+        unittesting: true
+      thorasDashboard:
+        unittesting: true
+    asserts:
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'SERVICE_ENABLE_SIMPLE_AUTH_SECRET')].value
+          value: "false"
+      - notExists:
+          path: $..spec.containers[*].env[?(@.name == 'SERVICE_SIMPLE_AUTH_SECRET')]
+
+  - it: Wires SERVICE_SIMPLE_AUTH_SECRET into the Go services when enabled
+    templates:
+      - operator/deployment.yaml
+      - operator/pre-delete-hook.yaml
+      - api-server-v2/deployment.yaml
+      - worker/deployment.yaml
+      - collector/deployment.yaml
+      - dashboard/deployment.yaml
+    set:
+      featureFlags:
+        enableSimpleAuthSecret: true
+      thorasMonitor:
+        unittesting: true
+      thorasDashboard:
+        unittesting: true
+    asserts:
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'SERVICE_ENABLE_SIMPLE_AUTH_SECRET')].value
+          value: "true"
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'SERVICE_SIMPLE_AUTH_SECRET')].valueFrom.secretKeyRef.name
+          value: api-client-secret
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'SERVICE_SIMPLE_AUTH_SECRET')].valueFrom.secretKeyRef.key
+          value: secret
+
+  # The forecaster reads its config unprefixed (LOGLEVEL, API_BASE_URL, ...),
+  # so it gets the same pair without the SERVICE_ prefix.
+  - it: Defaults ENABLE_SIMPLE_AUTH_SECRET to false on the forecast worker
+    templates:
+      - forecast-worker/deployment.yaml
+    set:
+      thorasForecast:
+        worker:
+          enabled: true
+    asserts:
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'ENABLE_SIMPLE_AUTH_SECRET')].value
+          value: "false"
+      - notExists:
+          path: $..spec.containers[*].env[?(@.name == 'SIMPLE_AUTH_SECRET')]
+      - notExists:
+          path: $..spec.containers[*].env[?(@.name == 'SERVICE_ENABLE_SIMPLE_AUTH_SECRET')]
+
+  - it: Wires unprefixed SIMPLE_AUTH_SECRET into the forecast worker when enabled
+    templates:
+      - forecast-worker/deployment.yaml
+    set:
+      featureFlags:
+        enableSimpleAuthSecret: true
+      thorasForecast:
+        worker:
+          enabled: true
+    asserts:
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'ENABLE_SIMPLE_AUTH_SECRET')].value
+          value: "true"
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'SIMPLE_AUTH_SECRET')].valueFrom.secretKeyRef.name
+          value: api-client-secret
+      - equal:
+          path: $..spec.containers[*].env[?(@.name == 'SIMPLE_AUTH_SECRET')].valueFrom.secretKeyRef.key
+          value: secret
+      - notExists:
+          path: $..spec.containers[*].env[?(@.name == 'SERVICE_SIMPLE_AUTH_SECRET')]

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -69,6 +69,11 @@ featureFlags:
   enableAstRecordMirroring: true
   enableForecastCollectorAntiAffinity: false
   enableMultiDimensional: false
+  # When enabled, the chart generates an `api-client-secret` Secret in the
+  # release namespace holding a random shared secret (generated once and
+  # preserved across upgrades) and wires it into every Thoras component as
+  # SERVICE_SIMPLE_AUTH_SECRET, with SERVICE_ENABLE_SIMPLE_AUTH_SECRET="true".
+  enableSimpleAuthSecret: false
 
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:


### PR DESCRIPTION
# What's changing and why?

Give users the ability to opt-in to authn enforcement on the api