### PR TITLE
feat: allow pod logs route through dashboard API proxy

### DIFF
--- a/charts/thoras/templates/dashboard/nginx-config-map.yaml
+++ b/charts/thoras/templates/dashboard/nginx-config-map.yaml
@@ -58,6 +58,7 @@ data:
         ~*^GET/v1/views/node-pools(\?|$)                                          1;
         ~*^GET/v1/views/nodes(\?|$)                                               1;
         ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
+        ~*^GET/v1/pods/[^/]+/[^/]+/logs(\?|$)                                     1;
         ~*^GET/v1/persistent-volumes(\?|$)                                        1;
 
 

--- a/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
+++ b/charts/thoras/tests/__snapshot__/dashboard_configmap_test.yaml.snap
@@ -51,6 +51,7 @@ Should default to v2 port:
           ~*^GET/v1/views/node-pools(\?|$)                                          1;
           ~*^GET/v1/views/nodes(\?|$)                                               1;
           ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
+          ~*^GET/v1/pods/[^/]+/[^/]+/logs(\?|$)                                     1;
           ~*^GET/v1/persistent-volumes(\?|$)                                        1;
 
 
@@ -163,6 +164,7 @@ should set extras in config.json:
           ~*^GET/v1/views/node-pools(\?|$)                                          1;
           ~*^GET/v1/views/nodes(\?|$)                                               1;
           ~*^GET/v1/views/nodes/summary(\?|$)                                       1;
+          ~*^GET/v1/pods/[^/]+/[^/]+/logs(\?|$)                                     1;
           ~*^GET/v1/persistent-volumes(\?|$)                                        1;
 
 


### PR DESCRIPTION
# What's changing and why?

## How does this change deliver value (especially for customers)

The dashboard's nginx proxy denies by default, so its pod-logs request was returning 403. This allowlists the route, letting users read pod logs from the UI instead of dropping to `kubectl`.

## What's changing?

- Allow `GET /v1/pods/{namespace}/{pod}/logs` in the dashboard nginx allowlist
- Update `dashboard_configmap_test.yaml` snapshots

## How Tested

`helm unittest ./charts/thoras` — 281 tests / 68 snapshots pass.

Checked the pattern against the caller's URL shape (`/v1/pods/${encodeURIComponent(ns)}/${encodeURIComponent(pod)}/logs`): bare and query-string forms (`?container=`, `?tailLines=`, `?previous=`) allow; `[^/]+` keeps percent-encoded segments (`%2F`) inside one path segment, and `/logs/extra`, `/logsfoo`, and `..` traversal all still deny.