### PR TITLE
feat: add allowedReplicas to AIScaleTarget CRDs

### DIFF
--- a/charts/thoras/templates/crd/aiscaletarget.yaml
+++ b/charts/thoras/templates/crd/aiscaletarget.yaml
@@ -520,6 +520,22 @@ spec:
                       - type
                       type: object
                     type: array
+                  allowedReplicas:
+                    description: |-
+                      AllowedReplicas restricts autonomous horizontal scaling to a specific set of
+                      replica counts — useful for sharded or partitioned workloads where only certain
+                      counts divide evenly across pods. Thoras rounds the desired replica count up to
+                      the smallest allowed value that meets or exceeds it, and never scales beyond the
+                      largest value in the set. Values must fall within minReplicas and maxReplicas when
+                      those are set, and cannot be combined with multipleOf.
+                    items:
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    maxItems: 64
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
                   exclude_metrics:
                     description: Metrics from HPA for thoras to ignore
                     items:
@@ -765,6 +781,13 @@ spec:
                 - message: multipleOf must not be greater than maxReplicas
                   rule: '!has(self.multipleOf) || !has(self.maxReplicas) || self.multipleOf
                     <= self.maxReplicas'
+                - message: allowedReplicas values must be within minReplicas and maxReplicas
+                  rule: '!has(self.allowedReplicas) || self.allowedReplicas.all(r,
+                    (!has(self.minReplicas) || r >= self.minReplicas) && (!has(self.maxReplicas)
+                    || r <= self.maxReplicas))'
+                - message: allowedReplicas and multipleOf are mutually exclusive
+                  rule: '!has(self.allowedReplicas) || self.allowedReplicas.size()
+                    == 0 || !has(self.multipleOf)'
               model:
                 description: |-
                   Defines the forecasting and scaling behavior for an AIScaleTarget, including
@@ -1681,6 +1704,24 @@ spec:
                       for each container.
                     items:
                       properties:
+                        jvm_args:
+                          properties:
+                            max_heap_size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            min_heap_size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - max_heap_size
+                          - min_heap_size
+                          type: object
                         name:
                           type: string
                         resources:

--- a/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
+++ b/charts/thoras/templates/crd/clusteraiscaletemplate.yaml
@@ -598,6 +598,22 @@ spec:
                           - type
                           type: object
                         type: array
+                      allowedReplicas:
+                        description: |-
+                          AllowedReplicas restricts autonomous horizontal scaling to a specific set of
+                          replica counts — useful for sharded or partitioned workloads where only certain
+                          counts divide evenly across pods. Thoras rounds the desired replica count up to
+                          the smallest allowed value that meets or exceeds it, and never scales beyond the
+                          largest value in the set. Values must fall within minReplicas and maxReplicas when
+                          those are set, and cannot be combined with multipleOf.
+                        items:
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: set
                       exclude_metrics:
                         description: Metrics from HPA for thoras to ignore
                         items:
@@ -849,6 +865,14 @@ spec:
                     - message: multipleOf must not be greater than maxReplicas
                       rule: '!has(self.multipleOf) || !has(self.maxReplicas) || self.multipleOf
                         <= self.maxReplicas'
+                    - message: allowedReplicas values must be within minReplicas and
+                        maxReplicas
+                      rule: '!has(self.allowedReplicas) || self.allowedReplicas.all(r,
+                        (!has(self.minReplicas) || r >= self.minReplicas) && (!has(self.maxReplicas)
+                        || r <= self.maxReplicas))'
+                    - message: allowedReplicas and multipleOf are mutually exclusive
+                      rule: '!has(self.allowedReplicas) || self.allowedReplicas.size()
+                        == 0 || !has(self.multipleOf)'
                   model:
                     description: |-
                       Defines the forecasting and scaling behavior for an AIScaleTarget, including


### PR DESCRIPTION
# What's changing and why?

Adds `allowedReplicas` to the AIScaleTarget and ClusterAIScaleTemplate CRDs, letting customers constrain autonomous horizontal scaling to a fixed set of replica counts.

This also pulls in the previously-missing `jvm_args` schema