### PR TITLE
fix: make API server netpol ports configurable

### DIFF
--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -184,6 +184,29 @@ true
 {{- end -}}
 
 {{/*
+Egress rule allowing components to reach the Kubernetes API server, for the
+"kubernetes" NetworkPolicy flavor.
+
+Standard NetworkPolicy cannot target the API server by label, so this permits
+egress to any destination on the configured ports. Policy is enforced after
+kube-proxy DNATs the service address to the real endpoint, so the ports must
+match what the API server actually listens on rather than the service port.
+Use the cilium flavor for precise scoping.
+
+Emits nothing when the port list is empty, leaving the rule out entirely
+instead of rendering a rule that would allow egress on every port.
+*/}}
+{{- define "thoras.apiServerEgressRule" -}}
+{{- with .Values.networkPolicy.apiServerPorts -}}
+- ports:
+  {{- range . }}
+  - port: {{ . }}
+    protocol: TCP
+  {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 True when the metrics collector should use a persistent volume.
 Tri-state: an explicit metricsCollector.persistence.enabled (true/false) is
 always honored. When it is unset, infer "on" if the customer configured any

--- a/charts/thoras/templates/api-server-v2/network-policy.yaml
+++ b/charts/thoras/templates/api-server-v2/network-policy.yaml
@@ -25,14 +25,8 @@ spec:
   # Allow all egress to pods within the same namespace
   - to:
     - podSelector: {}
-  # Allow access to the Kubernetes API server (metrics-server API is proxied through here).
-  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
-  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  {{- include "thoras.apiServerEgressRule" . | nindent 2 }}
   # Allow DNS resolution
   - to:
     - namespaceSelector:

--- a/charts/thoras/templates/operator/network-policy.yaml
+++ b/charts/thoras/templates/operator/network-policy.yaml
@@ -31,14 +31,8 @@ spec:
   # Allow all egress to pods within the same namespace
   - to:
     - podSelector: {}
-  # Allow access to the Kubernetes API server (metrics-server API is proxied through here).
-  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
-  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
+  # Allow access to the Kubernetes API server (metrics-server API is proxied through here)
+  {{- include "thoras.apiServerEgressRule" . | nindent 2 }}
   # Allow DNS resolution
   - to:
     - namespaceSelector:

--- a/charts/thoras/templates/operator/webhooks-certgen-network-policy.yaml
+++ b/charts/thoras/templates/operator/webhooks-certgen-network-policy.yaml
@@ -19,14 +19,8 @@ spec:
   policyTypes:
   - Egress
   egress:
-  # Allow access to the Kubernetes API server to read/write secrets and patch webhooks.
-  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
-  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
+  # Allow access to the Kubernetes API server to read/write secrets and patch webhooks
+  {{- include "thoras.apiServerEgressRule" . | nindent 2 }}
   # Allow DNS resolution
   - to:
     - namespaceSelector:

--- a/charts/thoras/templates/worker/network-policy.yaml
+++ b/charts/thoras/templates/worker/network-policy.yaml
@@ -25,14 +25,8 @@ spec:
   # Allow all egress to pods within the same namespace
   - to:
     - podSelector: {}
-  # Allow access to the Kubernetes API server.
-  # Note: standard NetworkPolicy cannot target the API server by label, so this permits
-  # egress to any destination on these ports. Use the cilium flavor for precise scoping.
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
+  # Allow access to the Kubernetes API server
+  {{- include "thoras.apiServerEgressRule" . | nindent 2 }}
   # Allow DNS resolution
   - to:
     - namespaceSelector:

--- a/charts/thoras/tests/network_policy_test.yaml
+++ b/charts/thoras/tests/network_policy_test.yaml
@@ -82,6 +82,72 @@ tests:
             - port: 6443
               protocol: TCP
 
+  - it: All kubernetes policies allow API server egress on custom ports
+    templates:
+      - api-server-v2/network-policy.yaml
+      - operator/network-policy.yaml
+      - operator/webhooks-certgen-network-policy.yaml
+      - worker/network-policy.yaml
+    set:
+      networkPolicy:
+        apiServerPorts:
+        - 443
+        - 6443
+        - 8443
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            ports:
+            - port: 443
+              protocol: TCP
+            - port: 6443
+              protocol: TCP
+            - port: 8443
+              protocol: TCP
+
+  # An empty list must drop the rule entirely. Rendering a rule with no ports
+  # would allow egress to every port instead of none.
+  - it: Empty apiServerPorts omits the API server egress rule
+    templates:
+      - api-server-v2/network-policy.yaml
+      - operator/network-policy.yaml
+      - operator/webhooks-certgen-network-policy.yaml
+      - worker/network-policy.yaml
+    set:
+      networkPolicy:
+        apiServerPorts: []
+    asserts:
+      - notContains:
+          path: spec.egress
+          content:
+            ports:
+            - port: 443
+              protocol: TCP
+            - port: 6443
+              protocol: TCP
+      - notContains:
+          path: spec.egress
+          content:
+            ports: null
+
+  - it: Cilium policies target the API server entity regardless of apiServerPorts
+    templates:
+      - api-server-v2/network-policy.yaml
+      - operator/network-policy.yaml
+      - operator/webhooks-certgen-network-policy.yaml
+      - worker/network-policy.yaml
+    set:
+      networkPolicy:
+        flavor: cilium
+        apiServerPorts: []
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            toEntities:
+            - kube-apiserver
+
   - it: Dashboard kubernetes policy allows external ingress on port 8080
     template: dashboard/network-policy.yaml
     asserts:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -26,6 +26,19 @@ networkPolicy:
   # flavor: "kubernetes" uses standard NetworkPolicy (networking.k8s.io/v1)
   # flavor: "cilium" uses CiliumNetworkPolicy (cilium.io/v2)
   flavor: kubernetes
+  # -- Ports the Kubernetes API server is reachable on, used by the "kubernetes"
+  # flavor to allow egress from components that talk to the API.
+  # NetworkPolicy is evaluated after kube-proxy translates the service address
+  # (10.96.0.1:443) to the real endpoint, so this must list the port the API
+  # server actually listens on -- not the service port. Check with:
+  #   kubectl get endpoints kubernetes -n default
+  # Clusters that front the API on a non-standard port (minikube uses 8443)
+  # must add it here or components will fail to reach the API.
+  # Ignored by the "cilium" flavor, which resolves the API server via
+  # `toEntities: [kube-apiserver]` and needs no port list.
+  apiServerPorts:
+  - 443
+  - 6443
 
 imagePullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
# What's changing and why?

Clusters that front the Kubernetes API on a non-standard port (minikube uses 8443) couldn't install with network policies enabled — the hardcoded 443/6443 egress rule blocked the operator, worker, api-server, and certgen from reaching the API. Ports are now configurable via `networkPolicy.apiServerPorts`, defaulting to the previous 443/6443 so existing installs are unaffected.

- Add `networkPolicy.apiServerPorts` to values.yaml
- Extract the duplicated egress rule into a `thoras.apiServerEgressRule` helper used by all four `kubernetes`-flavor policies
- Empty list drops the rule entirely rather than rendering a portless rule (which would allow egress on *every* port)
- Cilium flavor is unaffected — it targets `toEntities: [kube-apiserver]` and needs no ports

## How Tested

Added 3 helm unittest cases: custom port list applies to all four policies, empty list omits the rule, and cilium flavor ignores the setting. Full suite passes (270 tests).