### PR TITLE
Forward auth secret through dashboard proxy

### DIFF
--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -266,6 +266,27 @@ Usage: {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | 
 {{- end -}}
 
 {{/*
+Simple auth env vars injected into every Thoras component. The enable flag is
+always emitted so the components have an explicit "false"; the secret itself is
+only bound when the flag is on. "prefix" is required and must be passed
+explicitly (an empty string is falsey, so it cannot be defaulted): the Go
+services read SERVICE_-prefixed vars, the forecaster reads them unprefixed.
+Usage: {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
+*/}}
+{{- define "thoras.simpleAuthEnv" -}}
+{{- $enabled := .root.Values.featureFlags.enableSimpleAuthSecret -}}
+- name: {{ .prefix }}ENABLE_SIMPLE_AUTH_SECRET
+  value: {{ $enabled | ternary "true" "false" | quote }}
+{{- if $enabled }}
+- name: {{ .prefix }}SIMPLE_AUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: api-client-secret
+      key: secret
+{{- end }}
+{{- end -}}
+
+{{/*
 PodDisruptionBudget for a component. Renders nothing when pdb.enabled is falsey.
 Spec precedence: minAvailable wins if set, else maxUnavailable, else defaults to
 maxUnavailable: 1. Uses kindIs "invalid" so an explicit 0 is honored.

--- a/charts/thoras/templates/_helpers.tpl
+++ b/charts/thoras/templates/_helpers.tpl
@@ -266,27 +266,6 @@ Usage: {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | 
 {{- end -}}
 
 {{/*
-Simple auth env vars injected into every Thoras component. The enable flag is
-always emitted so the components have an explicit "false"; the secret itself is
-only bound when the flag is on. "prefix" is required and must be passed
-explicitly (an empty string is falsey, so it cannot be defaulted): the Go
-services read SERVICE_-prefixed vars, the forecaster reads them unprefixed.
-Usage: {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
-*/}}
-{{- define "thoras.simpleAuthEnv" -}}
-{{- $enabled := .root.Values.featureFlags.enableSimpleAuthSecret -}}
-- name: {{ .prefix }}ENABLE_SIMPLE_AUTH_SECRET
-  value: {{ $enabled | ternary "true" "false" | quote }}
-{{- if $enabled }}
-- name: {{ .prefix }}SIMPLE_AUTH_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: api-client-secret
-      key: secret
-{{- end }}
-{{- end -}}
-
-{{/*
 PodDisruptionBudget for a component. Renders nothing when pdb.enabled is falsey.
 Spec precedence: minAvailable wins if set, else maxUnavailable, else defaults to
 maxUnavailable: 1. Uses kindIs "invalid" so an explicit 0 is honored.

--- a/charts/thoras/templates/dashboard/deployment.yaml
+++ b/charts/thoras/templates/dashboard/deployment.yaml
@@ -48,9 +48,20 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: [ALL]
+        args: ["nginx", "-c", "/tmp/nginx.conf", "-g", "daemon off;"]
         env:
-          {{- include "thoras.simpleAuthEnv" (dict "root" . "prefix" "SERVICE_") | nindent 10 }}
-          {{- with include "thoras.globalEnv" . }}{{- . | nindent 10 }}{{- end }}
+        {{- with include "thoras.globalEnv" . }}
+          {{- . | nindent 10 }}
+        {{- end }}
+          - name: NGINX_ENVSUBST_OUTPUT_DIR
+            value: /tmp
+        {{- if .Values.featureFlags.enableSimpleAuthSecret }}
+          - name: SIMPLE_AUTH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: api-client-secret
+                key: secret
+        {{- end }}
         ports:
         - containerPort: {{ .Values.thorasDashboard.containerPort }}
           name: http
@@ -81,8 +92,8 @@ spec:
           failureThreshold: 48
         volumeMounts:
           - name: nginx-config
-            mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf
+            mountPath: /etc/nginx/templates/nginx.conf.template
+            subPath: nginx.conf.template
       {{- if .Values.thorasDashboard.extraContainers }}
       {{- toYaml .Values.thorasDashboard.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" .Values.thorasDashboard.labels) | nindent 4 }}
 data:
-  nginx.conf: |
+  nginx.conf.template: |
     pid /tmp/nginx.pid;
 
     events {
@@ -20,7 +20,7 @@ data:
       uwsgi_temp_path       /tmp/uwsgi_temp;
       scgi_temp_path        /tmp/scgi_temp;
 
-      include       mime.types;
+      include       /etc/nginx/mime.types;
 
       # Least-privilege allowlist for dashboard -> API calls.
       # Deny by default; only routes the dashboard actually uses are allowed.
@@ -92,6 +92,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- if .Values.featureFlags.enableSimpleAuthSecret }}
+          proxy_set_header Authorization "Bearer ${SIMPLE_AUTH_SECRET}";
+          {{- end }}
         }
 
         location /config.json {

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -1,244 +1,222 @@
 Should default to v2 port:
   1: |
-    apiVersion: v1
-    data:
-      nginx.conf: |
-        pid /tmp/nginx.pid;
+    |
+      pid /tmp/nginx.pid;
 
-        events {
-          worker_connections 1024;
+      events {
+        worker_connections 1024;
+      }
+
+      http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
+        include       /etc/nginx/mime.types;
+
+        # Least-privilege allowlist for dashboard -> API calls.
+        # Deny by default; only routes the dashboard actually uses are allowed.
+        # New dashboard API calls require a matching entry here or they will 403.
+        map $request_method$request_uri $thoras_dashboard_api_allowed {
+          default 0;
+
+          # GET — reads
+          ~*^GET/v1/ast(\?|$)                                                       1;
+          ~*^GET/v1/ast/[^/]+/[^/]+(\?|$)                                           1;
+          ~*^GET/v1/ast/[^/]+/[^/]+/pods(\?|$)                                      1;
+          ~*^GET/v1/ast/[^/]+/[^/]+/metrics/current(\?|$)                           1;
+          ~*^GET/v1/ast/[^/]+/[^/]+/suggestions(\?|$)                               1;
+          ~*^GET/v1/cost-savings/settings(\?|$)                                     1;
+          ~*^GET/v1/export(\?|$)                                                    1;
+          ~*^GET/v1/instance-costs/current(\?|$)                                    1;
+          ~*^GET/v1/system/jobs/status(\?|$)                                        1;
+          ~*^GET/v1/system/namespaces(\?|$)                                         1;
+          ~*^GET/v1/system/status(\?|$)                                             1;
+          ~*^GET/v1/views/asts(\?|$)                                                1;
+          ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
+          ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
+          ~*^GET/v1/views/cost/details(\?|$)                                        1;
+          ~*^GET/v1/views/cost/details/export(\?|$)                                 1;
+          ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
+          ~*^GET/v1/views/cost/projected(\?|$)                                      1;
+          ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
+          ~*^GET/v1/views/cost/savings-summary/namespaces/[^/]+(\?|$)               1;
+          ~*^GET/v1/views/kpis(\?|$)                                                1;
+          ~*^GET/v1/views/labels(\?|$)                                              1;
+          ~*^GET/v1/views/namespaces/[^/]+/asts(\?|$)                               1;
+          ~*^GET/v1/views/namespaces/[^/]+/kpis(\?|$)                               1;
+          ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
+          ~*^GET/v1/views/node-pools(\?|$)                                          1;
+          ~*^GET/v1/views/nodes(\?|$)                                               1;
+          ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
+          ~*^GET/v1/persistent-volumes(\?|$)                                        1;
+
+
+          # POST — dashboard-initiated mutations
+          ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
+          ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
+          ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+          # POST — reads that pass a request body (query payloads, not mutations)
+          ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
+
+          # PATCH — scale mode toggle
+          ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
+
+          # PUT — pause/resume system-wide scaling
+          ~*^PUT/v1/system/scaling(\?|$)                                            1;
         }
 
-        http {
-          client_body_temp_path /tmp/client_temp;
-          proxy_temp_path       /tmp/proxy_temp;
-          fastcgi_temp_path     /tmp/fastcgi_temp;
-          uwsgi_temp_path       /tmp/uwsgi_temp;
-          scgi_temp_path        /tmp/scgi_temp;
+        server {
+          listen       8080;
+          listen       [::]:8080 ipv6only=on;
+          server_name  localhost;
 
-          include       mime.types;
+          root   /usr/share/nginx/html;
+          index  index.html index.htm;
 
-          # Least-privilege allowlist for dashboard -> API calls.
-          # Deny by default; only routes the dashboard actually uses are allowed.
-          # New dashboard API calls require a matching entry here or they will 403.
-          map $request_method$request_uri $thoras_dashboard_api_allowed {
-            default 0;
-
-            # GET — reads
-            ~*^GET/v1/ast(\?|$)                                                       1;
-            ~*^GET/v1/ast/[^/]+/[^/]+(\?|$)                                           1;
-            ~*^GET/v1/ast/[^/]+/[^/]+/pods(\?|$)                                      1;
-            ~*^GET/v1/ast/[^/]+/[^/]+/metrics/current(\?|$)                           1;
-            ~*^GET/v1/ast/[^/]+/[^/]+/suggestions(\?|$)                               1;
-            ~*^GET/v1/cost-savings/settings(\?|$)                                     1;
-            ~*^GET/v1/export(\?|$)                                                    1;
-            ~*^GET/v1/instance-costs/current(\?|$)                                    1;
-            ~*^GET/v1/system/jobs/status(\?|$)                                        1;
-            ~*^GET/v1/system/namespaces(\?|$)                                         1;
-            ~*^GET/v1/system/status(\?|$)                                             1;
-            ~*^GET/v1/views/asts(\?|$)                                                1;
-            ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
-            ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
-            ~*^GET/v1/views/cost/details(\?|$)                                        1;
-            ~*^GET/v1/views/cost/details/export(\?|$)                                 1;
-            ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
-            ~*^GET/v1/views/cost/projected(\?|$)                                      1;
-            ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
-            ~*^GET/v1/views/cost/savings-summary/namespaces/[^/]+(\?|$)               1;
-            ~*^GET/v1/views/kpis(\?|$)                                                1;
-            ~*^GET/v1/views/labels(\?|$)                                              1;
-            ~*^GET/v1/views/namespaces/[^/]+/asts(\?|$)                               1;
-            ~*^GET/v1/views/namespaces/[^/]+/kpis(\?|$)                               1;
-            ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
-            ~*^GET/v1/views/node-pools(\?|$)                                          1;
-            ~*^GET/v1/views/nodes(\?|$)                                               1;
-            ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
-            ~*^GET/v1/persistent-volumes(\?|$)                                        1;
-
-
-            # POST — dashboard-initiated mutations
-            ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
-            ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
-            ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
-
-            # POST — reads that pass a request body (query payloads, not mutations)
-            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
-
-            # PATCH — scale mode toggle
-            ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
-
-            # PUT — pause/resume system-wide scaling
-            ~*^PUT/v1/system/scaling(\?|$)                                            1;
+          location /v1/ {
+            if ($thoras_dashboard_api_allowed != 1) {
+              return 403;
+            }
+            proxy_pass http://thoras-api-server-v2;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
           }
 
-          server {
-            listen       8080;
-            listen       [::]:8080 ipv6only=on;
-            server_name  localhost;
+          location /config.json {
+              default_type application/json;
+              return 200 '{ "api_base_url": "", "version": "4.36.0", "platformVersion": "1.2.3", "featureFlags": {"ignoreNewPods": true, "enableUpdateScaleModeApi": false}, "extra": {"cluster_name":"phantom-assassin","cost_analysis":true,"cost_breakdown_v2":true,"cost_simulator":false,"enable_change_highlighting":false,"enable_scaling_pause":true,"highlight_cpu_change_above_millicores":50,"highlight_memory_change_above_mib":100,"node_overrides":true,"rolling_savings":true,"show_node_details":true,"show_savings":true} }';
+          }
 
+          location / {
+            try_files $uri /index.html;
+          }
+
+          location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|otf|ttf|map)$ {
+            expires 1y;
+            access_log off;
+            add_header Cache-Control "public";
+          }
+
+          error_page   500 502 503 504  /50x.html;
+          location = /50x.html {
             root   /usr/share/nginx/html;
-            index  index.html index.htm;
-
-            location /v1/ {
-              if ($thoras_dashboard_api_allowed != 1) {
-                return 403;
-              }
-              proxy_pass http://thoras-api-server-v2;
-              proxy_set_header Host $host;
-              proxy_set_header X-Real-IP $remote_addr;
-              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-              proxy_set_header X-Forwarded-Proto $scheme;
-            }
-
-            location /config.json {
-                default_type application/json;
-                return 200 '{ "api_base_url": "", "version": "4.36.0", "platformVersion": "1.2.3", "featureFlags": {"ignoreNewPods": true, "enableUpdateScaleModeApi": false}, "extra": {"cluster_name":"phantom-assassin","cost_analysis":true,"cost_breakdown_v2":true,"cost_simulator":false,"enable_change_highlighting":false,"enable_scaling_pause":true,"highlight_cpu_change_above_millicores":50,"highlight_memory_change_above_mib":100,"node_overrides":true,"rolling_savings":true,"show_node_details":true,"show_savings":true} }';
-            }
-
-            location / {
-              try_files $uri /index.html;
-            }
-
-            location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|otf|ttf|map)$ {
-              expires 1y;
-              access_log off;
-              add_header Cache-Control "public";
-            }
-
-            error_page   500 502 503 504  /50x.html;
-            location = /50x.html {
-              root   /usr/share/nginx/html;
-            }
           }
         }
-    kind: ConfigMap
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: thoras
-        helm.sh/chart: thoras-4.36.0
-      name: thoras-dashboard-nginx-config
-      namespace: NAMESPACE
+      }
 should set extras in config.json:
   1: |
-    apiVersion: v1
-    data:
-      nginx.conf: |
-        pid /tmp/nginx.pid;
+    |
+      pid /tmp/nginx.pid;
 
-        events {
-          worker_connections 1024;
+      events {
+        worker_connections 1024;
+      }
+
+      http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
+        include       /etc/nginx/mime.types;
+
+        # Least-privilege allowlist for dashboard -> API calls.
+        # Deny by default; only routes the dashboard actually uses are allowed.
+        # New dashboard API calls require a matching entry here or they will 403.
+        map $request_method$request_uri $thoras_dashboard_api_allowed {
+          default 0;
+
+          # GET — reads
+          ~*^GET/v1/ast(\?|$)                                                       1;
+          ~*^GET/v1/ast/[^/]+/[^/]+(\?|$)                                           1;
+          ~*^GET/v1/ast/[^/]+/[^/]+/pods(\?|$)                                      1;
+          ~*^GET/v1/ast/[^/]+/[^/]+/metrics/current(\?|$)                           1;
+          ~*^GET/v1/ast/[^/]+/[^/]+/suggestions(\?|$)                               1;
+          ~*^GET/v1/cost-savings/settings(\?|$)                                     1;
+          ~*^GET/v1/export(\?|$)                                                    1;
+          ~*^GET/v1/instance-costs/current(\?|$)                                    1;
+          ~*^GET/v1/system/jobs/status(\?|$)                                        1;
+          ~*^GET/v1/system/namespaces(\?|$)                                         1;
+          ~*^GET/v1/system/status(\?|$)                                             1;
+          ~*^GET/v1/views/asts(\?|$)                                                1;
+          ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
+          ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
+          ~*^GET/v1/views/cost/details(\?|$)                                        1;
+          ~*^GET/v1/views/cost/details/export(\?|$)                                 1;
+          ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
+          ~*^GET/v1/views/cost/projected(\?|$)                                      1;
+          ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
+          ~*^GET/v1/views/cost/savings-summary/namespaces/[^/]+(\?|$)               1;
+          ~*^GET/v1/views/kpis(\?|$)                                                1;
+          ~*^GET/v1/views/labels(\?|$)                                              1;
+          ~*^GET/v1/views/namespaces/[^/]+/asts(\?|$)                               1;
+          ~*^GET/v1/views/namespaces/[^/]+/kpis(\?|$)                               1;
+          ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
+          ~*^GET/v1/views/node-pools(\?|$)                                          1;
+          ~*^GET/v1/views/nodes(\?|$)                                               1;
+          ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
+          ~*^GET/v1/persistent-volumes(\?|$)                                        1;
+
+
+          # POST — dashboard-initiated mutations
+          ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
+          ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
+          ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
+
+          # POST — reads that pass a request body (query payloads, not mutations)
+          ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
+
+          # PATCH — scale mode toggle
+          ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
+
+          # PUT — pause/resume system-wide scaling
+          ~*^PUT/v1/system/scaling(\?|$)                                            1;
         }
 
-        http {
-          client_body_temp_path /tmp/client_temp;
-          proxy_temp_path       /tmp/proxy_temp;
-          fastcgi_temp_path     /tmp/fastcgi_temp;
-          uwsgi_temp_path       /tmp/uwsgi_temp;
-          scgi_temp_path        /tmp/scgi_temp;
+        server {
+          listen       8080;
+          listen       [::]:8080 ipv6only=on;
+          server_name  localhost;
 
-          include       mime.types;
+          root   /usr/share/nginx/html;
+          index  index.html index.htm;
 
-          # Least-privilege allowlist for dashboard -> API calls.
-          # Deny by default; only routes the dashboard actually uses are allowed.
-          # New dashboard API calls require a matching entry here or they will 403.
-          map $request_method$request_uri $thoras_dashboard_api_allowed {
-            default 0;
-
-            # GET — reads
-            ~*^GET/v1/ast(\?|$)                                                       1;
-            ~*^GET/v1/ast/[^/]+/[^/]+(\?|$)                                           1;
-            ~*^GET/v1/ast/[^/]+/[^/]+/pods(\?|$)                                      1;
-            ~*^GET/v1/ast/[^/]+/[^/]+/metrics/current(\?|$)                           1;
-            ~*^GET/v1/ast/[^/]+/[^/]+/suggestions(\?|$)                               1;
-            ~*^GET/v1/cost-savings/settings(\?|$)                                     1;
-            ~*^GET/v1/export(\?|$)                                                    1;
-            ~*^GET/v1/instance-costs/current(\?|$)                                    1;
-            ~*^GET/v1/system/jobs/status(\?|$)                                        1;
-            ~*^GET/v1/system/namespaces(\?|$)                                         1;
-            ~*^GET/v1/system/status(\?|$)                                             1;
-            ~*^GET/v1/views/asts(\?|$)                                                1;
-            ~*^GET/v1/views/asts/[^/]+/[^/]+(\?|$)                                    1;
-            ~*^GET/v1/views/cost/analysis(\?|$)                                       1;
-            ~*^GET/v1/views/cost/details(\?|$)                                        1;
-            ~*^GET/v1/views/cost/details/export(\?|$)                                 1;
-            ~*^GET/v1/views/cost/details/namespaces/[^/]+(\?|$)                       1;
-            ~*^GET/v1/views/cost/projected(\?|$)                                      1;
-            ~*^GET/v1/views/cost/savings-summary(\?|$)                                1;
-            ~*^GET/v1/views/cost/savings-summary/namespaces/[^/]+(\?|$)               1;
-            ~*^GET/v1/views/kpis(\?|$)                                                1;
-            ~*^GET/v1/views/labels(\?|$)                                              1;
-            ~*^GET/v1/views/namespaces/[^/]+/asts(\?|$)                               1;
-            ~*^GET/v1/views/namespaces/[^/]+/kpis(\?|$)                               1;
-            ~*^GET/v1/views/namespaces/[^/]+/labels(\?|$)                             1;
-            ~*^GET/v1/views/node-pools(\?|$)                                          1;
-            ~*^GET/v1/views/nodes(\?|$)                                               1;
-            ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
-            ~*^GET/v1/persistent-volumes(\?|$)                                        1;
-
-
-            # POST — dashboard-initiated mutations
-            ~*^POST/v1/ast/candidates/[^/]+(\?|$)                                     1;
-            ~*^POST/v1/ast/enroll/all(\?|$)                                           1;
-            ~*^POST/v1/cost-savings/settings(\?|$)                                    1;
-
-            # POST — reads that pass a request body (query payloads, not mutations)
-            ~*^POST/v1/ast/[^/]+/metrics/series(\?|$)                                 1;
-
-            # PATCH — scale mode toggle
-            ~*^PATCH/v1/ast/[^/]+/[^/]+/mode(\?|$)                                    1;
-
-            # PUT — pause/resume system-wide scaling
-            ~*^PUT/v1/system/scaling(\?|$)                                            1;
+          location /v1/ {
+            if ($thoras_dashboard_api_allowed != 1) {
+              return 403;
+            }
+            proxy_pass http://thoras-api-server-v2;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
           }
 
-          server {
-            listen       8080;
-            listen       [::]:8080 ipv6only=on;
-            server_name  localhost;
+          location /config.json {
+              default_type application/json;
+              return 200 '{ "api_base_url": "", "version": "4.36.0", "platformVersion": "1.2.3", "featureFlags": {"ignoreNewPods": true, "enableUpdateScaleModeApi": false}, "extra": {"cluster_name":"phantom-assassin","cost_analysis":true,"cost_breakdown_v2":true,"cost_simulator":false,"enable_change_highlighting":false,"enable_scaling_pause":true,"feature":true,"foo":"bar","highlight_cpu_change_above_millicores":50,"highlight_memory_change_above_mib":100,"node_overrides":true,"rolling_savings":true,"show_node_details":true,"show_savings":true} }';
+          }
 
+          location / {
+            try_files $uri /index.html;
+          }
+
+          location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|otf|ttf|map)$ {
+            expires 1y;
+            access_log off;
+            add_header Cache-Control "public";
+          }
+
+          error_page   500 502 503 504  /50x.html;
+          location = /50x.html {
             root   /usr/share/nginx/html;
-            index  index.html index.htm;
-
-            location /v1/ {
-              if ($thoras_dashboard_api_allowed != 1) {
-                return 403;
-              }
-              proxy_pass http://thoras-api-server-v2;
-              proxy_set_header Host $host;
-              proxy_set_header X-Real-IP $remote_addr;
-              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-              proxy_set_header X-Forwarded-Proto $scheme;
-            }
-
-            location /config.json {
-                default_type application/json;
-                return 200 '{ "api_base_url": "", "version": "4.36.0", "platformVersion": "1.2.3", "featureFlags": {"ignoreNewPods": true, "enableUpdateScaleModeApi": false}, "extra": {"cluster_name":"phantom-assassin","cost_analysis":true,"cost_breakdown_v2":true,"cost_simulator":false,"enable_change_highlighting":false,"enable_scaling_pause":true,"feature":true,"foo":"bar","highlight_cpu_change_above_millicores":50,"highlight_memory_change_above_mib":100,"node_overrides":true,"rolling_savings":true,"show_node_details":true,"show_savings":true} }';
-            }
-
-            location / {
-              try_files $uri /index.html;
-            }
-
-            location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|otf|ttf|map)$ {
-              expires 1y;
-              access_log off;
-              add_header Cache-Control "public";
-            }
-
-            error_page   500 502 503 504  /50x.html;
-            location = /50x.html {
-              root   /usr/share/nginx/html;
-            }
           }
         }
-    kind: ConfigMap
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: thoras
-        helm.sh/chart: thoras-4.36.0
-      name: thoras-dashboard-nginx-config
-      namespace: NAMESPACE
+      }

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -801,9 +801,15 @@ Default matches snapshot:
             globalLabel: globalValue
         spec:
           containers:
-            - env:
-                - name: SERVICE_ENABLE_SIMPLE_AUTH_SECRET
-                  value: "false"
+            - args:
+                - nginx
+                - -c
+                - /tmp/nginx.conf
+                - -g
+                - daemon off;
+              env:
+                - name: NGINX_ENVSUBST_OUTPUT_DIR
+                  value: /tmp
               image: us-east4-docker.pkg.dev/thoras-registry/platform/thoras-dashboard-v2:TEST
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -844,9 +850,9 @@ Default matches snapshot:
                   port: http
                 periodSeconds: 5
               volumeMounts:
-                - mountPath: /etc/nginx/nginx.conf
+                - mountPath: /etc/nginx/templates/nginx.conf.template
                   name: nginx-config
-                  subPath: nginx.conf
+                  subPath: nginx.conf.template
           securityContext:
             runAsNonRoot: true
             seccompProfile:

--- a/charts/thoras/tests/dashboard_configmap_test.yaml
+++ b/charts/thoras/tests/dashboard_configmap_test.yaml
@@ -12,7 +12,7 @@ tests:
     set:
     asserts:
       - matchSnapshot:
-        path: data.nginx.conf
+          path: data["nginx.conf.template"]
   - it: should set extras in config.json
     set:
       thorasDashboard:
@@ -22,4 +22,10 @@ tests:
           feature: true
     asserts:
       - matchSnapshot:
-        path: data.nginx.conf
+          path: data["nginx.conf.template"]
+  - it: Should render the nginx config under the nginx.conf.template key
+    asserts:
+      - exists:
+          path: data["nginx.conf.template"]
+      - notExists:
+          path: data["nginx.conf"]

--- a/charts/thoras/tests/dashboard_deployment_test.yaml
+++ b/charts/thoras/tests/dashboard_deployment_test.yaml
@@ -21,8 +21,8 @@ tests:
           path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].volumeMounts[0]
           value:
             name: nginx-config
-            mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf
+            mountPath: /etc/nginx/templates/nginx.conf.template
+            subPath: nginx.conf.template
       - equal:
           path: spec.replicas
           value: 12

--- a/charts/thoras/tests/simple_auth_secret_test.yaml
+++ b/charts/thoras/tests/simple_auth_secret_test.yaml
@@ -28,12 +28,7 @@ tests:
 
   - it: Defaults SERVICE_ENABLE_SIMPLE_AUTH_SECRET to false on the Go services
     templates:
-      - operator/deployment.yaml
-      - operator/pre-delete-hook.yaml
       - api-server-v2/deployment.yaml
-      - worker/deployment.yaml
-      - collector/deployment.yaml
-      - dashboard/deployment.yaml
     set:
       thorasMonitor:
         unittesting: true
@@ -48,12 +43,7 @@ tests:
 
   - it: Wires SERVICE_SIMPLE_AUTH_SECRET into the Go services when enabled
     templates:
-      - operator/deployment.yaml
-      - operator/pre-delete-hook.yaml
       - api-server-v2/deployment.yaml
-      - worker/deployment.yaml
-      - collector/deployment.yaml
-      - dashboard/deployment.yaml
     set:
       featureFlags:
         enableSimpleAuthSecret: true
@@ -111,3 +101,58 @@ tests:
           value: secret
       - notExists:
           path: $..spec.containers[*].env[?(@.name == 'SERVICE_SIMPLE_AUTH_SECRET')]
+
+  - it: Does not forward an Authorization header from the dashboard nginx proxy by default
+    templates:
+      - dashboard/nginx-config-map.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf.template"]
+          pattern: "proxy_set_header Authorization"
+
+  - it: Does not wire SIMPLE_AUTH_SECRET into the dashboard by default
+    templates:
+      - dashboard/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].env[?(@.name == 'SIMPLE_AUTH_SECRET')]
+      - equal:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].env[?(@.name == 'NGINX_ENVSUBST_OUTPUT_DIR')].value
+          value: /tmp
+      - equal:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].args
+          value: ["nginx", "-c", "/tmp/nginx.conf", "-g", "daemon off;"]
+
+  - it: Forwards the shared secret as a Bearer header from the dashboard nginx proxy when enabled
+    templates:
+      - dashboard/nginx-config-map.yaml
+    set:
+      featureFlags:
+        enableSimpleAuthSecret: true
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf.template"]
+          pattern: 'proxy_set_header Authorization "Bearer \$\{SIMPLE_AUTH_SECRET\}";'
+
+  - it: Wires SIMPLE_AUTH_SECRET into the dashboard when enabled
+    templates:
+      - dashboard/deployment.yaml
+    set:
+      featureFlags:
+        enableSimpleAuthSecret: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].env[?(@.name == 'SIMPLE_AUTH_SECRET')].valueFrom.secretKeyRef.name
+          value: api-client-secret
+      - equal:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].env[?(@.name == 'SIMPLE_AUTH_SECRET')].valueFrom.secretKeyRef.key
+          value: secret
+      - equal:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].env[?(@.name == 'NGINX_ENVSUBST_OUTPUT_DIR')].value
+          value: /tmp
+      - equal:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].volumeMounts[?(@.name == 'nginx-config')].mountPath
+          value: /etc/nginx/templates/nginx.conf.template
+      - equal:
+          path: spec.template.spec.containers[?(@.name == 'thoras-dashboard')].volumeMounts[?(@.name == 'nginx-config')].subPath
+          value: nginx.conf.template


### PR DESCRIPTION
## What's changing
Wires the dashboard's nginx proxy to forward the existing shared auth secret as an `Authorization: Bearer` header on its `/v1/*` calls to api-server-v2, so enabling `featureFlags.enableSimpleAuthSecret` doesn't break the dashboard. Injected server-side via nginx's envsubst mechanism — secret never touches the ConfigMap, Helm history, or the browser.

## How this helps the customer
Lets operators turn on shared-secret auth without losing dashboard functionality.

## Testing
`helm unittest` (276/276 passing) + verified against the real `nginx:alpine` image (non-root UID, entrypoint/envsubst behavior, secret substitution).