### PR TITLE
chore: release chart 4.142.1 (app 4.117.1)

### DIFF
--- a/charts/thoras/Chart.yaml
+++ b/charts/thoras/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.142.0
+version: 4.142.1

--- a/charts/thoras/README.md
+++ b/charts/thoras/README.md
@@ -4,7 +4,7 @@ Thoras is an ML-powered platform that helps SRE teams view the future of their K
 
 This Helm Chart installs [Thoras](https://www.thoras.ai) onto Kubernetes.
 
-![Version: 4.142.0](https://img.shields.io/badge/Version-4.142.0-informational?style=flat-square) ![AppVersion: 4.117.0](https://img.shields.io/badge/AppVersion-4.117.0-informational?style=flat-square)
+![Version: 4.142.1](https://img.shields.io/badge/Version-4.142.1-informational?style=flat-square) ![AppVersion: 4.117.1](https://img.shields.io/badge/AppVersion-4.117.1-informational?style=flat-square)
 
 # Installs
 
@@ -52,7 +52,7 @@ helm install \
 
 | Key                                | Type    | Default                                          | Description                                                                                                            |
 | ---------------------------------- | ------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| thorasVersion                      | String  | 4.117.0                                          | Thoras app version                                                                                                     |
+| thorasVersion                      | String  | 4.117.1                                          | Thoras app version                                                                                                     |
 | imageCredentials.registry          | String  | us-east4-docker.pkg.dev/thoras-registry/platform | Container registry name                                                                                                |
 | imageCredentials.username          | String  | \_json_key_base64                                | Container registry username                                                                                            |
 | imageCredentials.password          | String  | ""                                               | Container registry auth string                                                                                         |

--- a/charts/thoras/values.yaml
+++ b/charts/thoras/values.yaml
@@ -1,5 +1,5 @@
 ---
-thorasVersion: "4.117.0"
+thorasVersion: "4.117.1"
 cluster:
   name: ""
 


### PR DESCRIPTION
# What's changing and why?

Bumps chart to 4.142.1 and `thorasVersion` to 4.117.1 so customers pull the latest Thoras platform image. No chart template changes merged since 4.142.0 — this is an app-version-only release.

- `Chart.yaml`: 4.142.0 → 4.142.1
- `values.yaml`: `thorasVersion` 4.117.0 → 4.117.1
- README version badges and defaults table regenerated

Version-only bump; CI runs Helm unit tests and pre-commit hooks.