### PR TITLE
feat: add WRITE_UBJ_ARTIFACTS flag to forecast worker

### DIFF
--- a/charts/thoras/templates/forecast-worker/deployment.yaml
+++ b/charts/thoras/templates/forecast-worker/deployment.yaml
@@ -84,6 +84,8 @@ spec:
             value: {{ .Values.thorasForecast.useForecasterComputedMetricId | ternary "true" "false" | quote }}
           - name: USE_FORECAST_ENRICHMENT
             value: {{ .Values.thorasForecast.useForecastEnrichment | ternary "true" "false" | quote }}
+          - name: WRITE_UBJ_ARTIFACTS
+            value: {{ .Values.thorasForecast.writeUbjArtifacts | ternary "true" "false" | quote }}
           - name: TRAINING_JITTER_MINUTES
             value: {{ .Values.thorasForecast.trainingJitterMinutes | quote }}
           - name: MULTI_DIMENSIONAL_ENABLED

--- a/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/global_label_snapshots_test.yaml.snap
@@ -965,6 +965,8 @@ Default matches snapshot:
                   value: "true"
                 - name: USE_FORECAST_ENRICHMENT
                   value: "false"
+                - name: WRITE_UBJ_ARTIFACTS
+                  value: "false"
                 - name: TRAINING_JITTER_MINUTES
                   value: "0"
                 - name: MULTI_DIMENSIONAL_ENABLED

--- a/charts/thoras/tests/forecast_worker_test.yaml
+++ b/charts/thoras/tests/forecast_worker_test.yaml
@@ -91,6 +91,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: WRITE_UBJ_ARTIFACTS
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: METRICS_PORT
             value: "9101"
       - contains:

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -571,6 +571,7 @@ thorasForecast:
   useAstMetricsSeries: true
   useForecasterComputedMetricId: true
   useForecastEnrichment: false
+  writeUbjArtifacts: false
   # Minimum lookback window required before autonomous scaling is enabled.
   minLookbackToScale: "24h"
   worker:


### PR DESCRIPTION
# What's changing and why?

Adds a `writeUbjArtifacts` flag (default off) that sets `WRITE_UBJ_ARTIFACTS` on the forecast worker, gating the new pickle-free UBJSON+JSON model serialization. Off by default, so this is a no-op until enabled per-environment. Pairs with the platform PR that adds the serialization code.