### PR TITLE
Allow passing in apiClientSecret

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.139.0
+version: 4.140.0

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.139.0](https://img.shields.io/badge/Version-4.139.0-informational?style=flat-square) ![AppVersion: 4.116.0](https://img.shields.io/badge/AppVersion-4.116.0-informational?style=flat-square)
+![Version: 4.140.0](https://img.shields.io/badge/Version-4.140.0-informational?style=flat-square) ![AppVersion: 4.116.0](https://img.shields.io/badge/AppVersion-4.116.0-informational?style=flat-square)
 
 # Installs
 
@@ -75,6 +75,7 @@ helm install \
 | costRefreshBatching.enabled        | Boolean | true                                             | Enables refreshing cost data in concurrent batches                                                                   |
 | costRefreshBatching.batchSize      | Number  | 200                                              | Number of AST costs to refresh per batch                                                                             |
 | costRefreshBatching.maxConcurrency | Number  | 5                                                | Number of concurrent AST cost refresh batches to process concurrently                                                |
+| apiClientSecret.secret             | String  | ""                                               | Shared secret components send to the API server when `featureFlags.enableSimpleAuthSecret` is true. Generated if empty |
 
 ## Feature Flags
 

--- a/charts/thoras/templates/api-client-secret.yaml
+++ b/charts/thoras/templates/api-client-secret.yaml
@@ -9,11 +9,13 @@ metadata:
   labels:
     {{- include "thoras.resourceLabels" (dict "root" . "component" dict) | nindent 4 }}
 data:
-  {{- /* Reuse the value already in the cluster so upgrades don't rotate the
-         secret out from under running components; only generate on first
-         install (or when the secret has been deleted). */}}
+  {{- /* Precedence matches the timescale password: the value already in the
+         cluster wins so upgrades don't rotate the secret out from under
+         running components, then an explicitly configured value, then a
+         generated one. Set apiClientSecret.secret to keep renders
+         deterministic where `lookup` is unavailable (helm template, Argo CD). */}}
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "api-client-secret") }}
   {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $authSecret := (get $secretData "secret") | default ($newAuthSecret | b64enc) }}
+  {{- $authSecret := (get $secretData "secret") | default ((.Values.apiClientSecret.secret | default $newAuthSecret) | b64enc) }}
   secret: {{ $authSecret | quote }}
 {{- end }}

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -88,6 +88,16 @@ featureFlags:
   # SERVICE_SIMPLE_AUTH_SECRET, with SERVICE_ENABLE_SIMPLE_AUTH_SECRET="true".
   enableSimpleAuthSecret: false
 
+# Shared secret Thoras components send to the API server. Only used when
+# featureFlags.enableSimpleAuthSecret is true.
+apiClientSecret:
+  # Plaintext value; the chart base64-encodes it. Leave empty to generate one.
+  # A value already present in the cluster takes precedence, so setting this
+  # after install has no effect until the api-client-secret Secret is deleted.
+  # Set it when rendering without cluster access (helm template, Argo CD),
+  # where a generated value would differ on every render.
+  secret: ""
+
 # Cost refresh batching configuration (shared by thorasApiServerV2 and thorasWorker)
 costRefreshBatching:
   enabled: true


### PR DESCRIPTION
# What's changing and why?

if a customer wants to pass a client secret manually, they can